### PR TITLE
csr: fix some field mask error in mstatus and sstatus.

### DIFF
--- a/resource/bbl/src/encoding.h
+++ b/resource/bbl/src/encoding.h
@@ -3,16 +3,13 @@
 #ifndef RISCV_CSR_ENCODING_H
 #define RISCV_CSR_ENCODING_H
 
-#define MSTATUS_UIE         0x00000001
 #define MSTATUS_SIE         0x00000002
-#define MSTATUS_HIE         0x00000004
 #define MSTATUS_MIE         0x00000008
-#define MSTATUS_UPIE        0x00000010
 #define MSTATUS_SPIE        0x00000020
-#define MSTATUS_HPIE        0x00000040
+#define MSTATUS_UBE         0x00000040
 #define MSTATUS_MPIE        0x00000080
 #define MSTATUS_SPP         0x00000100
-#define MSTATUS_HPP         0x00000600
+#define MSTATUS_VS          0x00000600
 #define MSTATUS_MPP         0x00001800
 #define MSTATUS_FS          0x00006000
 #define MSTATUS_XS          0x00018000
@@ -25,13 +22,15 @@
 #define MSTATUS32_SD        0x80000000
 #define MSTATUS_UXL         0x0000000300000000
 #define MSTATUS_SXL         0x0000000C00000000
+#define MSTATUS_SBE         0x0000001000000000
+#define MSTATUS_MBE         0x0000002000000000
 #define MSTATUS64_SD        0x8000000000000000
 
-#define SSTATUS_UIE         0x00000001
 #define SSTATUS_SIE         0x00000002
-#define SSTATUS_UPIE        0x00000010
 #define SSTATUS_SPIE        0x00000020
+#define SSTATUS_UBE         0x00000040
 #define SSTATUS_SPP         0x00000100
+#define SSTATUS_VS          0x00000600
 #define SSTATUS_FS          0x00006000
 #define SSTATUS_XS          0x00018000
 #define SSTATUS_SUM         0x00040000


### PR DESCRIPTION
According to riscv spec, I reorganized the fields in mstatus and sstatus.