### PR TITLE
profile: add program memory segment usage analysis

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -308,6 +308,16 @@ config TIMER_CLOCK_GETTIME
   bool "clock_gettime"
 endchoice
 
+config MEMORY_REGION_ANALYSIS
+  bool "Enable Program memory segment analysis"
+  default n
+
+if MEMORY_REGION_ANALYSIS
+config MEMORY_REGION_ANALYSIS_SIZE
+  int "Analysis block MB size"
+  default 32
+endif
+
 config REPORT_ILLEGAL_INSTR
   bool "Let NEMU report illegal instruction"
   default y

--- a/include/memory/paddr.h
+++ b/include/memory/paddr.h
@@ -80,6 +80,18 @@ int check_store_commit(uint64_t *addr, uint64_t *data, uint8_t *mask);
 uint64_t store_read_step();
 #endif
 
+//#define CONFIG_MEMORY_REGION_ANALYSIS
+#ifdef CONFIG_MEMORY_REGION_ANALYSIS
+#include <math.h>
+#define PROGRAM_MEMORY_SIZE (CONFIG_MSIZE /1024 /1024) // MB
+#define PROGRAM_ANALYSIS_PAGES (PROGRAM_MEMORY_SIZE / CONFIG_MEMORY_REGION_ANALYSIS_SIZE)
+#define ALIGNMENT_SIZE ((int)log2(CONFIG_MEMORY_REGION_ANALYSIS_SIZE * 1024 * 1024))// set MB alig
+
+void analysis_memory_commit(uint64_t addr);
+void analysis_use_addr_display();
+bool analysis_memory_isuse(uint64_t page);
+#endif
+
 #ifdef CONFIG_MULTICORE_DIFF
 extern uint8_t* golden_pmem;
 

--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -45,7 +45,9 @@ extern char *mapped_cpt_file;  // defined in paddr.c
 extern bool map_image_as_output_cpt;
 extern char *reg_dump_file;
 extern char *mem_dump_file;
-
+#ifdef CONFIG_MEMORY_REGION_ANALYSIS
+extern char *memory_region_record_file;
+#endif
 int is_batch_mode() { return batch_mode; }
 
 static inline void welcome() {
@@ -107,7 +109,7 @@ static inline int parse_args(int argc, char *argv[]) {
     // profiling
     {"simpoint-profile"   , no_argument      , NULL, 3},
     {"dont-skip-boot"     , no_argument      , NULL, 6},
-
+    {"mem_use_record_file", required_argument, NULL, 'A'},
     // restore cpt
     {"cpt-id"             , required_argument, NULL, 4},
 
@@ -172,6 +174,13 @@ static inline int parse_args(int argc, char *argv[]) {
       case 'M':
           mem_dump_file = optarg;
           break;
+      case 'A': 
+          #ifdef CONFIG_MEMORY_REGION_ANALYSIS
+          Log("Set mem analysis log path %s", optarg);
+          memory_region_record_file = optarg;
+          #else
+          Log("is set path but memory analysis is not turned on");
+          #endif
 
       case 5: sscanf(optarg, "%lu", &checkpoint_interval); break;
 
@@ -247,6 +256,7 @@ static inline int parse_args(int argc, char *argv[]) {
 
         printf("\t--simpoint-profile      simpoint profiling\n");
         printf("\t--dont-skip-boot        profiling/checkpoint immediately after boot\n");
+        printf("\t--mem_use_record_file   result output file for analyzing the memory use segment\n");
 //        printf("\t--cpt-id                checkpoint id\n");
         printf("\t-M,--dump-mem=DUMP_FILE dump memory into FILE\n");
         printf("\t-R,--dump-reg=DUMP_FILE dump register value into FILE\n");

--- a/src/monitor/ui.c
+++ b/src/monitor/ui.c
@@ -276,6 +276,10 @@ void ui_mainloop() {
   if (is_batch_mode()) {
     extern char *max_instr;
     cmd_c(max_instr);
+#ifdef CONFIG_MEMORY_REGION_ANALYSIS
+    extern void analysis_use_addr_display();
+    analysis_use_addr_display();
+#endif
     return;
   }
 


### PR DESCRIPTION
When MEMORY_REGION_ANALYSISis configured, the program's memory segment usage analysis is started and printed or exported to a file. The path is set using --mem_use_record_file, and the analysis is performed in 32MB block units by default