### PR TITLE
ref: don't copy lr address from dut

### DIFF
--- a/src/isa/riscv64/difftest/ref.c
+++ b/src/isa/riscv64/difftest/ref.c
@@ -86,7 +86,6 @@ void isa_difftest_uarchstatus_cpy(void *dut, bool direction) {
   if (direction == DIFFTEST_TO_REF) {
     struct SyncState* ms = (struct SyncState*)dut;
     cpu.lr_valid = ms->lrscValid;
-    cpu.lr_addr = ms->lrscAddr;
   } else {
     struct SyncState ms;
     ms.lrscValid = cpu.lr_valid;


### PR DESCRIPTION
LR address is unnecessary to force sc to fail. Copying LR address
makes NEMU fails even when lr_valid is true, because the address
may not be correct.