### PR TITLE
Fixed an issue where breakpoints could only be triggered on some PCs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,9 @@ override ARGS ?= --log=$(BUILD_DIR)/nemu-log.txt
 override ARGS += $(ARGS_DIFF)
 
 # Command to execute NEMU
-IMG ?=
+IMG_DIR = $(NEMU_HOME)/ready-to-run
+img ?= microbench
+IMG ?= $(IMG_DIR)/$(img).bin
 NEMU_EXEC := $(BINARY) $(ARGS) $(IMG)
 
 run-env: $(BINARY) $(DIFF_REF_SO)
@@ -165,6 +167,12 @@ run-env: $(BINARY) $(DIFF_REF_SO)
 run: run-env
 	$(call git_commit, "run")
 	$(NEMU_EXEC)
+
+batch:
+	./build/riscv64-nemu-interpreter -b $(IMG)
+
+step:
+	./build/riscv64-nemu-interpreter $(IMG)
 
 gdb: run-env
 	$(call git_commit, "gdb")

--- a/src/cpu/cpu-exec.c
+++ b/src/cpu/cpu-exec.c
@@ -289,6 +289,7 @@ static int execute(int n) {
   __attribute__((unused)) Decode *this_s = NULL;
   __attribute__((unused)) bool br_taken = false;
   __attribute__((unused)) bool is_ctrl = false;
+  
   while (true) {
 #if defined(CONFIG_DEBUG) || defined(CONFIG_DIFFTEST) || defined(CONFIG_IQUEUE)
     this_s = s;
@@ -343,7 +344,9 @@ static int execute(int n) {
     Logti("prev pc = 0x%lx, pc = 0x%lx", prev_s->pc, s->pc);
 
     save_globals(s);
+    cpu.pc = s->pc;
     debug_difftest(this_s, s);
+    if (nemu_state.state == NEMU_STOP) break;
   }
 
 end_of_loop:
@@ -589,6 +592,7 @@ static void update_global() {
   cpu.pc = prev_s->pc;
 }
 #endif
+
 
 /* Simulate how the CPU works. */
 void cpu_exec(uint64_t n) {


### PR DESCRIPTION
**修改了关于NEMU给PC加断点只能在一些PC触发的问题**。NEMU执行指令按组执行，组间使用s->pc执行，而断点检查使用cpu.pc，于是在组间不能够使用更新的pc来进行断点检查。修改了cpu.pc的更新时机，可以实现任意PC的断点触发。同时，修改了指令执行完成后对于nemu_state.state的检查，使得某PC触发断点之后，可以及时在断点处退出。

修改了makefile，简化了执行命令：

可以使用`make step img=<name>`进入调试模式执行，使用`make batch img=<name>`进入批处理模式执行。