### PR TITLE
kconfig: fix no MEM_COMPRESS chose

### DIFF
--- a/src/memory/Kconfig
+++ b/src/memory/Kconfig
@@ -80,7 +80,7 @@ config MEM_RANDOM
     This may help to find undefined behaviors.
 
 config MEM_COMPRESS
-  depends on MODE_SYSTEM && !DIFFTEST
+  depends on MODE_SYSTEM && !SHARE
   bool "Initialize the memory with a compressed gz file"
   default n
   help


### PR DESCRIPTION
Changed the ability to load gz when difftest is enabled