### PR TITLE
add a command line parameter: --small-log, output log to a limited size FILE, but log is always up to date

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -66,13 +66,20 @@ uint64_t get_time();
  )*/
 #define log_write(...) \
   do { \
+    extern bool enable_small_log; \
     extern FILE* log_fp; \
     extern char *log_filebuf; \
     extern uint64_t record_row_number; \
+    extern bool log_enable(); \
     extern void log_flush(); \
     if (log_fp != NULL) { \
-      snprintf(log_filebuf + record_row_number * 300, 300, __VA_ARGS__);\
-      log_flush(); \
+      if (enable_small_log) { \
+        snprintf(log_filebuf + record_row_number * 300, 300, __VA_ARGS__);\
+        log_flush(); \
+      } else if (log_enable()){ \
+        fprintf(log_fp, __VA_ARGS__); \
+        fflush(log_fp); \
+      } \
     }else{ \
       printf(__VA_ARGS__); \
     } \

--- a/src/checkpoint/simpoint.cpp
+++ b/src/checkpoint/simpoint.cpp
@@ -57,6 +57,7 @@ extern void log_flush();
 extern char *log_filebuf; 
 extern uint64_t record_row_number;  
 extern FILE *log_fp;
+extern bool enable_small_log;
 }
 
 SimPoint::SimPoint()

--- a/src/cpu/cpu-exec.c
+++ b/src/cpu/cpu-exec.c
@@ -468,9 +468,11 @@ static int execute(int n) {
     #endif // CONFIG_BR_LOG
     IFDEF(CONFIG_DEBUG, debug_hook(s.pc, s.logbuf));
     IFDEF(CONFIG_DIFFTEST, difftest_step(s.pc, cpu.pc));
-    if(isa_query_intr()){break;}
+    if (isa_query_intr() != INTR_EMPTY){
+      break;
+    }
     if (nemu_state.state == NEMU_STOP) {
-        break;
+      break;
     }
   }
   return n;

--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -32,6 +32,7 @@ void init_difftest(char *ref_so_file, long img_size, int port);
 void init_device();
 
 static char *log_file = NULL;
+bool enable_small_log = false;
 static char *diff_so_file = NULL;
 static char *img_file = NULL;
 static int batch_mode = false;
@@ -87,6 +88,9 @@ static inline int parse_args(int argc, char *argv[]) {
     // dump state
     {"dump-mem"           , required_argument, NULL, 'M'},
     {"dump-reg"           , required_argument, NULL, 'R'},
+
+    // small log file
+    {"small-log"          , required_argument, NULL, 8},
 
     {0          , 0                , NULL,  0 },
   };
@@ -153,11 +157,17 @@ static inline int parse_args(int argc, char *argv[]) {
 
       case 4: sscanf(optarg, "%d", &cpt_id); break;
 
+      case 8: 
+        log_file = optarg; 
+        enable_small_log = true;
+        break; 
+
       default:
         printf("Usage: %s [OPTION...] IMAGE [args]\n\n", argv[0]);
         printf("\t-b,--batch              run with batch mode\n");
         printf("\t-I,--max-instr          max number of instructions executed\n");
         printf("\t-l,--log=FILE           output log to FILE\n");
+        printf("\t--small-log=FILE        output log to a limited size FILE, but log is always up to date\n");
         printf("\t-d,--diff=REF_SO        run DiffTest with reference REF_SO\n");
         printf("\t-p,--port=PORT          run DiffTest with port PORT\n");
 

--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -24,7 +24,7 @@
 
 #ifndef CONFIG_SHARE
 void init_aligncheck();
-void init_log(const char *log_file);
+void init_log(const char *log_file, const bool small_log);
 void init_mem();
 void init_regex();
 void init_wp_pool();
@@ -32,7 +32,7 @@ void init_difftest(char *ref_so_file, long img_size, int port);
 void init_device();
 
 static char *log_file = NULL;
-bool enable_small_log = false;
+bool small_log = false;
 static char *diff_so_file = NULL;
 static char *img_file = NULL;
 static int batch_mode = false;
@@ -159,7 +159,7 @@ static inline int parse_args(int argc, char *argv[]) {
 
       case 8: 
         log_file = optarg; 
-        enable_small_log = true;
+        small_log = true;
         break; 
 
       default:
@@ -218,7 +218,7 @@ void init_monitor(int argc, char *argv[]) {
   }
 
   /* Open the log file. */
-  init_log(log_file);
+  init_log(log_file, small_log);
 
   /* Initialize memory. */
   init_mem();

--- a/src/utils/log.c
+++ b/src/utils/log.c
@@ -18,32 +18,34 @@
 // control when the log is printed, unit: number of instructions
 #define LOG_START (0)
 // restrict the size of log file
-#define LOG_END   (100 * 1024)
-#define LOG_ROW_NUM (LOG_END - LOG_START) // row number
+#define LOG_END   (1024 * 1024 * 50)
+#define SMALL_LOG_ROW_NUM (100 * 1024) // row number
 uint64_t record_row_number = 0;
 FILE *log_fp = NULL;
 char *log_filebuf;
+extern bool enable_small_log;
 void init_log(const char *log_file) {
   if (log_file == NULL) return;
   log_fp = fopen(log_file, "w");
   Assert(log_fp, "Can not open '%s'", log_file);
-  log_filebuf = (char *)malloc(sizeof(char) * LOG_ROW_NUM * 300);
-  
+  if (enable_small_log)
+    log_filebuf = (char *)malloc(sizeof(char) * SMALL_LOG_ROW_NUM * 300);
 }
 
-// bool log_enable() {
-//   extern uint64_t g_nr_guest_instr;
-//   return (g_nr_guest_instr >= LOG_START) && (g_nr_guest_instr <= LOG_END);
-// }
+bool log_enable() {
+  extern uint64_t g_nr_guest_instr;
+  return (g_nr_guest_instr >= LOG_START) && (g_nr_guest_instr <= LOG_END);
+}
 
 void log_flush() {
   record_row_number ++;
-  if(record_row_number > LOG_ROW_NUM){
+  if(record_row_number > SMALL_LOG_ROW_NUM){
     // rewind(log_fp);
     record_row_number = 0;
   }
 }
 void log_close(){
+  if (enable_small_log == false) return;
   if (log_fp == NULL) return;
   // fprintf(log_fp, "%s", log_filebuf);
   for (int i = 0; i < record_row_number; i++)

--- a/src/utils/log.c
+++ b/src/utils/log.c
@@ -23,11 +23,12 @@
 uint64_t record_row_number = 0;
 FILE *log_fp = NULL;
 char *log_filebuf;
-extern bool enable_small_log;
-void init_log(const char *log_file) {
+bool enable_small_log = false;
+void init_log(const char *log_file, const bool small_log) {
   if (log_file == NULL) return;
   log_fp = fopen(log_file, "w");
   Assert(log_fp, "Can not open '%s'", log_file);
+  enable_small_log = small_log;
   if (enable_small_log)
     log_filebuf = (char *)malloc(sizeof(char) * SMALL_LOG_ROW_NUM * 300);
 }


### PR DESCRIPTION
modify command line parameter
-l: output all log to a file with unlimited size, so the file maybe 10G or 100G.
--small-file: output log to a file with limited size when nemu end the program instead of "ctrl + c", the log in the file is always information near the end of the program. For example, when difftest find a bug, small log will save some log that output before executing the error instruction, instead of save all log from the start of program to the end.