### PR TITLE
csr, float: wrap fp CSRs in CONFIG_FPU_NONE

### DIFF
--- a/src/isa/riscv64/Kconfig
+++ b/src/isa/riscv64/Kconfig
@@ -21,6 +21,7 @@ config RVZICOND
   default y
 
 config RVV
+  depends on !FPU_NONE
   bool "RISC-V Vector Extension v1.0"
   default y
 

--- a/src/isa/riscv64/local-include/csr.h
+++ b/src/isa/riscv64/local-include/csr.h
@@ -27,8 +27,12 @@
 
 /* Unprivileged CSR */
 /** Unprivileged Floating-Point CSRs **/
-#define CSRS_UNPRIV_FLOAT(f) \
-  f(fflags       , 0x001) f(frm        , 0x002) f(fcsr       , 0x003) \
+#ifndef CONFIG_FPU_NONE
+  #define CSRS_UNPRIV_FLOAT(f) \
+    f(fflags       , 0x001) f(frm        , 0x002) f(fcsr       , 0x003)
+#else // CONFIG_FPU_NONE
+  #define CSRS_UNPRIV_FLOAT(f)
+#endif // CONFIG_FPU_NONE
 
 /** Unprivileged Counter/Timers **/
 #ifdef CONFIG_RV_Zicntr
@@ -850,6 +854,7 @@ CSR_STRUCT_END(vsatp)
 
 /** Unprivileged Floating-Point CSRs **/
 
+#ifndef CONFIG_FPU_NONE
 CSR_STRUCT_START(fflags)
 CSR_STRUCT_END(fflags)
 
@@ -871,6 +876,8 @@ CSR_STRUCT_START(fcsr)
     } fflags;
   };
 CSR_STRUCT_END(fcsr)
+
+#endif // CONFIG_FPU_NONE
 
 /** Unprivileged Vector CSRs **/
 

--- a/src/isa/riscv64/system/priv.c
+++ b/src/isa/riscv64/system/priv.c
@@ -309,27 +309,17 @@ if (is_read(vsie))           { return (mie->val & (hideleg->val & (mideleg->val 
   else if (is_read(vcsr))   { return (vxrm->val & 0x3) << 1 | (vxsat->val & 0x1); }
   else if (is_read(vlenb))  { return VLEN >> 3; }
 #endif
+#ifndef CONFIG_FPU_NONE
   else if (is_read(fcsr))   {
-#ifdef CONFIG_FPU_NONE
-    longjmp_exception(EX_II);
-#else
     return fcsr->val & FCSR_MASK;
-#endif // CONFIG_FPU_NONE
   }
   else if (is_read(fflags)) {
-#ifdef CONFIG_FPU_NONE
-    longjmp_exception(EX_II);
-#else
     return fcsr->fflags.val & FFLAGS_MASK;
-#endif // CONFIG_FPU_NONE
   }
   else if (is_read(frm))    {
-#ifdef CONFIG_FPU_NONE
-    longjmp_exception(EX_II);
-#else
     return fcsr->frm & FRM_MASK;
-#endif // CONFIG_FPU_NONE
   }
+#endif // CONFIG_FPU_NONE
 #ifdef CONFIG_RV_Zicntr
   else if (is_read(time))  { difftest_skip_ref(); return clint_uptime(); }
 #endif
@@ -487,34 +477,24 @@ static inline void csr_write(word_t *dest, word_t src) {
 #endif
   else if (is_write(mepc)) { *dest = src & (~0x1UL); }
   else if (is_write(sepc)) { *dest = src & (~0x1UL); }
+#ifndef CONFIG_FPU_NONE
   else if (is_write(fflags)) {
-#ifdef CONFIG_FPU_NONE
-  longjmp_exception(EX_II);
-#else
     *dest = src & FFLAGS_MASK;
     fcsr->val = (frm->val)<<5 | fflags->val;
     // fcsr->fflags.val = src;
-#endif // CONFIG_FPU_NONE
   }
   else if (is_write(frm)) {
-#ifdef CONFIG_FPU_NONE
-  longjmp_exception(EX_II);
-#else
     *dest = src & FRM_MASK;
     fcsr->val = (frm->val)<<5 | fflags->val;
     // fcsr->frm = src;
-#endif // CONFIG_FPU_NONE
   }
   else if (is_write(fcsr)) {
-#ifdef CONFIG_FPU_NONE
-  longjmp_exception(EX_II);
-#else
     *dest = src & FCSR_MASK;
     fflags->val = src & FFLAGS_MASK;
     frm->val = ((src)>>5) & FRM_MASK;
     // *dest = src & FCSR_MASK;
-#endif // CONFIG_FPU_NONE
   }
+#endif // CONFIG_FPU_NONE
 #ifdef CONFIG_RV_PMP_CSR
   else if (is_write_pmpaddr) {
     Logtr("Writing pmp addr");
@@ -629,16 +609,13 @@ static inline void csr_write(word_t *dest, word_t src) {
   else { *dest = src; }
 
   bool need_update_mstatus_sd = false;
+#ifndef CONFIG_FPU_NONE
   if (is_write(fflags) || is_write(frm) || is_write(fcsr)) {
-#ifdef CONFIG_FPU_NONE
-  longjmp_exception(EX_II);
-#else
     fp_set_dirty();
     fp_update_rm_cache(fcsr->frm);
     need_update_mstatus_sd = true;
-#endif // CONFIG_FPU_NONE
-
   }
+#endif // CONFIG_FPU_NONE
 #ifdef CONFIG_RVV
   if (is_write(vcsr) || is_write(vstart) || is_write(vxsat) || is_write(vxrm)) {
     vp_set_dirty();


### PR DESCRIPTION
Float point CSRs should not exist when there is no FPU (no RVF / RVD support).

This patch wraps mapping and structure of fp CSRs in CONFIG_FPU_NONE and adjusts csr_read() & csr_write() function accordingly.

This patch also add dependency of CONFIG_RVV on !FPU_NONE, which is required by RISC-V unpriv isa.