### PR TITLE
debug: fix inst trace format, enable trace for co-sim

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -128,7 +128,6 @@ endmenu
 
 menu "Testing and Debugging"
 config DEBUG
-  depends on !SHARE
   bool "Enable debug features: instruction tracing and watchpoint"
   default n
   help

--- a/src/cpu/cpu-exec.c
+++ b/src/cpu/cpu-exec.c
@@ -293,9 +293,9 @@ void fetch_decode(Decode *s, vaddr_t pc) {
   IFDEF(CONFIG_DEBUG, log_bytebuf[0] = '\0');
   int idx = isa_fetch_decode(s);
   Logtid(FMT_WORD ":   %s%*.s%s",
-        s->pc, log_bytebuf, 50 - (12 + 3 * (int)(s->snpc - s->pc)), "", log_asmbuf);
+        s->pc, log_bytebuf, 40 - (12 + 3 * (int)(s->snpc - s->pc)), "", log_asmbuf);
   IFDEF(CONFIG_DEBUG, snprintf(s->logbuf, sizeof(s->logbuf), FMT_WORD ":   %s%*.s%s",
-        s->pc, log_bytebuf, 50 - (12 + 3 * (int)(s->snpc - s->pc)), "", log_asmbuf));
+        s->pc, log_bytebuf, 40 - (12 + 3 * (int)(s->snpc - s->pc)), "", log_asmbuf));
   s->EHelper = g_exec_table[idx];
 }
 


### PR DESCRIPTION
* Fix debug inst trace format to disasm inst correctlly

    c_beqz  s0,0x80001        // before fix
    c_beqz  s0,0x80001ac0  // fixed

* Now it is possible to enable DEBUG config to print inst trace
(pc, inst, dasm) in co-simulation. It should be helpful when we
only have basic diff.