### PR TITLE
RVH: fix read mask absence of vsstatus

### DIFF
--- a/src/isa/riscv64/system/priv.c
+++ b/src/isa/riscv64/system/priv.c
@@ -273,6 +273,7 @@ if (is_read(hgeie))          { return hgeie->val & ~(0x1UL);}
 if (is_read(hip))            { return mip->val & HIP_RMASK & (mideleg->val | MIDELEG_FORCED_MASK);}
 if (is_read(hie))            { return mie->val & HIE_RMASK & (mideleg->val | MIDELEG_FORCED_MASK);}
 if (is_read(hvip))           { return mip->val & HVIP_MASK;}
+if (is_read(vsstatus))       { return vsstatus->val & SSTATUS_RMASK; }
 if (is_read(vsip))           { return (mip->val & (hideleg->val & (mideleg->val | MIDELEG_FORCED_MASK)) & VS_MASK) >> 1; }
 if (is_read(vsie))           { return (mie->val & (hideleg->val & (mideleg->val | MIDELEG_FORCED_MASK)) & VS_MASK) >> 1;}
 #endif


### PR DESCRIPTION
The function `csr_read()` lacks a mask for vsstatus, resulting in the reading of non-zero values from reserved WPRI fields. 

Actually `csr_write()` includes a mask for vsstatus, but incorrect values are being received from the Difftest DUT during initialization.