### PR TITLE
pmp: when PMP is not supported, still enable pmp r/w, but not check(todo)

### DIFF
--- a/src/isa/riscv64/system/priv.c
+++ b/src/isa/riscv64/system/priv.c
@@ -114,10 +114,10 @@ static inline void update_mstatus_sd() {
 static inline word_t csr_read(word_t *src) {
 
   if (is_read_pmpaddr) {
-#ifndef CONFIG_RV_PMP
-    longjmp_exception(EX_II);
-    return 0;
-#else
+// #ifndef CONFIG_RV_PMP
+//     longjmp_exception(EX_II);
+//     return 0;
+// #else
     // If n_pmp is zero, that means pmp is not implemented hence raise trap if it tries to access the csr
     if (NUM_PMP == 0) {
       Log("pmp number is 0, raise illegal instr exception when read pmpaddr");
@@ -137,7 +137,7 @@ static inline word_t csr_read(word_t *src) {
       return *src | (~pmp_tor_mask() >> 1);
     else
       return *src & pmp_tor_mask();
-#endif
+// #endif
   }
 
   if (is_read(mstatus) || is_read(sstatus)) { update_mstatus_sd(); }
@@ -198,10 +198,10 @@ static inline void csr_write(word_t *dest, word_t src) {
   }
   else if (is_write_pmpaddr) {
     Logtr("Writing pmp addr");
-#ifndef CONFIG_RV_PMP
-    Logtr("PMP disabled ignore");
-    return ;
-#else
+// #ifndef CONFIG_RV_PMP
+//     Logtr("PMP disabled ignore");
+//     return ;
+// #else
     // If no PMPs are configured, disallow access to all.  Otherwise, allow
     // access to all, but unimplemented ones are hardwired to zero.
     if (NUM_PMP == 0)
@@ -223,13 +223,13 @@ static inline void csr_write(word_t *dest, word_t src) {
 #endif
 
     mmu_tlb_flush(0);
-#endif
+// #endif
   }
   else if (is_write_pmpcfg) {
     // Log("Writing pmp config");
-#ifndef CONFIG_RV_PMP
-  return;
-#else
+// #ifndef CONFIG_RV_PMP
+//   return;
+// #else
     if (NUM_PMP == 0)
       return;
 
@@ -252,7 +252,7 @@ static inline void csr_write(word_t *dest, word_t src) {
     *dest = cfg_data;
 
     mmu_tlb_flush(0);
-#endif
+// #endif
   } else if (is_write(satp)) {
     *dest = MASKED_SATP(src);
   } else { *dest = src; }


### PR DESCRIPTION
When taking checkpoints or restore checkpoints, pmp regs should be stored or restored. But pmp check is not done(still bugs) under OPT mode, so pmp should be disabled under OPT mode. It makes nothing different when running most workloads except that for pmp correctness checking.
So enable pmp read/write even when pmp is disabled for checkpoint taking and restoring.