### PR TITLE
CSR: fix wrong wmask of medeleg of H-ext

### DIFF
--- a/src/isa/riscv64/system/priv.c
+++ b/src/isa/riscv64/system/priv.c
@@ -135,7 +135,7 @@ static inline word_t* csr_decode(uint32_t addr) {
 #ifdef CONFIG_RVH
 #define COUNTEREN_MASK 0
 #define MIDELEG_FORCED_MASK ((1 << 12) | (1 << 10) | (1 << 6) | (1 << 2)) // mideleg bits 2、6、10、12 are read_only one
-#define MEDELEG_MASK ((1 << 23) | (1 << 22) | (1 << 21) | (1 << 20) | (1 << 15) | (1 << 13) | (1 << 12) | (1 << 10) | (1 << 9) | (1 << 8) | (1 << 3) | (1 << 0))
+#define MEDELEG_MASK (0xf0b7ff)
 #define VSI_MASK (((1 << 12) | (1 << 10) | (1 << 6) | (1 << 2)) & hideleg->val)
 #define VS_MASK ((1 << 10) | (1 << 6) | (1 << 2))
 #define VSSIP (1 << 2)


### PR DESCRIPTION
When enabling H-ext, NEMU uses a incorrect write mask to CSR medeleg. This write mask lacks of some lower bits. This PR Fix it.