### PR TITLE
device,serial: add uartlite support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ SRCS-y += src/nemu-main.c
 DIRS-$(CONFIG_DEVICE) += src/device/io
 SRCS-$(CONFIG_DEVICE) += src/device/device.c src/device/alarm.c src/device/intr.c
 SRCS-$(CONFIG_HAS_SERIAL) += src/device/serial.c
+SRCS-$(CONFIG_SERIAL_UARTLITE) += src/device/uartlite.c
 SRCS-$(CONFIG_HAS_TIMER) += src/device/timer.c
 SRCS-$(CONFIG_HAS_KEYBOARD) += src/device/keyboard.c
 SRCS-$(CONFIG_HAS_VGA) += src/device/vga.c

--- a/src/device/Kconfig
+++ b/src/device/Kconfig
@@ -28,6 +28,10 @@ config SERIAL_MMIO
 config SERIAL_INPUT_FIFO
   bool "Enable input FIFO with /tmp/nemu.serial"
   default n
+
+config SERIAL_UARTLITE
+  bool "Use uartlite as the serial (default: 16550)"
+  default n
 endif # HAS_SERIAL
 
 menuconfig HAS_TIMER

--- a/src/device/serial.c
+++ b/src/device/serial.c
@@ -114,6 +114,12 @@ static void serial_io_handler(uint32_t offset, int len, bool is_write) {
 }
 
 void init_serial() {
+#ifdef CONFIG_SERIAL_UARTLITE
+  void init_uartlite();
+  init_uartlite();
+  // to avoid unused-function warning
+  (void)serial_io_handler;
+#else
   serial_base = new_space(8);
   add_pio_map ("serial", CONFIG_SERIAL_PORT, serial_base, 8, serial_io_handler);
   add_mmio_map("serial", CONFIG_SERIAL_MMIO, serial_base, 8, serial_io_handler);
@@ -122,4 +128,5 @@ void init_serial() {
   init_fifo();
   preset_input();
 #endif
+#endif // CONFIG_SERIAL_UARTLITE
 }

--- a/src/device/uartlite.c
+++ b/src/device/uartlite.c
@@ -1,0 +1,35 @@
+#include <utils.h>
+#include <device/map.h>
+
+#define CH_OFFSET 0
+#define UARTLITE_RX_FIFO  0x0
+#define UARTLITE_TX_FIFO  0x4
+#define UARTLITE_STAT_REG 0x8
+#define UARTLITE_CTRL_REG 0xc
+
+#define UARTLITE_RST_FIFO 0x03
+#define UARTLITE_TX_FULL  0x08
+#define UARTLITE_RX_VALID 0x01
+
+static uint8_t *uartlite_base = NULL;
+
+static void uartlite_io_handler(uint32_t offset, int len, bool is_write) {
+  assert(len == 1);
+  switch (offset) {
+    /* We bind the serial port with the host stdout in NEMU. */
+    case UARTLITE_TX_FIFO:
+      if (is_write) putc(uartlite_base[UARTLITE_TX_FIFO], stderr);
+      else panic("Cannot read UARTLITE_TX_FIFO");
+      break;
+    case UARTLITE_STAT_REG:
+      if (!is_write) uartlite_base[UARTLITE_STAT_REG] = 0x0;
+      break;
+  }
+}
+
+void init_uartlite() {
+  uartlite_base = new_space(0xd);
+  add_pio_map("uartlite", CONFIG_SERIAL_PORT, uartlite_base, 0xd, uartlite_io_handler);
+  add_mmio_map("uartlite", CONFIG_SERIAL_MMIO, uartlite_base, 0xd, uartlite_io_handler);
+}
+


### PR DESCRIPTION
This commit adds uartlite as another serial device. The current
default serial device is UART16550. Set CONFIG_SERIAL_UARTLITE
to enable uartlite.