### PR TITLE
difftest: guide spike to exec the instruction cause an exception.

### DIFF
--- a/src/cpu/difftest/dut.c
+++ b/src/cpu/difftest/dut.c
@@ -115,14 +115,6 @@ void init_difftest(char *ref_so_file, long img_size, int port) {
 
 static void checkregs(CPU_state *ref, vaddr_t pc) {
   if (!isa_difftest_checkregs(ref, pc)) {
-    // Second chance when ref model falls one step behind. For example, spike on misaligned load.
-    CPU_state second_ref_r;
-    ref_difftest_exec(1);
-    ref_difftest_regcpy(&second_ref_r, DIFFTEST_TO_DUT);
-    if (isa_difftest_checkregs(&second_ref_r, pc)) {
-      Log("REF and DUT matched after another step, continue");
-      return;
-    }
     isa_reg_display();
     IFDEF(CONFIG_IQUEUE, iqueue_dump());
     nemu_state.state = NEMU_ABORT;

--- a/src/isa/riscv64/system/intr.c
+++ b/src/isa/riscv64/system/intr.c
@@ -59,13 +59,25 @@ word_t raise_intr(word_t NO, vaddr_t epc) {
   Logti("raise intr cause NO: %ld, epc: %lx\n", NO, epc);
 #ifdef CONFIG_DIFFTEST_REF_SPIKE
   switch (NO) {
+    // ecall and ebreak are handled normally
 #ifdef CONFIG_RVH
-    case EX_VI:
+    // case EX_ECVS:
     case EX_IGPF:
     case EX_LGPF:
+    case EX_VI:
     case EX_SGPF:
 #endif
+    case EX_IAM:
+    case EX_IAF:
     case EX_II:
+    // case EX_BP:
+    case EX_LAM:
+    case EX_LAF:
+    case EX_SAM:
+    case EX_SAF:
+    // case EX_ECU:
+    // case EX_ECS:
+    // case EX_ECM:
     case EX_IPF:
     case EX_LPF:
     case EX_SPF: difftest_skip_dut(1, 0); break;


### PR DESCRIPTION
When there is an exception happen in nemu as dut, spike should also execute the same instruction that caused the exception.
In particular, the **ebreak** and **ecall** instructions are different from other instructions that can cause exceptions, because when they are executed in nemu, spike has already been instructed to execute the corresponding **ebreak** and **ecall** instructions, so there is no need to guide spike to execute another instruction in either case.