### PR TITLE
fix: fix sv39 mtval

### DIFF
--- a/src/isa/riscv64/system/mmu.c
+++ b/src/isa/riscv64/system/mmu.c
@@ -582,7 +582,12 @@ void isa_misalign_data_addr_check(vaddr_t vaddr, int len, int type) {
   if (ISDEF(CONFIG_AC_SOFT) && unlikely((vaddr & (len - 1)) != 0)) {
     Log("addr misaligned happened: vaddr:%lx len:%d type:%d pc:%lx", vaddr, len, type, cpu.pc);
     int ex = cpu.amo || type == MEM_TYPE_WRITE ? EX_SAM : EX_LAM;
+#ifdef CONFIG_USE_XS_ARCH_CSRS
+    vaddr = vaddr & (vaddr_t)0x7FFFFFFFFF;
+    INTR_TVAL_REG(ex) = SEXT(vaddr, 39); // USE SV39 VADDR
+#else
     INTR_TVAL_REG(ex) = vaddr;
+#endif // CONFIG_USE_XS_ARCH_CSRS
     longjmp_exception(ex);
   }
 }


### PR DESCRIPTION
In xiangshan, the virtual address is trimmed to save the chip area. When SAM LAM exception is triggered, only the address with a large size of 39 bits will be written, so certain changes need to be made when xs ref is used