### PR TITLE
configs: disable LTO for ref configs

### DIFF
--- a/configs/riscv64-nutshell-ref_defconfig
+++ b/configs/riscv64-nutshell-ref_defconfig
@@ -49,7 +49,7 @@ CONFIG_CC="gcc"
 CONFIG_CC_O2=y
 # CONFIG_CC_O3 is not set
 CONFIG_CC_OPT="-O2"
-CONFIG_CC_LTO=y
+# CONFIG_CC_LTO is not set
 # CONFIG_CC_DEBUG is not set
 # CONFIG_CC_ASAN is not set
 # end of Build Options

--- a/configs/riscv64-xs-ref_defconfig
+++ b/configs/riscv64-xs-ref_defconfig
@@ -51,7 +51,7 @@ CONFIG_CC="gcc"
 CONFIG_CC_O2=y
 # CONFIG_CC_O3 is not set
 CONFIG_CC_OPT="-O2"
-CONFIG_CC_LTO=y
+# CONFIG_CC_LTO is not set
 # CONFIG_CC_DEBUG is not set
 # CONFIG_CC_ASAN is not set
 # end of Build Options


### PR DESCRIPTION
Link-time optimizations may not work with clang sanitizer.