### PR TITLE
log: add nemu-ref csr skip info dump

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -301,6 +301,11 @@ config REF_STATUS
   bool "Enable ref status API"
   default n
 
+config REF_SKIP_INFO 
+  depends on SHARE
+  bool "Enable dump debug information when forcing sync"
+  default n
+
 endmenu
 
 menu "Miscellaneous"

--- a/Makefile
+++ b/Makefile
@@ -57,10 +57,13 @@ SRCS-y += $(shell find $(DIRS-y) -name "*.c")
 
 SRCS = $(SRCS-y)
 
+DIRS-y += src/profiling # profiling.c
+ifndef CONFIG_SHARE
 DIRS-cpp = src/checkpoint src/base src/iostream3 src/memory src/profiling
-DIRS-y += src/checkpoint src/profiling # profiling.c
+DIRS-y += src/checkpoint # profiling.c
 
 XSRCS = $(shell find $(DIRS-cpp) -name "*.cpp")
+endif
 
 CC = $(call remove_quote,$(CONFIG_CC))
 CXX = $(call remove_quote,$(CONFIG_CXX))

--- a/include/checkpoint/cpt_env.h
+++ b/include/checkpoint/cpt_env.h
@@ -13,6 +13,7 @@
 * See the Mulan PSL v2 for more details.
 ***************************************************************************************/
 
+#ifndef CONFIG_SHARE
 #ifndef __CHECKPOINT_CPT_ENV__
 #define __CHECKPOINT_CPT_ENV__
 
@@ -28,3 +29,4 @@ extern char *restorer;
 extern char compress_file_format;
 
 #endif
+#endif // CONFIG_SHARE

--- a/include/checkpoint/path_manager.h
+++ b/include/checkpoint/path_manager.h
@@ -17,6 +17,7 @@
 // Created by zyy on 2020/11/21.
 //
 
+#ifndef CONFIG_SHARE
 #ifndef NEMU_PATH_MANAGER_H
 #define NEMU_PATH_MANAGER_H
 
@@ -58,3 +59,4 @@ class PathManager
 extern PathManager pathManager;
 
 #endif //NEMU_PATH_MANAGER_H
+#endif //CONFIG_SHARE

--- a/include/checkpoint/serializer.h
+++ b/include/checkpoint/serializer.h
@@ -17,6 +17,7 @@
 // Created by zyy on 2020/11/16.
 //
 
+#ifndef CONFIG_SHARE
 #ifndef NEMU_SERIALIZER_H
 #define NEMU_SERIALIZER_H
 
@@ -70,3 +71,4 @@ extern Serializer serializer;
 #define MAX_RESTORER_SIZE 0xa000
 
 #endif //NEMU_SERIALIZER_H
+#endif //CONFIG_SHARE

--- a/include/checkpoint/simpoint.h
+++ b/include/checkpoint/simpoint.h
@@ -38,6 +38,7 @@
  *          Curtis Dunham
  */
 
+#ifndef CONFIG_SHARE
 #ifndef __CPU_SIMPLE_PROBES_SIMPOINT_HH__
 #define __CPU_SIMPLE_PROBES_SIMPOINT_HH__
 
@@ -127,3 +128,4 @@ class SimPoint
 }
 
 #endif // __CPU_SIMPLE_PROBES_SIMPOINT_HH__
+#endif // CONFIG_SHARE

--- a/src/checkpoint/cpt_env.c
+++ b/src/checkpoint/cpt_env.c
@@ -13,6 +13,7 @@
 * See the Mulan PSL v2 for more details.
 ***************************************************************************************/
 
+#ifndef CONFIG_SHARE
 #include <stddef.h>
 
 char *output_base_dir = NULL;
@@ -22,3 +23,4 @@ char *simpoints_dir = NULL;
 int cpt_id = -1;
 char *cpt_file = NULL;
 char *restorer = NULL;
+#endif // CONFIG_SHARE

