### PR TITLE
ref: remove unnecessary compilation links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,10 +57,10 @@ SRCS-y += $(shell find $(DIRS-y) -name "*.c")
 
 SRCS = $(SRCS-y)
 
-DIRS-y += src/profiling # profiling.c
+DIRS-y += src/profiling
 ifndef CONFIG_SHARE
 DIRS-cpp = src/checkpoint src/base src/iostream3 src/memory src/profiling
-DIRS-y += src/checkpoint # profiling.c
+DIRS-y += src/checkpoint
 
 XSRCS = $(shell find $(DIRS-cpp) -name "*.cpp")
 endif

--- a/Makefile
+++ b/Makefile
@@ -57,10 +57,13 @@ SRCS-y += $(shell find $(DIRS-y) -name "*.c")
 
 SRCS = $(SRCS-y)
 
+DIRS-y += src/profiling # profiling.c
+ifndef CONFIG_SHARE
 DIRS-cpp = src/checkpoint src/base src/iostream3 src/memory src/profiling
-DIRS-y += src/checkpoint src/profiling # profiling.c
+DIRS-y += src/checkpoint # profiling.c
 
 XSRCS = $(shell find $(DIRS-cpp) -name "*.cpp")
+endif
 
 CC = $(call remove_quote,$(CONFIG_CC))
 CXX = $(call remove_quote,$(CONFIG_CXX))

--- a/src/cpu/cpu-exec.c
+++ b/src/cpu/cpu-exec.c
@@ -207,6 +207,7 @@ static inline void debug_difftest(Decode *_this, Decode *next) {
   IFDEF(CONFIG_DIFFTEST, difftest_step(_this->pc, next->pc));
 }
 
+#ifndef CONFIG_SHARE
 uint64_t per_bb_profile(Decode *prev_s, Decode *s, bool control_taken) {
   uint64_t abs_inst_count = get_abs_instr_count();
   // workload_loaded set from nemu_trap
@@ -267,6 +268,7 @@ uint64_t per_bb_profile(Decode *prev_s, Decode *s, bool control_taken) {
   }
   return abs_inst_count;
 }
+#endif // CONFIG_SHARE
 
 static int execute(int n) {
   Logtb("Will execute %i instrs\n", n);

--- a/src/engine/interpreter/rtl-basic.h
+++ b/src/engine/interpreter/rtl-basic.h
@@ -183,7 +183,9 @@ static inline def_rtl(host_sm, void *addr, const rtlreg_t *src1, int len) {
 }
 
 // control
+#ifndef CONFIG_SHARE
 extern void simpoint_profiling(uint64_t pc, bool is_control, uint64_t abs_instr_count);
+#endif // CONFIG_SHARE
 extern uint64_t get_abs_instr_count();
 
 extern uint64_t br_count;
@@ -210,9 +212,11 @@ static inline def_rtl(j, vaddr_t target) {
   cpu.pc = target;
   // real_target = target;
 
+#ifndef CONFIG_SHARE
   if (profiling_state == SimpointProfiling && workload_loaded) {
     simpoint_profiling(cpu.pc, true, get_abs_instr_count());
   }
+#endif // CONFIG_SHARE
 
 #ifdef CONFIG_GUIDED_EXEC
 end_of_rtl_j:
@@ -244,9 +248,11 @@ static inline def_rtl(jr, rtlreg_t *target) {
   real_target = *target;
   #endif // CONFIG_BR_LOG
 
+#ifndef CONFIG_SHARE
   if (profiling_state == SimpointProfiling && workload_loaded) {
     simpoint_profiling(cpu.pc, true, get_abs_instr_count());
   }
+#endif // CONFIG_SHARE
 
 #ifdef CONFIG_GUIDED_EXEC
 end_of_rtl_jr:


### PR DESCRIPTION
When compiling as ref, you don't need to enable checkpoint functionality, which saves you 50kb of compile size and avoids some cases where the host doesn't have the relevant library files to run
在作为ref编译时不需要开启checkpoint的相关功能，这样可以减少50kb的编译大小，并且避免一些因为宿主机没有相关库文件造成无法运行的情况