### PR TITLE
log: add nemu-ref csr skip info dump

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -301,6 +301,11 @@ config REF_STATUS
   bool "Enable ref status API"
   default n
 
+config REF_SKIP_INFO 
+  depends on SHARE
+  bool "Enable dump debug information when forcing sync"
+  default n
+
 endmenu
 
 menu "Miscellaneous"

--- a/src/cpu/cpu-exec.c
+++ b/src/cpu/cpu-exec.c
@@ -534,6 +534,8 @@ static int execute(int n) {
     cpu.instr = s.isa.instr.val;
 #endif
 #ifdef CONFIG_SHARE
+    IFDEF(CONFIG_REF_SKIP_INFO, iqueue_commit(cpu.pc, (void *)&s.isa.instr.val,
+                s.snpc - s.pc));
     if (unlikely(dynamic_config.debug_difftest)) {
       fprintf(stderr, "(%d) [NEMU] pc = 0x%lx inst %x\n", getpid(), s.pc,
               s.isa.instr.val);

--- a/src/isa/riscv64/difftest/ref.c
+++ b/src/isa/riscv64/difftest/ref.c
@@ -171,6 +171,17 @@ void isa_difftest_regcpy(void *dut, bool direction) {
 #endif // CONFIG_LIGHTQS
   //ramcmp();
   if (direction == DIFFTEST_TO_REF) {
+#ifdef CONFIG_REF_SKIP_INFO
+    if (((CPU_state *)dut)->pc != 0 && (cpu.mcause != ((CPU_state *)dut)->mcause || cpu.scause != ((CPU_state *)dut)->scause)) {
+      printf("NEMU ref csr-cause skip info start\n");
+      printf("ref pc %lx\n", cpu.pc);
+      printf("update mcause %lx to %lx, scause %lx to %lx\n",
+        cpu.mcause, ((CPU_state *)dut)->mcause, cpu.scause, ((CPU_state *)dut)->scause);
+      printf("dut mepc %lx sepc %lx\n",((CPU_state *)dut)->mepc, ((CPU_state *)dut)->sepc);
+      iqueue_dump();
+      printf("NEMU ref skip info end\n\n");
+    }
+#endif // CONFIG_REF_SKIP_INFO
     memcpy(&cpu, dut, DIFFTEST_REG_SIZE);
     csr_writeback();
     // need to clear the cached mmu states as well

--- a/src/utils/iqueue.c
+++ b/src/utils/iqueue.c
@@ -14,9 +14,11 @@
 ***************************************************************************************/
 
 #include <common.h>
-
+#ifdef CONFIG_REF_SKIP_INFO
+#define INSTR_QUEUE_SIZE (1 << 3)
+#else
 #define INSTR_QUEUE_SIZE (1 << 5)
-
+#endif // CONFIG_REF_SKIP_INFO
 static struct {
   vaddr_t pc;
   uint8_t instr[20];


### PR DESCRIPTION
When nemu is used as ref, add optional function. When dut initiates mandatory update to cover mcause or scause of ref, it will be regarded as an exception, and will print part of the correct execution of itrace and the value of cause and mepc before modification. This feature can provide debug information in the case of some workload internal errors without causing difftest inconsistency and stopping the simulation
当nemu作为ref时，增加可选功能， 在由dut发起强制更新覆盖ref的mcause或scause时，视为产生异常，将打印部分正确执行的itrace以及被即将被修改和修改前的cause值 和mepc值，该功能可以在一些workload内部产生报错而没有引起difftest不一致而停下仿真的debug情况下提供调试信息