### PR TITLE
exec: reset cpu.amo before executing instructions

### DIFF
--- a/src/cpu/cpu-exec.c
+++ b/src/cpu/cpu-exec.c
@@ -444,6 +444,7 @@ static int execute(int n) {
 #ifdef CONFIG_LIGHTQS_DEBUG
     printf("ahead pc %lx %lx\n", g_nr_guest_instr, cpu.pc);
 #endif // CONFIG_LIGHTQS_DEBUG
+    cpu.amo = false;
     fetch_decode(&s, cpu.pc);
     cpu.debug.current_pc = s.pc;
     cpu.pc = s.snpc;


### PR DESCRIPTION
This would avoid previous instructions' cpu.amo affecting the following instructions.

However, trace cache may not be affected and may have bugs.