### PR TITLE
clint: use physical uptime for real-time timer

### DIFF
--- a/src/isa/riscv64/clint.c
+++ b/src/isa/riscv64/clint.c
@@ -20,7 +20,8 @@
 
 #define CLINT_MTIMECMP (0x4000 / sizeof(clint_base[0]))
 #define CLINT_MTIME    (0xBFF8 / sizeof(clint_base[0]))
-#define TIMEBASE 10000000ul
+#define CLOCK_FREQ 1000000ul
+#define US_PERCYCLE (1000000 / CLOCK_FREQ)
 
 static uint64_t *clint_base = NULL;
 static uint64_t boot_time = 0;
@@ -48,8 +49,8 @@ void update_clint() {
 #ifdef CONFIG_DETERMINISTIC
   clint_base[CLINT_MTIME] += TIMEBASE / 10000;
 #else
-  uint64_t now = get_time() - boot_time;
-  clint_base[CLINT_MTIME] = TIMEBASE * now / 1000000;
+  uint64_t uptime = get_time();
+  clint_base[CLINT_MTIME] = uptime / US_PERCYCLE;
 #endif
   mip->mtip = (clint_base[CLINT_MTIME] >= clint_base[CLINT_MTIMECMP]);
 }

--- a/src/isa/riscv64/clint.c
+++ b/src/isa/riscv64/clint.c
@@ -20,8 +20,8 @@
 
 #define CLINT_MTIMECMP (0x4000 / sizeof(clint_base[0]))
 #define CLINT_MTIME    (0xBFF8 / sizeof(clint_base[0]))
-#define CLOCK_FREQ 1000000ul
-#define US_PERCYCLE (1000000 / CLOCK_FREQ)
+#define TIMEBASE 1000000ul
+#define US_PERCYCLE (1000000 / TIMEBASE)
 
 static uint64_t *clint_base = NULL;
 static uint64_t boot_time = 0;


### PR DESCRIPTION
修改非 CONFIG_DETERMINISTIC 情况下 mtime计算方法
mtime = 运行时间(微秒) / 每周期微秒数

CLOCK_FREQ 设置为 1000000ul 与 opensbi 中 system.dts 对齐