### PR TITLE
rv64v: remove panic when lmul is reserved value

### DIFF
--- a/src/isa/riscv64/instr/rvv/vreg_impl.c
+++ b/src/isa/riscv64/instr/rvv/vreg_impl.c
@@ -93,7 +93,8 @@ int get_vlmax(int vsew, int vlmul) {
       default: panic("Unexpected vlmul\n");
     }
   } else {
-    panic("vlmul = 4 is reserved\n");
+    Loge("vlmul = 4 is reserved\n");
+    return -1;
   }
 }
 


### PR DESCRIPTION
* when lmul == 4, the vill will be setted to 1, if vill is 1, running vector instructions which depend on vtype will raise exception