### PR TITLE
vector-diff: vector store not diff enough times

### DIFF
--- a/include/memory/paddr.h
+++ b/include/memory/paddr.h
@@ -77,6 +77,7 @@ extern store_commit_t store_commit_queue[CONFIG_DIFFTEST_STORE_QUEUE_SIZE];
 void store_commit_queue_push(uint64_t addr, uint64_t data, int len);
 store_commit_t *store_commit_queue_pop();
 int check_store_commit(uint64_t *addr, uint64_t *data, uint8_t *mask);
+uint64_t store_read_step();
 #endif
 
 #ifdef CONFIG_MULTICORE_DIFF

--- a/src/memory/paddr.c
+++ b/src/memory/paddr.c
@@ -341,6 +341,12 @@ int check_store_commit(uint64_t *addr, uint64_t *data, uint8_t *mask) {
   return result;
 }
 
+inline uint64_t store_read_step() {
+  if (tail >= head) 
+    return tail - head;
+  else 
+    return (CONFIG_DIFFTEST_STORE_QUEUE_SIZE - head + tail);
+}
 #endif
 
 char *mem_dump_file = NULL;


### PR DESCRIPTION
Fixed the case that store diff does not diff enough times under V vector memory access