### PR TITLE
rv64: let fflags be accrued, add panic on unimplemented CSR config

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -233,6 +233,11 @@ config LARGE_COPY
   bool "Enable difftest large memory copy optimization"
   default y
 
+config PANIC_ON_UNIMP_CSR
+  depends on SHARE
+  bool "Panic if an unimplemented CSR is being accessed"
+  default n
+
 endmenu
 
 menu "Miscellaneous"

--- a/configs/riscv64-xs-ref_defconfig
+++ b/configs/riscv64-xs-ref_defconfig
@@ -73,6 +73,7 @@ CONFIG_SHARE=y
 CONFIG_CONFIG_DIFFTEST_STORE_COMMIT=y
 CONFIG_GUIDED_EXEC=y
 CONFIG_LARGE_COPY=y
+# CONFIG_PANIC_ON_UNIMP_CSR is not set
 # end of Processor difftest reference config
 
 #

--- a/src/isa/riscv64/instr/fp.c
+++ b/src/isa/riscv64/instr/fp.c
@@ -44,7 +44,7 @@ void isa_fp_set_ex(uint32_t ex) {
   if (ex & FPCALL_EX_OF) f |= 0x04;
   if (ex & FPCALL_EX_DZ) f |= 0x08;
   if (ex & FPCALL_EX_NV) f |= 0x10;
-  fcsr->fflags.val = f;
+  fcsr->fflags.val = fcsr->fflags.val | f;
   fp_set_dirty();
 }
 

--- a/src/isa/riscv64/system/priv.c
+++ b/src/isa/riscv64/system/priv.c
@@ -33,7 +33,9 @@ static inline bool csr_is_legal(uint32_t addr) {
   assert(addr < 4096);
   // CSR does not exist
   if(!csr_exist[addr]) {
-    printf("[NEMU] unimplemented CSR 0x%x at pc = " FMT_WORD, addr, cpu.pc);
+#ifdef CONFIG_PANIC_ON_UNIMP_CSR
+    panic("[NEMU] unimplemented CSR 0x%x", addr);
+#endif
     return false;
   }
   // CSR exists, but access is not legal


### PR DESCRIPTION
* Fix fflags implementation, previous fflag should not be cleared by `isa_fp_set_ex`
* Add panic on unimplemented CSR config