### PR TITLE
csr: update and display the correct cpu.xstatus value.

### DIFF
--- a/src/isa/riscv64/reg.c
+++ b/src/isa/riscv64/reg.c
@@ -36,6 +36,7 @@ const char *fpregsl[] = {
 };
 
 void isa_reg_display() {
+  csr_prepare();
   int i;
   for (i = 0; i < 32; i ++) {
     printf("%4s: " FMT_WORD " ", regsl[i], cpu.gpr[i]._64);


### PR DESCRIPTION
Fix a bug that the correct **xstatus** value could not be obtained when executing **info r** command. This was because the code only assigned a value to **xstatus->val** when **xstatus** should change, but did not update the value of **cpu.xstatus**. One feasible method is to assign values to both **xstatus->val** and update **cpu.xstatus** every time **xstatus** changes. However, I think this approach is too cumbersome, requiring changes to many parts of the code. Therefore, I chose to generate the value of **cpu.xstatus** from **xstatus->val** whenever **cpu.xstatus** is needed. So why didn't I just add a copy of **xstatus** but instead executed the entire **csr_prepare** function? This is to facilitate potential future issues such as the **sd** field in **xstatus** is read-only. In this case, we would still only need to execute the **csr_prepare** function.