### PR TITLE
rv64v: fix vill check for vector instructions

### DIFF
--- a/src/isa/riscv64/instr/rvv/vcompute_impl.c
+++ b/src/isa/riscv64/instr/rvv/vcompute_impl.c
@@ -319,6 +319,7 @@ void vector_slide_check(Decode *s, bool is_over) {
 
 void arthimetic_instr(int opcode, int is_signed, int widening, int narrow, int dest_mask, Decode *s) {
   if(check_vstart_ignore(s)) return;
+  require_vector(true);
   int vlmax = get_vlmax(vtype->vsew, vtype->vlmul);
   int idx;
   uint64_t carry;
@@ -833,6 +834,7 @@ void arthimetic_instr(int opcode, int is_signed, int widening, int narrow, int d
  */
 void permutaion_instr(int opcode, Decode *s) {
   if(check_vstart_ignore(s)) return;
+  require_vector(true);
   int vlmax = get_vlmax(vtype->vsew, vtype->vlmul);
   int idx;
   for(idx = vstart->val; idx < vl->val; idx ++) {
@@ -977,6 +979,7 @@ void permutaion_instr(int opcode, Decode *s) {
 
 void floating_arthimetic_instr(int opcode, int is_signed, int widening, int dest_mask, Decode *s) {
   if(check_vstart_ignore(s)) return;
+  require_vector(true);
   if (dest_mask) {
     if (s->src_vmode == SRC_VV) {
       vector_mvv_check(s, true);

--- a/src/isa/riscv64/instr/rvv/vldst.h
+++ b/src/isa/riscv64/instr/rvv/vldst.h
@@ -31,7 +31,7 @@ def_EHelper(vlm) { //mask
 }
 
 def_EHelper(vlr) { // whole register
-  require_vector(true);
+  require_vector(false);
   VLR(MODE_UNIT, UNSIGNED, s, MMU_DIRECT)
 }
 
@@ -60,7 +60,7 @@ def_EHelper(vsm) {
 }
 
 def_EHelper(vsr) {
-  require_vector(true);
+  require_vector(false);
   VSR(MODE_UNIT, MMU_DIRECT)
 }
 
@@ -89,7 +89,7 @@ def_EHelper(vlm_mmu) { //mask
 }
 
 def_EHelper(vlr_mmu) { //whple register
-  require_vector(true);
+  require_vector(false);
   VLR(MODE_UNIT, UNSIGNED, s, MMU_TRANSLATE)
 }
 
@@ -118,7 +118,7 @@ def_EHelper(vsm_mmu) {
 }
 
 def_EHelper(vsr_mmu) {
-  require_vector(true);
+  require_vector(false);
   VSR(MODE_UNIT, MMU_TRANSLATE)
 }
 


### PR DESCRIPTION
* vset{i}vl{i} and whole register loads and stores do not depend upon vtype