### PR TITLE
rv64v: fix some vector extension instruction

### DIFF
--- a/src/isa/riscv64/instr/rvv/vcompute.h
+++ b/src/isa/riscv64/instr/rvv/vcompute.h
@@ -398,7 +398,7 @@ def_EHelper(vfirst) {
   // longjmp_raise_intr(EX_II);
   if(vstart->val != 0)
     longjmp_raise_intr(EX_II);
-  
+
   int pos = -1;
   for(int idx = vstart->val; idx < vl->val; idx ++) {
     *s0 = get_mask(id_src2->reg, idx, vtype->vsew, vtype->vlmul);
@@ -420,12 +420,12 @@ def_EHelper(vmsbf) {
   for(int idx = vstart->val; idx < vl->val; idx ++) {
     rtlreg_t mask = get_mask(0, idx, vtype->vsew, vtype->vlmul);
     if(s->vm == 0 && mask == 0) {
-      if (vtype->vma) {
-        set_mask(id_dest->reg, idx, 1, vtype->vsew, vtype->vlmul);
-      }
+      //if (vtype->vma) {
+        //set_mask(id_dest->reg, idx, 1, vtype->vsew, vtype->vlmul);
+      //}
       continue;
     }
-    
+
     *s0 = get_mask(id_src2->reg, idx, vtype->vsew, vtype->vlmul);
     *s0 &= 1;
 
@@ -436,6 +436,13 @@ def_EHelper(vmsbf) {
     if(first_one) {
       set_mask(id_dest->reg, idx, 0, vtype->vsew, vtype->vlmul);
     } else{
+      set_mask(id_dest->reg, idx, 1, vtype->vsew, vtype->vlmul);
+    }
+  }
+  // If there is no set bit in the active element of the source vector,
+  // all active elements in the target are written to 1.
+  if (!first_one) {
+    for(int idx = vstart->val; idx < vl->val; idx ++) {
       set_mask(id_dest->reg, idx, 1, vtype->vsew, vtype->vlmul);
     }
   }

--- a/src/isa/riscv64/instr/rvv/vcompute.h
+++ b/src/isa/riscv64/instr/rvv/vcompute.h
@@ -401,11 +401,13 @@ def_EHelper(vfirst) {
 
   int pos = -1;
   for(int idx = vstart->val; idx < vl->val; idx ++) {
-    *s0 = get_mask(id_src2->reg, idx, vtype->vsew, vtype->vlmul);
-    *s0 &= 1;
-    if(*s0 == 1) {
+    if (s->vm || (cpu.vr[0]._64[idx/64] & (1lu << (idx % 64))) ) {
+      *s0 = get_mask(id_src2->reg, idx, vtype->vsew, vtype->vlmul);
+      *s0 &= 1;
+      if(*s0 == 1) {
         pos = idx;
         break;
+      }
     }
   }
   rtl_li(s, s1, pos);
@@ -562,7 +564,7 @@ def_EHelper(viota) {
 
 def_EHelper(vid) {
   for(int idx = 0; idx < vl->val; idx ++) {
-        // mask
+    // mask
     rtlreg_t mask = get_mask(0, idx, vtype->vsew, vtype->vlmul);
     // Masking does not change the index value written to active elements.
     if(s->vm == 0 && mask == 0) {
@@ -885,7 +887,8 @@ def_EHelper(vfslide1down) {
 }
 
 def_EHelper(vfmvfs) {
-  if (vstart->val < vl->val) {
+  // vfmv.f.s performs its action even if vstart≥vl or vl=0
+  if (vstart->val < vl->val || vl->val == 0) {
     get_vreg(id_src2->reg, 0, s0, vtype->vsew, vtype->vlmul, 1, 1);
     if (vtype->vsew < 3) {
         *s0 = *s0 | (UINT64_MAX << (8 << vtype->vsew));

--- a/src/isa/riscv64/instr/rvv/vcompute_impl.c
+++ b/src/isa/riscv64/instr/rvv/vcompute_impl.c
@@ -173,6 +173,14 @@ void arthimetic_instr(int opcode, int is_signed, int widening, int narrow, int d
         else {
           if ( (opcode == MSLTU) || (opcode == MSLEU) || (opcode == MSGTU) )
             rtl_li(s, s1, s->isa.instr.v_opv2.v_simm5);
+          else if (opcode == SADDU) {
+            switch (vtype->vsew) {
+              case 0 : *s1 = s->isa.instr.v_opv2.v_simm5 & 0xff; break;
+              case 1 : *s1 = s->isa.instr.v_opv2.v_simm5 & 0xffff; break;
+              case 2 : *s1 = s->isa.instr.v_opv2.v_simm5 & 0xffffffff; break;
+              case 3 : *s1 = s->isa.instr.v_opv2.v_simm5 & 0xffffffffffffffff; break;
+            }
+          }
           else
             rtl_li(s, s1, s->isa.instr.v_opv3.v_imm5);
         }       
@@ -335,9 +343,14 @@ void arthimetic_instr(int opcode, int is_signed, int widening, int narrow, int d
         if ((uint64_t)idx >= (uint64_t)*s1) get_vreg(id_src2->reg, idx - *s1, s1, vtype->vsew, vtype->vlmul, 0, 1);
         else get_vreg(id_dest->reg, idx, s1, vtype->vsew, vtype->vlmul, 0, 1);
         break;
-      case SLIDEDOWN :
-        if ((uint64_t)idx + (uint64_t)*s1 < (uint64_t)vlmax) get_vreg(id_src2->reg, idx + *s1, s1, vtype->vsew, vtype->vlmul, 0, 1);
-        else rtl_li(s, s1, 0);
+      case SLIDEDOWN :// idx + s1 should be prevented from overflowing and thus failing the judgment
+        // Data manipulation is forbidden when vl is 0
+        if (vtype->val != 0) {
+          if ((uint64_t)idx + (uint64_t)*s1 < (uint64_t)vlmax && (uint64_t)*s1 < (uint64_t)vlmax) 
+            get_vreg(id_src2->reg, idx + *s1, s1, vtype->vsew, vtype->vlmul, 0, 1);
+          else
+            rtl_li(s, s1, 0);
+        }
         break;
       case SLIDE1UP :
         if (idx > 0) get_vreg(id_src2->reg, idx - 1, s1, vtype->vsew, vtype->vlmul, 0, 1);
@@ -359,9 +372,16 @@ void arthimetic_instr(int opcode, int is_signed, int widening, int narrow, int d
         *s2 = *s1;
         rtl_add(s, s1, s0, s1);
         sat = 0;
-        for (int i = 0; i < (8 << vtype->vsew); i++) {
-            carry = (((*s0 >> i) & 1) + ((*s2 >> i) & 1) + carry) >> 1;
-            carry &= 1;
+        uint8_t bit_num=(8 << vtype->vsew);
+        if (vtype->vsew >=3){
+          uint64_t sum = *s0 + *s2;
+          // Since the overflow result is added from 0,
+          // the result is less than two additions, which is an overflow
+          carry = ((sum < *s0) & (sum < *s2));
+        } else {
+          uint64_t sum = *s0 + *s2;
+          // Computation overflow bit
+          carry =  (sum >> bit_num) > 0 ? 1 : 0;
         }
         if (carry) {rtl_li(s, s1, ~0lu); sat = 1;}
         vxsat->val |= sat;
@@ -774,10 +794,9 @@ void float_reduction_instr(int opcode, int widening, Decode *s) {
     // operand - vs2
     get_vreg(id_src2->reg, idx, s0, vtype->vsew, vtype->vlmul, 0, 1);
 
-
     // op
     switch (opcode) {
-      case FREDUSUM : rtl_hostcall(s, HOSTCALL_VFP, s1, s0, s1, FPCALL_CMD(FPCALL_ADD, FPCALL_TYPE)); break;
+      case FREDUSUM : rtl_hostcall(s, HOSTCALL_VFP, s1, s0, s1, FPCALL_CMD(FPCALL_UADD, FPCALL_TYPE)); break;
       case FREDOSUM : rtl_hostcall(s, HOSTCALL_VFP, s1, s0, s1, FPCALL_CMD(FPCALL_ADD, FPCALL_TYPE)); break;
       case FREDMIN : rtl_hostcall(s, HOSTCALL_VFP, s1, s0, s1, FPCALL_CMD(FPCALL_MIN, FPCALL_TYPE)); break;
       case FREDMAX : rtl_hostcall(s, HOSTCALL_VFP, s1, s0, s1, FPCALL_CMD(FPCALL_MAX, FPCALL_TYPE)); break;
@@ -789,10 +808,13 @@ void float_reduction_instr(int opcode, int widening, Decode *s) {
   if (RVV_AGNOSTIC) {
     if(vtype->vta) set_vreg_tail(id_dest->reg);
   }
-  if (widening)
-    set_vreg(id_dest->reg, 0, *s1, vtype->vsew+1, vtype->vlmul, 0);
-  else
-    set_vreg(id_dest->reg, 0, *s1, vtype->vsew, vtype->vlmul, 0);
+  // No write when vl is 0
+  if (vl->val != 0) {
+    if (widening)
+      set_vreg(id_dest->reg, 0, *s1, vtype->vsew+1, vtype->vlmul, 0);
+    else
+      set_vreg(id_dest->reg, 0, *s1, vtype->vsew, vtype->vlmul, 0);
+  }
 }
 
 void float_reduction_step2(uint64_t src, Decode *s) {


### PR DESCRIPTION
fix vfwredusum, vfwredosum, vsaddu, vslidedown, vmsbf, vfmvfms, vfirst