### PR TITLE
rv64,priv: fix the write mask of mstatus

### DIFF
--- a/src/isa/riscv64/system/priv.c
+++ b/src/isa/riscv64/system/priv.c
@@ -117,12 +117,12 @@ static inline word_t* csr_decode(uint32_t addr) {
 
 // WPRI, SXL, UXL cannot be written
 #ifdef CONFIG_RVH
-#define MSTATUS_WMASK (0x7e79bbUL) | (1UL << 63) | (1UL << 39) | (1UL << 38)
+#define MSTATUS_WMASK (0x7e79aaUL) | (1UL << 63) | (1UL << 39) | (1UL << 38)
 #define HSTATUS_WMASK ((1 << 22) | (1 << 21) | (1 << 20) | (1 << 18) | (0x3f << 12) | (1 << 9) | (1 << 8) | (1 << 7) | (1 << 6) | (1 << 5))
 #elif defined(CONFIG_RVV)
-#define MSTATUS_WMASK (0x7e79bbUL) | (1UL << 63) | (3UL << 8)
+#define MSTATUS_WMASK (0x7e79aaUL) | (1UL << 63) | (3UL << 8)
 #else
-#define MSTATUS_WMASK (0x7e79bbUL) | (1UL << 63)
+#define MSTATUS_WMASK (0x7e79aaUL) | (1UL << 63)
 #endif
 
 #ifdef CONFIG_RVH


### PR DESCRIPTION

Hello, during the simulation process, I noticed that the 0th and 4th bits of mstatus in NEMU are not aligned with the requirements in the privilege specification. These positions need to be cleared to zero.