### PR TITLE
riscv64: fix imm width of B-ext slli.uw

### DIFF
--- a/src/isa/riscv64/instr/rvb/exec.h
+++ b/src/isa/riscv64/instr/rvb/exec.h
@@ -186,7 +186,7 @@ def_EHelper(adduw) {
 }
 
 def_EHelper(slliuw) {
-  *ddest = (uint64_t)(uint32_t)*dsrc1 << (id_src2->imm & 0x1f);
+  *ddest = (uint64_t)(uint32_t)*dsrc1 << (id_src2->imm & 0x3f);
 }
 
 def_EHelper(sh1add) {


### PR DESCRIPTION
`shamt` field for B-extension `slli.uw` instruction is 6 bits wide, as specified in [RISC-V Bit-Manipulation ISA-extensions version 1.0.0](https://github.com/riscv/riscv-bitmanip/releases/download/1.0.0/bitmanip-1.0.0-38-g865e7a7.pdf), page 52.
