### PR TITLE
RV64: fix several bugs of H extention and performance optimization

### DIFF
--- a/src/isa/riscv64/include/isa-all-instr.h
+++ b/src/isa/riscv64/include/isa-all-instr.h
@@ -33,12 +33,6 @@
 #define AMO_INSTR_TERNARY(f) f(atomic)
 #endif
 
-// #ifdef CONFIG_RV_DEBUG
-//   #define RV_D_NULLARY(f) f(ebreak)
-// #else
-//   #define RV_D_NULLARY(f)
-// #endif
-
 #ifdef CONFIG_RVH 
 #ifdef CONFIG_RV_SVINVAL
   #define RVH_INST_BINARY(f) f(hfence_vvma) f(hfence_gvma) f(hinval_vvma) f(hinval_gvma) \

--- a/src/isa/riscv64/include/isa-all-instr.h
+++ b/src/isa/riscv64/include/isa-all-instr.h
@@ -33,11 +33,11 @@
 #define AMO_INSTR_TERNARY(f) f(atomic)
 #endif
 
-#ifdef CONFIG_RV_DEBUG
-  #define RV_D_NULLARY(f) f(ebreak)
-#else
-  #define RV_D_NULLARY(f)
-#endif
+// #ifdef CONFIG_RV_DEBUG
+//   #define RV_D_NULLARY(f) f(ebreak)
+// #else
+//   #define RV_D_NULLARY(f)
+// #endif
 
 #ifdef CONFIG_RVH 
 #ifdef CONFIG_RV_SVINVAL

--- a/src/isa/riscv64/instr/decode.c
+++ b/src/isa/riscv64/instr/decode.c
@@ -20,7 +20,7 @@
 #include <cpu/cpu.h>
 #include <cpu/ifetch.h>
 #include <cpu/decode.h>
-#include <isa-all-instr.h>
+#include "../include/isa-all-instr.h"
 
 
 def_all_THelper();
@@ -130,25 +130,26 @@ int isa_fetch_decode(Decode *s) {
       s->jnpc = id_dest->imm; s->type = INSTR_TYPE_B; break;
 
     case EXEC_ID_p_ret: case EXEC_ID_c_jr: case EXEC_ID_c_jalr: case EXEC_ID_jalr:
-    IFDEF(CONFIG_DEBUG, case EXEC_ID_mret: case EXEC_ID_sret: case EXEC_ID_ecall:)
+    IFDEF(CONFIG_DEBUG, case EXEC_ID_mret: case EXEC_ID_sret: case EXEC_ID_ecall: case EXEC_ID_ebreak:)
       s->type = INSTR_TYPE_I; break;
 
 #ifndef CONFIG_DEBUG
 #ifdef CONFIG_RVH
     case EXEC_ID_priv:
-#else
+#else // CONFIG_RVH
     case EXEC_ID_system:
-#endif
+#endif // CONFIG_RVH
       if (s->isa.instr.i.funct3 == 0) {
         switch (s->isa.instr.csr.csr) {
-          case 0:     // ecall
+          case 0x0:   // ecall
+          case 0x1:   // ebreak
           case 0x102: // sret
           case 0x302: // mret
             s->type = INSTR_TYPE_I;
         }
       }
       break;
-#endif
+#endif // CONFIG_DEBUG
   }
 
   return idx;

--- a/src/isa/riscv64/instr/priv/exec.h
+++ b/src/isa/riscv64/instr/priv/exec.h
@@ -23,9 +23,6 @@ def_EHelper(name) { \
 }
 
 #ifdef CONFIG_DEBUG
-// #ifdef CONFIG_RV_DEBUG
-//   def_SYS_EHelper(ebreak)
-// #endif
 
 #ifdef CONFIG_RVH 
 #define def_hld_template(name) \

--- a/src/isa/riscv64/instr/priv/exec.h
+++ b/src/isa/riscv64/instr/priv/exec.h
@@ -23,9 +23,9 @@ def_EHelper(name) { \
 }
 
 #ifdef CONFIG_DEBUG
