### PR TITLE
checkpoint: avoid simpoint files before init

### DIFF
--- a/src/checkpoint/simpoint.cpp
+++ b/src/checkpoint/simpoint.cpp
@@ -54,8 +54,8 @@ extern "C" {
 #include <debug.h>
 extern bool log_enable();
 extern void log_flush();
-extern char *log_filebuf; 
-extern uint64_t record_row_number;  
+extern char *log_filebuf;
+extern uint64_t record_row_number;
 extern FILE *log_fp;
 extern bool enable_small_log;
 }
@@ -66,18 +66,19 @@ SimPoint::SimPoint()
       simpointStream(nullptr),
       currentBBV(0, 0),
       currentBBVInstCount(0) {
-
-  simpointStream = NEMUNS::simout.create("simpoint_bbv", false);
-  if (!simpointStream)
-    xpanic("unable to open SimPoint profile_file");
 }
 
 SimPoint::~SimPoint() {
-  NEMUNS::simout.close(simpointStream);
+  if (simpointStream)
+    NEMUNS::simout.close(simpointStream);
 }
 
 void
 SimPoint::init() {
+  simpointStream = NEMUNS::simout.create("simpoint_bbv", false);
+  if (!simpointStream)
+    xpanic("unable to open SimPoint profile_file");
+
   if (profiling_state == SimpointProfiling) {
     assert(checkpoint_interval);
     intervalSize = checkpoint_interval;


### PR DESCRIPTION
No need to initialize the simpoint bbv files before calling init.