### PR TITLE
Detect misalign mem access by software for XiangShan

### DIFF
--- a/configs/riscv64-xs_defconfig
+++ b/configs/riscv64-xs_defconfig
@@ -89,8 +89,8 @@ CONFIG_SDCARD_IMG_PATH=""
 # CONFIG_FPU_HOST is not set
 CONFIG_FPU_SOFT=y
 # CONFIG_FPU_NONE is not set
-CONFIG_AC_HOST=y
-# CONFIG_AC_SOFT is not set
+# CONFIG_AC_HOST is not set
+CONFIG_AC_SOFT=y
 # CONFIG_AC_NONE is not set
 
 #


### PR DESCRIPTION
We detect misaligned memory accessing by software to deal with that
in Linux. Now riscv64-xs_defconfig should be able to boot up Linux.