### PR TITLE
Fix bug in function nemu_large_memcpy.

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -229,9 +229,9 @@ config GUIDED_EXEC
   default y
 
 config LARGE_COPY
-  depends on SHARE
+  depends on SHARE && !MEM_RANDOM
   bool "Enable difftest large memory copy optimization"
-  default y
+  default n
 
 config PANIC_ON_UNIMP_CSR
   depends on SHARE


### PR DESCRIPTION
Every bits should be copy from dut. Otherwise, uninitialized ref memory would be random values, which leads to random results when launching difftest.