### PR TITLE
chore: update Makefile to use -flto=auto for CONFIG_CC_LTO， if no aut…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ endif
 CC = $(call remove_quote,$(CONFIG_CC))
 CXX = $(call remove_quote,$(CONFIG_CXX))
 CFLAGS_BUILD += $(call remove_quote,$(CONFIG_CC_OPT))
-CFLAGS_BUILD += $(if $(CONFIG_CC_LTO),-flto,)
+CFLAGS_BUILD += $(if $(CONFIG_CC_LTO),-flto=auto,)
 CFLAGS_BUILD += $(if $(CONFIG_CC_DEBUG),-ggdb3,)
 CFLAGS_BUILD += $(if $(CONFIG_CC_ASAN),-fsanitize=address,)
 CFLAGS  += $(CFLAGS_BUILD)


### PR DESCRIPTION
update Makefile to use -flto=auto for CONFIG_CC_LTO， if no auto, we will get lto-wrapper warning: using serial compilation of 3 LTRANS jobs in gcc-11