### PR TITLE
[H-ext] Remove writing read-only regs and add restoring virtualization mode

### DIFF
--- a/resource/gcpt_restore/src/csr.h
+++ b/resource/gcpt_restore/src/csr.h
@@ -45,7 +45,7 @@
   f(hstatus    , 0x600) f(hedeleg    , 0x602) f(hideleg    , 0x603) \
   f(hie        , 0x604) f(hcounteren , 0x606) f(hgeie      , 0x607) \
   f(htval      , 0x643) f(hip        , 0x644) f(hvip       , 0x645) \
-  f(htinst     , 0x64A) f(hgeip      , 0xE12) f(henvcfg    , 0x60A) \
+  f(htinst     , 0x64A) f(henvcfg    , 0x60A) \
   f(hgatp      , 0x680) f(htimedelta , 0x605) \
   f(vsstatus   , 0x200) f(vsie       , 0x204) f(vstvec     , 0x205) \
   f(vsscratch  , 0x240) f(vsepc      , 0x241) f(vscause    , 0x242) \

--- a/resource/gcpt_restore/src/restore.S
+++ b/resource/gcpt_restore/src/restore.S
@@ -49,9 +49,17 @@ restore_csr_vector:
   csrc CSR_MSTATUS, t1
 
 
-  li t0, MSTATUS_MPP # MPP is M
-  ld s2, 8(s0) #load mode flag into s2
-  slli t1, s2, 11 # mode flag shift to MPP
+  li t0, MSTATUS_MPP  # MPP is M
+  ld s2, 8(s0)        # load mode flag into s2
+  slli t1, s2, 11     # mode flag shift to MPP
+
+#ifdef CONFIG_RVH
+  ld s2, 32(s0)       # load v flag into s2 
+  slli s2, s2, 39     # mode flag shift to MPV
+
+  or t1, t1, s2
+#endif // CONFIG_RVH
+
 2:
   beq t0, t1, 2b #stuck if mode flag is M
   # set MPP to mode flag (U or S), clear and set

--- a/src/checkpoint/serializer.cpp
+++ b/src/checkpoint/serializer.cpp
@@ -192,6 +192,12 @@ void Serializer::serializeRegs() {
   *mtime_cmp = ::paddr_read(CLINT_MMIO+0x4000, 8, MEM_TYPE_READ, MODE_M, CLINT_MMIO+0x4000);
   Log("Record time: 0x%lx at addr 0x%x", cpu.mode, BOOT_FLAGS+24);
 
+#ifdef CONFIG_RVH
+  auto *mode_flag_v = (uint64_t *) (get_pmem() + CptFlagAddr + 32);
+  *mode_flag_v = cpu.v;
+  Log("Record virtualization mode: 0x%lx at addr 0x%x", cpu.v, BOOT_FLAGS + 32);
+#endif
+
   regDumped = true;
 }
 


### PR DESCRIPTION
There are two problems when generating checkpoints for H-ext tests:

1. When restoring, gcpt writes to **read-only** reg `hgeip`, which results from `resource/gcpt_restore/src/csr.h`:
	```c
	#define HCSRS(f) \
	  f(hstatus    , 0x600) f(hedeleg    , 0x602) f(hideleg    , 0x603) \
	  f(hie        , 0x604) f(hcounteren , 0x606) f(hgeie      , 0x607) \
	  f(htval      , 0x643) f(hip        , 0x644) f(hvip       , 0x645) \
	  f(htinst     , 0x64A) f(hgeip      , 0xE12) f(henvcfg    , 0x60A) \
	  f(hgatp      , 0x680) f(htimedelta , 0x605) \
	  f(vsstatus   , 0x200) f(vsie       , 0x204) f(vstvec     , 0x205) \
	  f(vsscratch  , 0x240) f(vsepc      , 0x241) f(vscause    , 0x242) \
	  f(vstval     , 0x243) f(vsip       , 0x244) f(vsatp      , 0x280) \
	  f(mtval2     , 0x34b) f(mtinst     , 0x34A)
	```
2. gcpt does not store and restore virtualization mode, denoted as `cpu.v`, which may incur inpredictable errors if taking checkpoints in virtualization mode.

This pull request aims to fix these two issues.