### PR TITLE
rv64v: fix a bug that no boxing for fp in f2v case.

### DIFF
--- a/src/isa/riscv64/instr/rvv/vcommon.c
+++ b/src/isa/riscv64/instr/rvv/vcommon.c
@@ -24,4 +24,45 @@ bool check_vlmul_sew_illegal(rtlreg_t vtype_req){
   return false;
 }
 
+void set_NAN(rtlreg_t* fpreg, uint64_t vsew){
+  switch (vsew) {
+    case 0:
+      *fpreg = (*fpreg & 0xffffffffffffff00) | 0x78;
+      break;
+    case 1:
+      *fpreg = (*fpreg & 0xffffffffffff0000) | 0x7e00;
+      break;
+    case 2:
+      *fpreg = (*fpreg & 0xffffffff00000000) | 0x7fc00000;
+      break;
+    case 3:
+      break;
+    default:
+      break;
+  }
+}
+
+bool check_isFpCanonicalNAN(rtlreg_t* fpreg, uint64_t vsew){
+  int isFpCanonicalNAN = 0;
+  switch (vsew) {
+    case 0:
+      isFpCanonicalNAN = ~(*fpreg | 0xff) != 0;
+      if(isFpCanonicalNAN) set_NAN(fpreg, vsew);
+      break;
+    case 1:
+      isFpCanonicalNAN = ~(*fpreg | 0xffff) != 0;
+      if(isFpCanonicalNAN) set_NAN(fpreg, vsew);
+      break;
+    case 2:
+      isFpCanonicalNAN = ~(*fpreg | 0xffffffff) != 0;
+      if(isFpCanonicalNAN) set_NAN(fpreg, vsew);
+      break;
+    case 3:
+      break;
+    default:
+      break;
+  }
+  return isFpCanonicalNAN;
+}
+
 #endif

--- a/src/isa/riscv64/instr/rvv/vcommon.h
+++ b/src/isa/riscv64/instr/rvv/vcommon.h
@@ -10,6 +10,8 @@
 
 uint8_t check_vstart_ignore(Decode *s);
 bool check_vlmul_sew_illegal(rtlreg_t vtype_req);
+void set_NAN(rtlreg_t* fpreg, uint64_t vsew);
+bool check_isFpCanonicalNAN(rtlreg_t* fpreg, uint64_t vsew);
 void vp_set_dirty();
 
 #endif

--- a/src/isa/riscv64/instr/rvv/vcompute.h
+++ b/src/isa/riscv64/instr/rvv/vcompute.h
@@ -1015,7 +1015,6 @@ def_EHelper(vfmvfs) {
   if (vtype->vsew < 3) {
       *s0 = *s0 | (UINT64_MAX << (8 << vtype->vsew));
   }
-  check_isFpCanonicalNAN(s0, vtype->vsew);
   rtl_mv(s, &fpreg_l(id_dest->reg), s0);
   vstart->val = 0;
 }

--- a/src/isa/riscv64/instr/rvv/vcompute.h
+++ b/src/isa/riscv64/instr/rvv/vcompute.h
@@ -17,6 +17,7 @@
 #ifdef CONFIG_RVV
 
 #include "vcompute_impl.h"
+#include "vcommon.h"
 
 def_EHelper(vadd) {
   ARTHI(ADD, SIGNED)
@@ -1014,6 +1015,7 @@ def_EHelper(vfmvfs) {
   if (vtype->vsew < 3) {
       *s0 = *s0 | (UINT64_MAX << (8 << vtype->vsew));
   }
+  check_isFpCanonicalNAN(s0, vtype->vsew);
   rtl_mv(s, &fpreg_l(id_dest->reg), s0);
   vstart->val = 0;
 }
@@ -1022,6 +1024,7 @@ def_EHelper(vfmvsf) {
   require_vector(true);
   if (vl->val > 0 && vstart->val < vl->val) {
     rtl_mv(s, s1, &fpreg_l(id_src1->reg)); // f[rs1]
+    check_isFpCanonicalNAN(s1, vtype->vsew);
     set_vreg(id_dest->reg, 0, *s1, vtype->vsew, vtype->vlmul, 1);
     if (RVV_AGNOSTIC) {
       if(vtype->vta) {

--- a/src/isa/riscv64/instr/rvv/vcompute_impl.c
+++ b/src/isa/riscv64/instr/rvv/vcompute_impl.c
@@ -18,6 +18,7 @@
 
 #include "vcompute_impl.h"
 #include <cpu/cpu.h>
+#include "vcommon.h"
 
 #undef s0
 #undef s1
@@ -1084,6 +1085,7 @@ void floating_arthimetic_instr(int opcode, int is_signed, int widening, int dest
         break;
       case SRC_VF :   
         rtl_mv(s, s1, &fpreg_l(id_src1->reg)); // f[rs1]
+        check_isFpCanonicalNAN(s1, vtype->vsew);
         switch (vtype->vsew) {
           case 0 : *s1 = *s1 & 0xff; break;
           case 1 : *s1 = *s1 & 0xffff; break;


### PR DESCRIPTION
For fp 16/32 obtained from a 64-bit number, if the upper bits are not all 1s, it is considered a CNAN. In this case, the lower significant bits need to be set to the corresponding NAN.