### PR TITLE
memory: mmap difftest pmem_base for dual-core difftest

### DIFF
--- a/include/memory/paddr.h
+++ b/include/memory/paddr.h
@@ -20,6 +20,7 @@
 #include <common.h>
 
 extern unsigned long MEMORY_SIZE;
+extern unsigned int PMEM_HARTID;
 
 #ifdef CONFIG_MODE_USER
 #define CONFIG_MBASE 0

--- a/src/cpu/difftest/ref.c
+++ b/src/cpu/difftest/ref.c
@@ -255,6 +255,7 @@ uint8_t *golden_pmem = NULL;
 
 void difftest_set_mhartid(int n) {
   isa_difftest_set_mhartid(n);
+  PMEM_HARTID = n;
 }
 
 void difftest_put_gmaddr(uint8_t* ptr) {


### PR DESCRIPTION
Previous we use MAP_FIXED for single-core, prevent allocating memory repeatedly for each initialization.

For dual-core, we also want to use mmap for MEMORY_SIZE config. To avoid different core conflict with same PMEM_BASE, we apply different pmem_base according to hartid.