--- a/src/checkpoint/path_manager.cpp
+++ b/src/checkpoint/path_manager.cpp
@@ -17,6 +17,7 @@
 // Created by zyy on 2020/11/21.
 //
 
+#ifdef CONFIG_SHARE
 #include <checkpoint/path_manager.h>
 #include <checkpoint/cpt_env.h>
 #include <checkpoint/serializer.h>
@@ -118,3 +119,4 @@ void init_path_manager()
 }
 
 }
+#endif // CONFIG_SHARE

--- a/src/checkpoint/serializer.cpp
+++ b/src/checkpoint/serializer.cpp
@@ -17,6 +17,7 @@
 // Created by zyy on 2020/11/16.
 //
 
+#ifdef CONFIG_SHARE
 #include <checkpoint/cpt_env.h>
 #include <checkpoint/path_manager.h>
 #include <checkpoint/serializer.h>
@@ -356,3 +357,4 @@ void serialize_reg_to_mem() {
 }
 
 }
+#endif // CONFIG_SHARE

--- a/src/checkpoint/simpoint.cpp
+++ b/src/checkpoint/simpoint.cpp
@@ -38,6 +38,7 @@
  *          Curtis Dunham
  */
 
+#ifdef CONFIG_SHARE
 #include "checkpoint/path_manager.h"
 #include <cassert>
 // #include <debug.h>
@@ -187,3 +188,4 @@ void simpoint_profiling(uint64_t pc, bool is_control, uint64_t abs_instr_count) 
 }
 #endif
 }
+#endif // CONFIG_SHARE

--- a/src/cpu/cpu-exec.c
+++ b/src/cpu/cpu-exec.c
@@ -207,6 +207,7 @@ static inline void debug_difftest(Decode *_this, Decode *next) {
   IFDEF(CONFIG_DIFFTEST, difftest_step(_this->pc, next->pc));
 }
 
+#ifndef CONFIG_SHARE
 uint64_t per_bb_profile(Decode *prev_s, Decode *s, bool control_taken) {
   uint64_t abs_inst_count = get_abs_instr_count();
   // workload_loaded set from nemu_trap
@@ -267,6 +268,7 @@ uint64_t per_bb_profile(Decode *prev_s, Decode *s, bool control_taken) {
   }
   return abs_inst_count;
 }
