### PR TITLE
ci: build difftest so in docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     name: nemu - Basics for XiangShan
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup env
         run: |
           echo "PATH=/nfs/home/share/riscv-toolchain-20230425/bin:$PATH" >> $GITHUB_ENV
@@ -71,7 +71,7 @@ jobs:
     timeout-minutes: 10
     name: nemu - Basics for NutShell
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup env
         run: |
           echo "PATH=/nfs/home/share/riscv-toolchain-20230425/bin:$PATH" >> $GITHUB_ENV
@@ -97,7 +97,7 @@ jobs:
     name: NEMU should report error if RVV agnostic is enabled when comparing against Spike ref; It should crash in the expected way
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup env
         run: |
           echo "PATH=/nfs/home/share/riscv-toolchain-20230425/bin:$PATH" >> $GITHUB_ENV
@@ -122,7 +122,7 @@ jobs:
     name: nemu - H-extension
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup env
         run: |
           echo "PATH=/nfs/home/share/riscv-toolchain-20230425/bin:$PATH" >> $GITHUB_ENV
@@ -167,7 +167,7 @@ jobs:
     name: nemu - V-extension
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup env
         run: |
           echo "PATH=/nfs/home/share/riscv-toolchain-20230425/bin:$PATH" >> $GITHUB_ENV
@@ -204,7 +204,7 @@ jobs:
     timeout-minutes: 60
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Setup env
       run: |
         echo "PATH=/nfs/home/share/riscv-toolchain-20230425/bin:$PATH" >> $GITHUB_ENV
@@ -213,3 +213,21 @@ jobs:
       id: list_configs
       run: |
         bash ./scripts/compilation-test.sh
+
+  compile-difftest-so:
+    runs-on: ubuntu-latest
+    continue-on-error: false
+    name: Compile difftest-so
+    timeout-minutes: 10
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: compile in CentOS 7 docker
+      run: |
+        bash ./scripts/generate_so_from_docker.sh
+    - name: archive difftest-so artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: difftest-so
+        path: |
+          artifact

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 !*.cpp
 !*.lds
 !.gitignore
+!Dockerfile
 !README.md
 !Kconfig
 !.github/workflows/ci.yml

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,0 +1,18 @@
+FROM centos:7
+
+# use baseurl instead of mirrorlist
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+RUN yum clean all && yum makecache
+
+RUN yum install -y centos-release-scl
+# use baseurl instead of mirrorlist in CentOS-SCLo-scl.repo
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+RUN yum clean all && yum makecache
+
+RUN yum install -y git dtc devtoolset-11 llvm-toolset-7 bison flex
+RUN echo "source /opt/rh/devtoolset-11/enable" >> /etc/profile
+RUN echo "source /opt/rh/llvm-toolset-7/enable" >> /etc/profile

--- a/scripts/generate_so_for_difftest.sh
+++ b/scripts/generate_so_for_difftest.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+export NEMU_HOME=/root/NEMU
+
+# gcpt_restore is not needed for ref-so. Just skip it in Makefile.
+mkdir -p $(pwd)/resource/gcpt_restore/src
+touch $(pwd)/resource/gcpt_restore/src/restore_rom_addr.h
+mkdir -p $(pwd)/resource/gcpt_restore/build
+touch $(pwd)/resource/gcpt_restore/build/gcpt.bin
+
+# The old version of GNU Make in CentOS 7 will check the
+# indentation of Makefile, causing make failure after fetching the
+# berkeley-softfloat-3. This dry run fixed this by fetching the
+# dependencies for the first time.
+make riscv64-xs-ref_defconfig && \
+(make -j `nproc` || true)
+
+artifact_dir=$(pwd)/artifact
+mkdir -p $artifact_dir
+make clean
+make riscv64-xs-ref_defconfig
+make -j
+cp build/riscv64-nemu-interpreter-so ${artifact_dir}
+make clean
+make riscv64-dual-xs-ref_defconfig
+make -j
+cp build/riscv64-nemu-interpreter-so ${artifact_dir}/riscv64-nemu-interpreter-dual-so

--- a/scripts/generate_so_from_docker.sh
+++ b/scripts/generate_so_from_docker.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+docker build -t difftest-so-env ./scripts && \
+docker run --rm --volume=$(pwd):/root/NEMU --workdir /root/NEMU difftest-so-env bash -l scripts/generate_so_for_difftest.sh


### PR DESCRIPTION
This PR add a CI to compile difftest-so in CentOS 7 docker and upload them as an archived artifact. Users can obtain them through Actions page, like https://github.com/OpenXiangShan/NEMU/actions/runs/10185291877.

<img width="960" alt="image" src="https://github.com/user-attachments/assets/7610f40b-9c52-4544-a986-cebfac21b7bf">
