### PR TITLE
rv64v: fix four bugs discovered by riscv-vector-intrinsic-fuzzing

### DIFF
--- a/include/rtl/fp.h
+++ b/include/rtl/fp.h
@@ -17,6 +17,7 @@
 #define __RTL_FP_H__
 
 enum {
+  FPCALL_W8,
   FPCALL_W16,
   FPCALL_W32,
   FPCALL_W64,

--- a/src/engine/interpreter/fp.c
+++ b/src/engine/interpreter/fp.c
@@ -145,8 +145,19 @@ def_rtl(vfpcall, rtlreg_t *dest, const rtlreg_t *src1, const rtlreg_t *src2, uin
   isa_fp_csr_check();
 
   softfloat_roundingMode = isa_fp_get_frm();
-
-  if (w == FPCALL_W16) {
+  if (w == FPCALL_W8) {
+    // w8 only can hold int/uint
+    // f need at least w16
+    // so src must be int/uint
+    int8_t isrc1 = *(int8_t*)(src1);
+    // now is unused variable 
+    // int8_t isrc2 = *(int8_t*)(src2);
+    // uint8_t usrc1 = *(uint8_t*)(src1);
+    // uint8_t usrc2 = *(uint8_t*)(src2);
+    switch (op) {
+      case FPCALL_SToDF: *dest = i32_to_f16((int32_t)(int8_t)isrc1).v; break;
+    }
+  } else if (w == FPCALL_W16) {
     float16_t fsrc1 = rtlToF16(*src1);
     float16_t fsrc2 = rtlToF16(*src2);
     switch (op) {
@@ -200,11 +211,7 @@ def_rtl(vfpcall, rtlreg_t *dest, const rtlreg_t *src1, const rtlreg_t *src2, uin
       case FPCALL_FToDUT: *dest = f16_to_ui32(fsrc1, softfloat_round_minMag, true); break;
       case FPCALL_FToDST: *dest = f16_to_i32(fsrc1, softfloat_round_minMag, true); break;
       case FPCALL_UToDF: *dest = ui32_to_f32(fsrc1.v).v; break;
-      case FPCALL_SToDF: 
-          if ((fsrc1.v & ~0xffffULL) == 0) *dest = i32_to_f32((int32_t)(int16_t)fsrc1.v).v;
-          else if ((fsrc1.v & ~0xffULL) == 0) *dest = i32_to_f32((int32_t)(int8_t)fsrc1.v).v;
-          else *dest = i32_to_f32(fsrc1.v).v;
-          break;
+      case FPCALL_SToDF: *dest = i32_to_f32((int32_t)(int16_t)fsrc1.v).v; break;
       case FPCALL_FToDF: *dest = f16_to_f32(fsrc1).v; break;
 
       case FPCALL_DFToU: *dest = f16_to_ui8(fsrc1, softfloat_roundingMode, true); break;
@@ -282,11 +289,7 @@ def_rtl(vfpcall, rtlreg_t *dest, const rtlreg_t *src1, const rtlreg_t *src2, uin
       case FPCALL_FToDUT: *dest = f32_to_ui64(fsrc1, softfloat_round_minMag, true); break;
       case FPCALL_FToDST: *dest = f32_to_i64(fsrc1, softfloat_round_minMag, true); break;
       case FPCALL_UToDF: *dest = ui32_to_f64(fsrc1.v).v; break;
-      case FPCALL_SToDF:
-          if ((fsrc1.v & ~0xffffULL ) == 0) *dest = i32_to_f64((int32_t)(int16_t)fsrc1.v).v;
-          else if ((fsrc1.v & ~0xffULL ) == 0) *dest = i32_to_f64((int32_t)(int8_t)fsrc1.v).v;
-          else *dest = i32_to_f64(fsrc1.v).v;
-          break;
+      case FPCALL_SToDF: *dest = i32_to_f64(fsrc1.v).v; break;
       case FPCALL_FToDF: *dest = f32_to_f64(fsrc1).v; break;
 
       case FPCALL_DFToU: *dest = f32_to_ui16(fsrc1, softfloat_roundingMode, true); break;

--- a/src/isa/riscv64/instr/rvv/vcompute_impl.c
+++ b/src/isa/riscv64/instr/rvv/vcompute_impl.c
@@ -480,7 +480,11 @@ void floating_arthimetic_instr(int opcode, int is_signed, int widening, int dest
   word_t FPCALL_TYPE = FPCALL_W64;
   // fpcall type
   switch (vtype->vsew) {
-    case 0 : panic("f8 not supported"); break;
+    case 0 :
+      switch (widening) {
+        case vdNarrow : FPCALL_TYPE = FPCALL_W16; break;
+      }
+      break;
     case 1 : 
       switch (widening) {
         case vsdWidening : FPCALL_TYPE = FPCALL_W16_to_32; break;

--- a/src/isa/riscv64/instr/rvv/vcompute_impl.c
+++ b/src/isa/riscv64/instr/rvv/vcompute_impl.c
@@ -483,6 +483,7 @@ void floating_arthimetic_instr(int opcode, int is_signed, int widening, int dest
     case 0 :
       switch (widening) {
         case vdNarrow : FPCALL_TYPE = FPCALL_W16; break;
+        case vdWidening : FPCALL_TYPE = FPCALL_W8; break;
       }
       break;
     case 1 : 


### PR DESCRIPTION
1. fix align bug in the set_vreg of vld. Align is based on eew and emul, not just sew and lmul.
2. fix a bug in the vmsbf.  It generated redundant assign for the rule 'when there are no active 1 in the source, set all active elements in the destination to 1'. This rule was already ensured by the for loop, and this way would overwrite non-active elements in destnation.
3. for f16_to_i8 vfncvt, add  processing path for it.
4. for i8_to_f16 vfwcvt, add processing path for it, and delete redundant convert assign in i16_to_f32 and i32_to_f64.