### PR TITLE
Makefile: fix indent for old make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ endif
 
 SOFTFLOAT_REPO_PATH = resource/softfloat/repo
 ifeq ($(wildcard $(SOFTFLOAT_REPO_PATH)/COPYING.txt),)
-  $(shell git clone --depth=1 https://github.com/ucb-bar/berkeley-softfloat-3 $(SOFTFLOAT_REPO_PATH))
+	$(shell git clone --depth=1 https://github.com/ucb-bar/berkeley-softfloat-3 $(SOFTFLOAT_REPO_PATH))
 endif
 SOFTFLOAT_BUILD_PATH = $(abspath $(SOFTFLOAT_REPO_PATH)/build/Linux-x86_64-GCC)
 


### PR DESCRIPTION
There are some spaces and indent in current Makefile, causing NEMU failed to build on old version of gnu make. This commit fixed this.