### PR TITLE
device: fix the init steps of flash

### DIFF
--- a/src/cpu/difftest/ref.c
+++ b/src/cpu/difftest/ref.c
@@ -19,6 +19,7 @@
 #include <cpu/cpu.h>
 #include <difftest.h>
 
+extern void init_flash();
 extern void load_flash_contents(const char *flash_img);
 
 
@@ -62,6 +63,7 @@ void difftest_load_flash(void *flash_bin, size_t f_size){
   printf("nemu does not enable flash fetch!\n");
 #else
   load_flash_contents((const char *)flash_bin);
+  init_flash();
 #endif
 }
 

--- a/src/device/device.c
+++ b/src/device/device.c
@@ -94,9 +94,9 @@ void init_device() {
   IFDEF(CONFIG_HAS_AUDIO, init_audio());
   IFDEF(CONFIG_HAS_DISK, init_disk());
   IFDEF(CONFIG_HAS_SDCARD, init_sdcard());
-  IFDEF(CONFIG_HAS_FLASH, init_flash());
 #ifndef CONFIG_SHARE
   IFDEF(CONFIG_HAS_FLASH, load_flash_contents(CONFIG_FLASH_IMG_PATH));
+  IFDEF(CONFIG_HAS_FLASH, init_flash());
 #endif
 
 #ifndef CONFIG_SHARE

--- a/src/device/flash.c
+++ b/src/device/flash.c
@@ -58,6 +58,6 @@ void load_flash_contents(const char *flash_img) {
   }
 }
 
-void init_flash(const char *flash_img) {
+void init_flash() {
   add_mmio_map("flash", CONFIG_FLASH_START_ADDR, flash_base, CONFIG_FLASH_SIZE, flash_io_handler);
 }


### PR DESCRIPTION
flash_init should be called after load_flash_contents, which init the space pointer.