### PR TITLE
Fix FS,VS and SD fields in mstatus and vsstatus

### DIFF
--- a/src/isa/riscv64/difftest/ref.c
+++ b/src/isa/riscv64/difftest/ref.c
@@ -43,11 +43,11 @@ void ramcmp() {
 #endif //CONFIG_RVH
 
 void csr_prepare() {
-  cpu.mstatus = mstatus->val;
+  cpu.mstatus = gen_status_sd(mstatus->val) | mstatus->val;
   cpu.mcause  = mcause->val;
   cpu.mepc    = mepc->val;
 
-  cpu.sstatus = mstatus->val & SSTATUS_RMASK; // sstatus
+  cpu.sstatus = gen_status_sd(mstatus->val) | (mstatus->val & SSTATUS_RMASK); // sstatus
   cpu.scause  = scause->val;
   cpu.sepc    = sepc->val;
 
@@ -81,7 +81,7 @@ void csr_prepare() {
   cpu.htval   = htval->val;
   cpu.htinst  = htinst->val;
   cpu.hgatp   = hgatp->val;
-  cpu.vsstatus= vsstatus->val;
+  cpu.vsstatus= gen_status_sd(vsstatus->val) | vsstatus->val;
   cpu.vstvec  = vstvec->val;
   cpu.vsepc   = vsepc->val;
   cpu.vscause = vscause->val;
@@ -93,6 +93,9 @@ void csr_prepare() {
 
 void csr_writeback() {
   mstatus->val = cpu.mstatus;
+  // Keep the value of mstatus->sd always zero
+  // The value used to diff with REF/DUT will set mstatus->sd with fs or vs is dirty.
+  mstatus->sd  = 0;
   mcause ->val = cpu.mcause ;
   mepc   ->val = cpu.mepc   ;
   //sstatus->val = cpu.sstatus;  // sstatus is a shadow of mstatus
@@ -130,6 +133,9 @@ void csr_writeback() {
   htinst->val  = cpu.htinst;
   hgatp->val   = cpu.hgatp;
   vsstatus->val= cpu.vsstatus;
+  // Keep the value of vsstatus->sd always zero
+  // The value used to diff with REF/DUT will set vsstatus->sd with fs or vs is dirty.
+  vsstatus->_64.sd = 0;
   vstvec->val  = cpu.vstvec;
   vsepc->val   = cpu.vsepc;
   vscause->val = cpu.vscause;

--- a/src/isa/riscv64/init.c
+++ b/src/isa/riscv64/init.c
@@ -65,6 +65,9 @@ void init_isa() {
   // For RV64 systems, if S-mode is not supported, then SXL is hardwired to zero.
   // For RV64 systems, if U-mode is not supported, then UXL is hardwired to zero.
   mstatus->val = 0xaUL << 32;
+  // initialize the value fs and vs to 0
+  mstatus->fs = 0;
+  mstatus->vs = 0;
 
 #ifdef CONFIG_RV_PMP_ENTRY_16
   pmpcfg0->val = 0;
@@ -101,7 +104,6 @@ void init_isa() {
 
 #ifdef CONFIG_RVV
   // vector
-  mstatus->val |= 0x1UL << 9; // set mstatus.vs to initial.
   misa->extensions |= ext('v');
   vl->val = 0;
   vtype->val = (uint64_t) 1 << 63; // actually should be 1 << 63 (set vill bit to forbidd)

--- a/src/isa/riscv64/instr/fp.c
+++ b/src/isa/riscv64/instr/fp.c
@@ -36,19 +36,6 @@ bool fp_enable() {
 }
 
 void fp_set_dirty() {
-  // lazily update mstatus->sd when reading mstatus
-#if defined (CONFIG_SHARE) || defined (CONFIG_DIFFTEST_REF_SPIKE)
-  mstatus->sd = 1;
-#ifdef CONFIG_RVH
-  if (cpu.v == 1) {
-    if (hstatus->vsxl == 1)
-      vsstatus->_32.sd = 1;
-    else
-      vsstatus->_64.sd = 1;
-  }
-#endif //CONFIG_RVH
-#endif
-// Spike update fs and sd in the meantime
   mstatus->fs = 3;
 #ifdef CONFIG_RVH
   if (cpu.v == 1) {

--- a/src/isa/riscv64/instr/fp.c
+++ b/src/isa/riscv64/instr/fp.c
@@ -36,13 +36,13 @@ bool fp_enable() {
 }
 
 void fp_set_dirty() {
-  mstatus->fs = 3;
+  mstatus->fs = EXT_CONTEXT_DIRTY;
 #ifdef CONFIG_RVH
   if (cpu.v == 1) {
     if (hstatus->vsxl == 1)
-      vsstatus->_32.fs = 3;
+      vsstatus->_32.fs = EXT_CONTEXT_DIRTY;
     else
-      vsstatus->_64.fs = 3;
+      vsstatus->_64.fs = EXT_CONTEXT_DIRTY;
   }
 #endif //CONFIG_RVH
 }

--- a/src/isa/riscv64/instr/vp.c
+++ b/src/isa/riscv64/instr/vp.c
@@ -25,11 +25,6 @@ bool vp_enable() {
 }
 
 void vp_set_dirty() {
-  // lazily update mstatus->sd when reading mstatus
-#if defined (CONFIG_SHARE) || defined (CONFIG_DIFFTEST_REF_SPIKE)
-  mstatus->sd = 1;
-#endif
-// Spike update vs and sd in the meantime
-  mstatus->vs = 3;
+  mstatus->vs = EXT_CONTEXT_DIRTY;
 }
 #endif // CONFIG_RVV

--- a/src/isa/riscv64/instr/vp.c
+++ b/src/isa/riscv64/instr/vp.c
@@ -26,5 +26,13 @@ bool vp_enable() {
 
 void vp_set_dirty() {
   mstatus->vs = EXT_CONTEXT_DIRTY;
+#ifdef CONFIG_RVH
+  if (cpu.v == 1) {
+    if (hstatus->vsxl == 1)
+      vsstatus->_32.vs = EXT_CONTEXT_DIRTY;
+    else
+      vsstatus->_64.vs = EXT_CONTEXT_DIRTY;
+  }
+#endif //CONFIG_RVH
 }
 #endif // CONFIG_RVV

--- a/src/isa/riscv64/local-include/csr.h
+++ b/src/isa/riscv64/local-include/csr.h
@@ -436,6 +436,13 @@ CSR_STRUCT_START(mstatus)
   uint64_t sd  : 1;
 CSR_STRUCT_END(mstatus)
 
+typedef enum ExtContextStatus {
+  EXT_CONTEXT_DISABLED = 0,
+  EXT_CONTEXT_INITIAL,
+  EXT_CONTEXT_CLEAN,
+  EXT_CONTEXT_DIRTY,
+} ExtContextStatus;
+
 CSR_STRUCT_START(mtvec)
 CSR_STRUCT_END(mtvec)
 
@@ -1083,6 +1090,9 @@ MAP(CSRS, CSRS_DECL)
 
 /** General **/
 void csr_prepare();
+
+word_t gen_status_sd(word_t status);
+
 word_t csrid_read(uint32_t csrid);
 
 /** PMP **/

--- a/src/isa/riscv64/reg.c
+++ b/src/isa/riscv64/reg.c
@@ -52,7 +52,7 @@ void isa_reg_display() {
   }
 #endif // CONFIG_FPU_NONE
   printf("pc: " FMT_WORD " mstatus: " FMT_WORD " mcause: " FMT_WORD " mepc: " FMT_WORD "\n",
-      cpu.pc, mstatus->val, mcause->val, mepc->val);
+      cpu.pc, cpu.mstatus, mcause->val, mepc->val);
   printf("%22s sstatus: " FMT_WORD " scause: " FMT_WORD " sepc: " FMT_WORD "\n",
       "", cpu.sstatus, scause->val, sepc->val);
   printf("satp: " FMT_WORD "\n", satp->val);
@@ -68,7 +68,7 @@ void isa_reg_display() {
   printf("hedeleg: " FMT_WORD " hcounteren: " FMT_WORD " htval: " FMT_WORD " htinst: " FMT_WORD "\n",
       hedeleg->val, hcounteren->val, htval->val, htinst->val);
   printf("hgatp: " FMT_WORD " vsscratch: " FMT_WORD " vsstatus: " FMT_WORD " vstvec: " FMT_WORD "\n",
-      hgatp->val, vsscratch->val, vsstatus->val, vstvec->val);
+      hgatp->val, vsscratch->val, cpu.vsstatus, vstvec->val);
   printf("vsepc: " FMT_WORD " vscause: " FMT_WORD " vstval: " FMT_WORD " vsatp: " FMT_WORD "\n",
       vsepc->val, vscause->val, vstval->val, vsatp->val);
   printf("virtualization mode: %ld\n", cpu.v);

--- a/src/isa/riscv64/system/priv.c
+++ b/src/isa/riscv64/system/priv.c
@@ -758,10 +758,13 @@ static inline void csr_write(word_t *dest, word_t src) {
   }
   else { *dest = src; }
 
+#ifndef CONFIG_FPU_NONE
   if (is_write(fflags) || is_write(frm) || is_write(fcsr)) {
     fp_set_dirty();
     fp_update_rm_cache(fcsr->frm);
   }
+#endif
+
 #ifdef CONFIG_RVV
   if (is_write(vcsr) || is_write(vstart) || is_write(vxsat) || is_write(vxrm)) {
     vp_set_dirty();

--- a/src/isa/riscv64/system/priv.c
+++ b/src/isa/riscv64/system/priv.c
@@ -276,10 +276,9 @@ static inline void update_mstatus_fs() {
 }
 
 inline word_t gen_status_sd(word_t status) {
-  __attribute_maybe_unused__
   mstatus_t xstatus = (mstatus_t)status;
-  bool fs_dirty = MUXNDEF(CONFIG_FPU_NONE, xstatus.fs == EXT_CONTEXT_DIRTY, false);
-  bool vs_dirty = MUXDEF(CONFIG_RVV, xstatus.vs == EXT_CONTEXT_DIRTY, false);
+  bool fs_dirty = xstatus.fs == EXT_CONTEXT_DIRTY;
+  bool vs_dirty = xstatus.vs == EXT_CONTEXT_DIRTY;
   return ((word_t)(fs_dirty || vs_dirty)) << 63;
 }
 


### PR DESCRIPTION
* Set vs and fs of mstatus to OFF(0) when initial hart state.
* Set vstatus.vs dirty when in virtual mode and modifying vector status.
* As specified in RISC-V spec, the mstatus.SD is read-only field and producted from FS, VS or XS is dirty.
* Produce SD field when SD field when copy from REF to DIFFTEST.
* Hardwire SD to 0 when copy from DIFFTEST to REF.