### PR TITLE
fix,vset{i}vl{i}:vlmul and vsew is illegal, set vl and rd zero

### DIFF
--- a/src/isa/riscv64/instr/rvv/vcommon.c
+++ b/src/isa/riscv64/instr/rvv/vcommon.c
@@ -1,6 +1,7 @@
 #include <common.h>
 #ifdef CONFIG_RVV
 
+#include <math.h>
 #include "vcommon.h"
 uint8_t check_vstart_ignore(Decode *s) {
   if(vstart->val >= vl->val) {
@@ -12,6 +13,15 @@ uint8_t check_vstart_ignore(Decode *s) {
     return 1;
   }
   return 0;
+}
+
+bool check_vlmul_sew_illegal(rtlreg_t vtype_req){
+  vtype_t vt = (vtype_t )vtype_req;
+  int vlmul = vt.vlmul;
+  int vsew = vt.vsew;
+  if (vlmul > 4) vlmul -= 8;
+  if((vlmul < vsew + 3 - log2(MAXELEN)) || vlmul == 4) return true; // vmul < sew/ELEN || vlmul == 100
+  return false;
 }
 
 #endif

--- a/src/isa/riscv64/instr/rvv/vcommon.h
+++ b/src/isa/riscv64/instr/rvv/vcommon.h
@@ -9,6 +9,7 @@
 #include "../local-include/rtl.h"
 
 uint8_t check_vstart_ignore(Decode *s);
+bool check_vlmul_sew_illegal(rtlreg_t vtype_req);
 
 #endif
 #endif


### PR DESCRIPTION
This commit fix the situation that a vset{i}vl{i} instruction have illegal vlmul and vsew should set vl and rd to zero。