### PR TITLE
Fix some bugs about checkpoint

### DIFF
--- a/include/checkpoint/path_manager.h
+++ b/include/checkpoint/path_manager.h
@@ -32,7 +32,7 @@ class PathManager
     std::string configName;
     std::string workloadName;
 
-    int cptID;
+    uint64_t cptID;
 
     std::string workloadPath;
     fs::path outputPath;
@@ -43,7 +43,7 @@ class PathManager
 
     void incCptID();
 
-    int getCptID() const {return cptID;}
+    uint64_t getCptID() const {return cptID;}
 
     std::string getOutputPath() const;
 

--- a/include/checkpoint/serializer.h
+++ b/include/checkpoint/serializer.h
@@ -48,7 +48,7 @@ class Serializer
 
     uint64_t intervalSize{10 * 1000 * 1000};
 
-    int cptID;
+    uint64_t cptID;
     std::string weightIndicator;
 
     const uint32_t IntRegStartAddr;

--- a/src/checkpoint/path_manager.cpp
+++ b/src/checkpoint/path_manager.cpp
@@ -51,7 +51,7 @@ void PathManager::init() {
   //    cptID = cpt_id;
   //  }
 
-  Log("Cpt id: %i", cptID);
+  Log("Cpt id: %li", cptID);
 
   workloadPath = statsBaseDir + "/" + configName + "/" + workloadName + "/";
 
@@ -77,7 +77,7 @@ void PathManager::setSimpointProfilingOutputDir() {
 
 void PathManager::setCheckpointingOutputDir() {
   //set checkpoint id
-  cptID=serializer.next_index();
+  cptID = serializer.next_index();
   if (checkpoint_state!=NoCheckpoint) {
     std::string output_path = workloadPath;
     output_path += to_string(cptID) + "/";
@@ -93,7 +93,7 @@ void PathManager::setCheckpointingOutputDir() {
 }
 
 void PathManager::incCptID() {
-  cptID=serializer.next_index();
+  cptID = serializer.next_index();
 }
 
 std::string PathManager::getOutputPath() const {

--- a/src/checkpoint/serializer.cpp
+++ b/src/checkpoint/serializer.cpp
@@ -75,7 +75,7 @@ void Serializer::serializePMem(uint64_t inst_count) {
   if (!fp) {
     xpanic("Cannot open restorer %s\n", restorer);
   }
-  uint32_t restorer_size = 0x400;
+  uint32_t restorer_size = 0xf00;
   fseek(fp, 0, SEEK_SET);
   assert(restorer_size == fread(pmem, 1, restorer_size, fp));
   fclose(fp);


### PR DESCRIPTION
1. When generating and executing checkpoints according to the tutorials or README.md, it **may** incur confusing errors. I found that **NEMU only restores a part of `gcpt.bin`**.

> What is incredible is that scripts(restore.sh) uses different shell commands from those in tutorials and thus bypasses this question... I may stuck here for longer if I haven't look at your CI workflow.
2. The directory name become negative number when `inst_count` excesses the limitation of `int`. I fixed it.

What I haven't solved is that NEMU will generate `csrrs x10, 0x0c1, x0` instruction, which is not supported by XiangShan. I found it resulted from following codes:

`csr.h`
```c
#define CSRS(f) \
...
  f(mtime      , 0xc01) \
```
`resource/gcpt_restore/src/restore.S`
```asm
restore_csr_vector:
  # set fs
  li t0, MSTATUS_FS
  csrs  CSR_MSTATUS, t0

  li t0, CSR_CPT_ADDR
  CSRS(CSRS_RESTORE)
  HCSRS(CSRS_RESTORE)
```
To fix this may acquire more discussion.