### PR TITLE
memory: Allow DUT to provide pmem for NEMU ref

### DIFF
--- a/include/memory/paddr.h
+++ b/include/memory/paddr.h
@@ -57,6 +57,15 @@ word_t paddr_read(paddr_t addr, int len, int type, int mode, vaddr_t vaddr);
 void paddr_write(paddr_t addr, int len, word_t data, int mode, vaddr_t vaddr);
 uint8_t *get_pmem();
 
+#if CONFIG_ENABLE_MEM_DEDUP || CONFIG_USE_MMAP
+/** Currently, when enable mmap, memory allocation is done by NEMU itself.
+  * If one wants to control when is memory allocated,
+  * he/she can disable default alloction in NEMU and call set_pmem(fales, NULL) from outside.
+  */
+void set_pmem(bool pass_pmem_from_dut, uint8_t *_pmem);
+#endif
+
+
 #ifdef CONFIG_USE_SPARSEMM
 void * get_sparsemm();
 #endif

--- a/src/cpu/difftest/ref.c
+++ b/src/cpu/difftest/ref.c
@@ -51,6 +51,14 @@ static void nemu_large_memcpy(void *dest, void *src, size_t n) {
 #endif
 #endif
 
+void difftest_get_backed_memory(void *backed_pmem, size_t n) {
+#if CONFIG_ENABLE_MEM_DEDUP
+  // set pmem to backed_pmem, then nothing
+  assert(n == CONFIG_MSIZE);
+  set_pmem(true, backed_pmem);
+#endif
+}
+
 void difftest_memcpy(paddr_t nemu_addr, void *dut_buf, size_t n, bool direction) {
 #ifdef CONFIG_USE_SPARSEMM
   void *a = get_sparsemm();
@@ -67,9 +75,11 @@ void difftest_memcpy(paddr_t nemu_addr, void *dut_buf, size_t n, bool direction)
 
 #else
 #ifdef CONFIG_LARGE_COPY
+  assert(guest_to_host(nemu_addr) != NULL);
   if (direction == DIFFTEST_TO_REF) nemu_large_memcpy(guest_to_host(nemu_addr), dut_buf, n);
   else nemu_large_memcpy(dut_buf, guest_to_host(nemu_addr), n);
 #else
+  assert(guest_to_host(nemu_addr) != NULL);
   if (direction == DIFFTEST_TO_REF) memcpy(guest_to_host(nemu_addr), dut_buf, n);
   else memcpy(dut_buf, guest_to_host(nemu_addr), n);
 #endif

--- a/src/memory/Kconfig
+++ b/src/memory/Kconfig
@@ -72,6 +72,12 @@ config USE_MMAP
   bool "Allocate guest physical memory with mmap()"
   default y
 
+config ENABLE_MEM_DEDUP
+  depends on SHARE
+  depends on !USE_MMAP
+  bool "When used as reference, use memory provided by DUT"
+  default n
+
 config MEM_RANDOM
   depends on MODE_SYSTEM && !DIFFTEST
   bool "Initialize the memory with random values"


### PR DESCRIPTION
When restoring from checkpoints, most memory contents of DUT and reference are the same. Therefore, creating a COW mirror memory in DUT side as the memory of reference design can save memory, especially when using multi-core difftest.