### PR TITLE
csr: fix the read/write masks of sstatus

### DIFF
--- a/src/isa/riscv64/difftest/ref.c
+++ b/src/isa/riscv64/difftest/ref.c
@@ -42,13 +42,6 @@ void ramcmp() {
 #define MIDELEG_FORCED_MASK ((1 << 12) | (1 << 10) | (1 << 6) | (1 << 2))
 #endif //CONFIG_RVH
 
-
-#ifdef CONFIG_RVV
-#define SSTATUS_WMASK ((1 << 19) | (1 << 18) | (0x3 << 13) | (0x3 << 9) | (1 << 8) | (1 << 5) | (1 << 1))
-#else
-#define SSTATUS_WMASK ((1 << 19) | (1 << 18) | (0x3 << 13) | (1 << 8) | (1 << 5) | (1 << 1))
-#endif // CONFIG_RVV
-#define SSTATUS_RMASK (SSTATUS_WMASK | (0x3 << 15) | (1ull << 63) | (3ull << 32))
 void csr_prepare() {
   cpu.mstatus = mstatus->val;
   cpu.mcause  = mcause->val;

--- a/src/isa/riscv64/local-include/csr.h
+++ b/src/isa/riscv64/local-include/csr.h
@@ -844,12 +844,11 @@ MAP(CSRS, CSRS_DECL)
   #define _vsstatus_  ((hstatus->vsxl == 1)? vsstatus->_32  : vsstatus->_64)
 #endif // CONFIG_RVH
 
- #ifdef CONFIG_RVV
-  #define SSTATUS_WMASK ((1 << 19) | (1 << 18) | (0x3 << 13) | (0x3 << 9) | (1 << 8) | (1 << 5) | (1 << 1))
-#else
-  #define SSTATUS_WMASK ((1 << 19) | (1 << 18) | (0x3 << 13) | (1 << 8) | (1 << 5) | (1 << 1))
-#endif // CONFIG_RVV
-#define SSTATUS_RMASK (SSTATUS_WMASK | (0x3 << 15) | (1ull << 63) | (3ull << 32))
+// All valid fields defined by RISC-V spec and not affected by extensions
+// This mask is used to get the value of sstatus from mstatus
+// SD, UXL, MXR, SUM, XS, FS, VS, SPP, UBE, SPIE, SIE
+#define SSTATUS_RMASK 0x80000003000de762UL
+
 word_t csrid_read(uint32_t csrid);
 
 // PMP

--- a/src/isa/riscv64/system/priv.c
+++ b/src/isa/riscv64/system/priv.c
@@ -141,8 +141,11 @@ static inline word_t* csr_decode(uint32_t addr) {
 #define MSTATUS_WMASK_RVV 0
 #endif
 
-// final mstatus wmask
+// final mstatus wmask: dependent of the ISA extensions
 #define MSTATUS_WMASK (MSTATUS_WMASK_BASE | MSTATUS_WMASK_FS | MSTATUS_WMASK_RVH | MSTATUS_WMASK_RVV)
+
+// wmask of sstatus is given by masking the valid fields in sstatus
+#define SSTATUS_WMASK (MSTATUS_WMASK & SSTATUS_RMASK)
 
 // hstatus wmask
 #if defined(CONFIG_RVH)
@@ -464,7 +467,7 @@ static inline void csr_write(word_t *dest, word_t src) {
 #endif // CONFIG_RVH
   else if (is_write(sstatus)) { mstatus->val = mask_bitset(mstatus->val, SSTATUS_WMASK, src); }
   else if (is_write(sie)) { mie->val = mask_bitset(mie->val, SIE_MASK, src); }
-  else if (is_write(mie)) { 
+  else if (is_write(mie)) {
     mie->val = mask_bitset(mie->val, MIE_MASK_BASE | MIE_MASK_H, src);
   }
   else if (is_write(mip)) {
@@ -818,7 +821,7 @@ static word_t priv_instr(uint32_t op, const rtlreg_t *src) {
             longjmp_exception(EX_VI);
           } else if (cpu.v == 1 && cpu.mode == MODE_S && hstatus->vtvm == 1) {
             longjmp_exception(EX_VI);
-          } 
+          }
 #else
           if (!srnctl->svinval) { // srnctl contrl extension enable or not
             longjmp_exception(EX_II);


### PR DESCRIPTION
sstatus is a masked register of mstatus. Its read and write masks are partial masks of the mstatus masks.

This commit fixes the wmask for sstatus.fs, which should depend on the existence of FPU. We also clean up some duplicated code.