### PR TITLE
monitor: support init mem with a gz file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,10 @@ LDFLAGS += $(CFLAGS_BUILD)
 
 NAME  = nemu-$(ENGINE)
 
+ifdef CONFIG_MEM_COMPRESS
+LDFLAGS += -lz
+endif
+
 ifndef CONFIG_SHARE
 LDFLAGS += -lreadline -ldl -pie
 else

--- a/src/memory/Kconfig
+++ b/src/memory/Kconfig
@@ -25,4 +25,11 @@ config MEM_RANDOM
   help
     This may help to find undefined behaviors.
 
+config MEM_COMPRESS
+  depends on MODE_SYSTEM && !DIFFTEST
+  bool "Initialize the memory with a compressed gz file"
+  default n
+  help
+    Must have zlib installed.
+
 endmenu #MEMORY


### PR DESCRIPTION
This commit adds support for initializing memory with a compressed
gzip file. When CONFIG_MEM_COMPRESS is enabled, files with names
ending with ".gz" will be seen as compressed gzip files and be
decompressed before loading into memory.

Only non-zero bytes are copied into pmem, to avoid using too much
memory (by copy-on-write).