### PR TITLE
chore: fix dependency for softfloat-fp.h

### DIFF
--- a/scripts/build.mk
+++ b/scripts/build.mk
@@ -27,7 +27,7 @@ LDFLAGS := -O2 $(LDFLAGS)
 OBJS = $(SRCS:%.c=$(OBJ_DIR)/%.o)
 
 # Compilation patterns
-$(OBJ_DIR)/%.o: %.c
+$(OBJ_DIR)/%.o: %.c $(LIBS)
 	@echo + CC $<
 	@mkdir -p $(dir $@)
 	@$(CC) $(CFLAGS) $(SO_CFLAGS) -c -o $@ $<


### PR DESCRIPTION
It should fix the following compile error:

src/engine/interpreter/softfloat-fp.h:4:10: fatal error:
softfloat.h: No such file or directory