+#endif // CONFIG_SHARE
 
 static int execute(int n) {
   Logtb("Will execute %i instrs\n", n);

--- a/src/cpu/cpu-exec.c
+++ b/src/cpu/cpu-exec.c
@@ -534,6 +534,8 @@ static int execute(int n) {
     cpu.instr = s.isa.instr.val;
 #endif
 #ifdef CONFIG_SHARE
+    IFDEF(CONFIG_REF_SKIP_INFO, iqueue_commit(cpu.pc, (void *)&s.isa.instr.val,
+                s.snpc - s.pc));
     if (unlikely(dynamic_config.debug_difftest)) {
       fprintf(stderr, "(%d) [NEMU] pc = 0x%lx inst %x\n", getpid(), s.pc,
               s.isa.instr.val);

--- a/src/engine/interpreter/rtl-basic.h
+++ b/src/engine/interpreter/rtl-basic.h
@@ -183,7 +183,9 @@ static inline def_rtl(host_sm, void *addr, const rtlreg_t *src1, int len) {
 }
 
 // control
+#ifndef CONFIG_SHARE
 extern void simpoint_profiling(uint64_t pc, bool is_control, uint64_t abs_instr_count);
+#endif // CONFIG_SHARE
 extern uint64_t get_abs_instr_count();
 
 extern uint64_t br_count;
@@ -210,9 +212,11 @@ static inline def_rtl(j, vaddr_t target) {
   cpu.pc = target;
   // real_target = target;
 
+#ifndef CONFIG_SHARE
   if (profiling_state == SimpointProfiling && workload_loaded) {
     simpoint_profiling(cpu.pc, true, get_abs_instr_count());
   }
+#endif // CONFIG_SHARE
 
 #ifdef CONFIG_GUIDED_EXEC
 end_of_rtl_j:
@@ -244,9 +248,11 @@ static inline def_rtl(jr, rtlreg_t *target) {
   real_target = *target;
   #endif // CONFIG_BR_LOG
 
+#ifndef CONFIG_SHARE
   if (profiling_state == SimpointProfiling && workload_loaded) {
     simpoint_profiling(cpu.pc, true, get_abs_instr_count());
   }
+#endif // CONFIG_SHARE
 
 #ifdef CONFIG_GUIDED_EXEC
 end_of_rtl_jr:

--- a/src/isa/riscv64/difftest/ref.c
+++ b/src/isa/riscv64/difftest/ref.c
@@ -171,6 +171,17 @@ void isa_difftest_regcpy(void *dut, bool direction) {
 #endif // CONFIG_LIGHTQS
   //ramcmp();
   if (direction == DIFFTEST_TO_REF) {
+#ifdef CONFIG_REF_SKIP_INFO
+    if (((CPU_state *)dut)->pc != 0 && (cpu.mcause != ((CPU_state *)dut)->mcause || cpu.scause != ((CPU_state *)dut)->scause)) {
+      printf("NEMU ref csr-cause skip info start\n");
+      printf("ref pc %lx\n", cpu.pc);
+      printf("update mcause %lx to %lx, scause %lx to %lx\n",
+        cpu.mcause, ((CPU_state *)dut)->mcause, cpu.scause, ((CPU_state *)dut)->scause);
+      printf("dut mepc %lx sepc %lx\n",((CPU_state *)dut)->mepc, ((CPU_state *)dut)->sepc);
+      iqueue_dump();
+      printf("NEMU ref skip info end\n\n");
+    }
+#endif // CONFIG_REF_SKIP_INFO
     memcpy(&cpu, dut, DIFFTEST_REG_SIZE);
     csr_writeback();
     // need to clear the cached mmu states as well

--- a/src/memory/Kconfig
+++ b/src/memory/Kconfig
@@ -80,7 +80,7 @@ config MEM_RANDOM
     This may help to find undefined behaviors.
 
 config MEM_COMPRESS
-  depends on MODE_SYSTEM && !DIFFTEST
+  depends on MODE_SYSTEM
   bool "Initialize the memory with a compressed gz file"
   default n
   help

--- a/src/profiling/profiling_control.c
+++ b/src/profiling/profiling_control.c
@@ -22,7 +22,7 @@ void reset_inst_counters() {
   workload_loaded=true;
 }
 
-#ifdef CONFIG_SHARE
+#ifndef CONFIG_SHARE
 // empty definition on share
 void simpoint_profiling(uint64_t pc, bool is_control, uint64_t abs_instr_count) {}
 #endif 

--- a/src/utils/iqueue.c
+++ b/src/utils/iqueue.c
@@ -14,9 +14,11 @@
 ***************************************************************************************/
 
 #include <common.h>
-
+#ifdef CONFIG_REF_SKIP_INFO
+#define INSTR_QUEUE_SIZE (1 << 3)
+#else
 #define INSTR_QUEUE_SIZE (1 << 5)
-
+#endif // CONFIG_REF_SKIP_INFO
 static struct {
   vaddr_t pc;
   uint8_t instr[20];


### PR DESCRIPTION
When nemu is used as ref, add optional function. When dut initiates mandatory update to cover mcause or scause of ref, it will be regarded as an exception, and will print part of the correct execution of itrace and the value of cause and mepc before modification. This feature can provide debug information in the case of some workload internal errors without causing difftest inconsistency and stopping the simulation
当nemu作为ref时，增加可选功能， 在由dut发起强制更新覆盖ref的mcause或scause时，视为产生异常，将打印部分正确执行的itrace以及被即将被修改和修改前的cause值 和mepc值，该功能可以在一些workload内部产生报错而没有引起difftest不一致而停下仿真的debug情况下提供调试信息