-#ifdef CONFIG_RV_DEBUG
-  def_SYS_EHelper(ebreak)
-#endif
+// #ifdef CONFIG_RV_DEBUG
+//   def_SYS_EHelper(ebreak)
+// #endif
 
 #ifdef CONFIG_RVH 
 #define def_hld_template(name) \

--- a/src/isa/riscv64/system/intr.c
+++ b/src/isa/riscv64/system/intr.c
@@ -15,6 +15,7 @@
 ***************************************************************************************/
 
 #include <cpu/difftest.h>
+#include <cpu/cpu.h>
 #include "../local-include/csr.h"
 #include "../local-include/intr.h"
 
@@ -129,6 +130,7 @@ word_t raise_intr(word_t NO, vaddr_t epc) {
       hstatus->spvp = cpu.mode; 
     }
     cpu.v = 0;
+    set_sys_state_flag(SYS_STATE_FLUSH_TCACHE);
 #else
   if (delegS) {
 #endif
@@ -162,7 +164,7 @@ word_t raise_intr(word_t NO, vaddr_t epc) {
     mstatus->gva = (NO == EX_IGPF || NO == EX_LGPF || NO == EX_SGPF ||
                     ((v || hld_st_temp) && ((0 <= NO && NO <= 7 && NO != 2) || NO == EX_IPF || NO == EX_LPF || NO == EX_SPF)));
     mstatus->mpv = cpu.v;
-    cpu.v = 0;
+    cpu.v = 0;set_sys_state_flag(SYS_STATE_FLUSH_TCACHE);
 #endif
     mcause->val = NO;
     mepc->val = epc;

--- a/src/isa/riscv64/system/priv.c
+++ b/src/isa/riscv64/system/priv.c
@@ -640,6 +640,7 @@ static word_t priv_instr(uint32_t op, const rtlreg_t *src) {
       if (cpu.v == 0){
         cpu.v = hstatus->spv;
         hstatus->spv = 0;
+        set_sys_state_flag(SYS_STATE_FLUSH_TCACHE);
       }else if (cpu.v == 1){
         if((cpu.mode == MODE_S && hstatus->vtsr) || cpu.mode < MODE_S){
           longjmp_exception(EX_VI);
@@ -684,6 +685,7 @@ static word_t priv_instr(uint32_t op, const rtlreg_t *src) {
 #ifdef CONFIG_RVH
       cpu.v = mstatus->mpv;
       mstatus->mpv = 0;
+      set_sys_state_flag(SYS_STATE_FLUSH_TCACHE);
 #endif // CONFIG_RVH
       if (mstatus->mpp != MODE_M) { mstatus->mprv = 0; }
       mstatus->mpp = MODE_U;


### PR DESCRIPTION
This PR fix several bugs of H extention and performance optimization.

* Fix compile error when enabling "Enable debug features: instruction tracing and watchpoint" (`CONFIG_DEBUG`)
  * Duplicated definition of ebreak caused this problem
* Fix the issue of EBREAK instruction causing segmentation fault when enabling "Performance optimization" (`CONFIG_PERF_OPT`) #132 
  * EBREAK was missed during decoding Type-I instruction, causing pointer `tnext` of its `Decode` struct to be NULL.
* Fix executing incorrect VS-mode instructions in M-mode.
  * Some VS-mode instructions and M-mode instructions have the same PC address. NEMU did not flush TCACHE when an exception which changing virtualization mode occurs. Fix it.

这个合并请求修复了 H 扩展和性能优化相关的若干问题。
* 修复了启用“Enable debug features: instruction tracing and watchpoint”（`CONFIG_DEBUG`）时出现的编译错误
  * 有关 EBREAK 的重复定义造成了此问题
* 修复了启用性能优化选项“Performance optimization”（`CONFIG_PERF_OPT`）时调用 EBREAK 指令造成 NEMU 段错误的问题。 #132 
  * 译码时指定 I 类型指令时漏掉了 EBREAK，导致其 `Decode` 项中的 `tnext` 为空指针。
* 修复了在 M 态错误执行 VS 态指令的问题
  * 某些 M 态代码和 VS 态代码具有相同的地址。当发生更改虚拟化模式的异常时，NEMU 没有刷新 TCACHE。修复了这个问题。