### PR TITLE
fix(host-tlb.c): hosttlb permission check bug and some other bugs

### DIFF
--- a/src/memory/host-tlb.c
+++ b/src/memory/host-tlb.c
@@ -28,9 +28,10 @@ typedef struct {
   vaddr_t gvpn; // guest virtual page number
 } HostTLBEntry;
 
-static HostTLBEntry hosttlb[HOSTTLB_SIZE * 2];
+static HostTLBEntry hosttlb[HOSTTLB_SIZE * 3];
 static HostTLBEntry* const hostrtlb = &hosttlb[0];
 static HostTLBEntry* const hostwtlb = &hosttlb[HOSTTLB_SIZE];
+static HostTLBEntry* const hostxtlb = &hosttlb[HOSTTLB_SIZE * 2];
 
 static inline vaddr_t hosttlb_vpn(vaddr_t vaddr) {
   return (vaddr >> PAGE_SHIFT);
@@ -48,6 +49,7 @@ void hosttlb_flush(vaddr_t vaddr) {
     int idx = hosttlb_idx(vaddr);
     if (hostrtlb[idx].gvpn == gvpn) hostrtlb[idx].gvpn = (sword_t)-1;
     if (hostwtlb[idx].gvpn == gvpn) hostwtlb[idx].gvpn = (sword_t)-1;
+    if (hostxtlb[idx].gvpn == gvpn) hostxtlb[idx].gvpn = (sword_t)-1;
   }
 }
 
@@ -57,10 +59,10 @@ void hosttlb_init() {
 
 static paddr_t va2pa(struct Decode *s, vaddr_t vaddr, int len, int type) {
   if (type != MEM_TYPE_IFETCH) save_globals(s);
-  int ret = isa_mmu_check(vaddr, len, type);
-  if (ret == MMU_DIRECT) return vaddr;
+  // int ret = isa_mmu_check(vaddr, len, type);
+  // if (ret == MMU_DIRECT) return vaddr;
   paddr_t pg_base = isa_mmu_translate(vaddr, len, type);
-  ret = pg_base & PAGE_MASK;
+  int ret = pg_base & PAGE_MASK;
   assert(ret == MEM_RET_OK);
   return pg_base | (vaddr & PAGE_MASK);
 }
@@ -68,24 +70,26 @@ static paddr_t va2pa(struct Decode *s, vaddr_t vaddr, int len, int type) {
 __attribute__((noinline))
 static word_t hosttlb_read_slowpath(struct Decode *s, vaddr_t vaddr, int len, int type) {
   paddr_t paddr = va2pa(s, vaddr, len, type);
+  word_t data = paddr_read(paddr, len, type, cpu.mode, vaddr);
   if (likely(in_pmem(paddr))) {
-    HostTLBEntry *e = &hostrtlb[hosttlb_idx(vaddr)];
+    HostTLBEntry *e = type == MEM_TYPE_IFETCH ?
+      &hostxtlb[hosttlb_idx(vaddr)] : &hostrtlb[hosttlb_idx(vaddr)];
     e->offset = guest_to_host(paddr) - vaddr;
     e->gvpn = hosttlb_vpn(vaddr);
   }
   Logtr("Slowpath, vaddr " FMT_WORD " --> paddr: " FMT_PADDR, vaddr, paddr);
-  return paddr_read(paddr, len, MEM_TYPE_READ, MODE_S, vaddr);
+  return data;
 }
 
 __attribute__((noinline))
 static void hosttlb_write_slowpath(struct Decode *s, vaddr_t vaddr, int len, word_t data) {
   paddr_t paddr = va2pa(s, vaddr, len, MEM_TYPE_WRITE);
+  paddr_write(paddr, len, data, cpu.mode, vaddr);
   if (likely(in_pmem(paddr))) {
     HostTLBEntry *e = &hostwtlb[hosttlb_idx(vaddr)];
     e->offset = guest_to_host(paddr) - vaddr;
     e->gvpn = hosttlb_vpn(vaddr);
   }
-  paddr_write(paddr, len, data, MODE_S, vaddr);
 }
 
 word_t hosttlb_read(struct Decode *s, vaddr_t vaddr, int len, int type) {
@@ -94,11 +98,12 @@ word_t hosttlb_read(struct Decode *s, vaddr_t vaddr, int len, int type) {
   extern bool has_two_stage_translation();
   if(has_two_stage_translation()){
     paddr_t paddr = va2pa(s, vaddr, len, type);
-    return paddr_read(paddr, len, MEM_TYPE_READ, MODE_S, vaddr);
+    return paddr_read(paddr, len, type, cpu.mode, vaddr);
   }
 #endif
   vaddr_t gvpn = hosttlb_vpn(vaddr);
-  HostTLBEntry *e = &hostrtlb[hosttlb_idx(vaddr)];
+  HostTLBEntry *e = type == MEM_TYPE_IFETCH ?
+    &hostxtlb[hosttlb_idx(vaddr)] : &hostrtlb[hosttlb_idx(vaddr)];
   if (unlikely(e->gvpn != gvpn)) {
     Logm("Host TLB slow path");
     return hosttlb_read_slowpath(s, vaddr, len, type);
@@ -113,7 +118,7 @@ void hosttlb_write(struct Decode *s, vaddr_t vaddr, int len, word_t data) {
   extern bool has_two_stage_translation();
   if(has_two_stage_translation()){
     paddr_t paddr = va2pa(s, vaddr, len, MEM_TYPE_WRITE);
-    return paddr_write(paddr, len, data, MODE_S, vaddr);
+    return paddr_write(paddr, len, data, cpu.mode, vaddr);
   }
 #endif
   vaddr_t gvpn = hosttlb_vpn(vaddr);


### PR DESCRIPTION
fix permission check bug:
- add hostxtlb, separate mem read and ifetch
- put the paddr_read or paddr_write before the tlb record
- no performance loss
other fixs:
- change MODE_S to cpu.mode
- change MEM_TYPE_READ to type
- remove isa_mmu_check in va2pa