### PR TITLE
rv64,amo: SC should invalidate any reservation set

### DIFF
--- a/src/isa/riscv64/instr/rva/amo.c
+++ b/src/isa/riscv64/instr/rva/amo.c
@@ -39,9 +39,9 @@ def_rtl(amo_slow_path, rtlreg_t *dest, const rtlreg_t *src1, const rtlreg_t *src
 #endif
     // should check overlapping instead of equality
     int success = cpu.lr_addr == *src1 && cpu.lr_valid;
+    cpu.lr_valid = 0;
     if (success) {
       rtl_sm(s, src2, src1, 0, width, MMU_DYNAMIC);
-      cpu.lr_valid = 0;
     } else {
       cpu.lr_valid = 0;
       // Even if scInvalid, SPF (if raised) also needs to be reported


### PR DESCRIPTION
According to the RISC-V spec, regardless of success or failure, executing an SC.W/D instruction invalidates any reservation held by this hart.