### PR TITLE
rv64v: fast path for unit-stride ld/st; vectorize this fast path

### DIFF
--- a/include/cpu/decode.h
+++ b/include/cpu/decode.h
@@ -74,6 +74,7 @@ typedef struct Decode {
   uint32_t vm;
   uint32_t src_vmode;
   rtlreg_t tmp_reg[4];
+  void *last_access_host_addr;
   #endif // CONFIG_RVV
 
 } Decode;

--- a/include/memory/host.h
+++ b/include/memory/host.h
@@ -20,15 +20,26 @@
 
 static inline word_t host_read(void *addr, int len) {
   switch (len) {
-    case 1: return *(uint8_t  *)addr;
-    case 2: return *(uint16_t *)addr;
-    case 4: return *(uint32_t *)addr;
-    IFDEF(CONFIG_ISA64, case 8: return *(uint64_t *)addr);
+    case 1:
+    Logm("load: addr = %p, len = %d, data = 0x%x", addr, len, *(uint8_t  *)addr);
+    return *(uint8_t  *)addr;
+    case 2:
+    Logm("load: addr = %p, len = %d, data = 0x%x", addr, len, *(uint16_t  *)addr);
+    return *(uint16_t *)addr;
+    case 4:
+    Logm("load: addr = %p, len = %d, data = 0x%x", addr, len, *(uint32_t  *)addr);
+    return *(uint32_t *)addr;
+#ifdef CONFIG_ISA64
+    case 8:
+    Logm("load: addr = %p, len = %d, data = 0x%lx", addr, len, *(uint64_t  *)addr);
+    return *(uint64_t *)addr;
+#endif
     default: MUXDEF(CONFIG_RT_CHECK, assert(0), return 0);
   }
 }
 
 static inline void host_write(void *addr, int len, word_t data) {
+  Logm("write: addr = %p, len = %d, data = 0x%lx", addr, len, data);
   switch (len) {
     case 1: *(uint8_t  *)addr = data; return;
     case 2: *(uint16_t *)addr = data; return;

--- a/scripts/build.mk
+++ b/scripts/build.mk
@@ -32,9 +32,9 @@ CC := $(CCACHE) $(CC)
 LD := $(CCACHE) $(CXX)
 INCLUDES = $(addprefix -I, $(INC_DIR))
 XINCLUDES = $(addprefix -I, $(XINC_DIR))
-CFLAGS  := -O2 -MMD -Wall -Werror $(INCLUDES) $(CFLAGS) $(PGO_FLAGS)
+CFLAGS  := -O2 -flto -ftree-vectorize -march=native -MMD -Wall -Werror $(INCLUDES) $(CFLAGS) $(PGO_FLAGS)
 CXXFLAGS  := --std=c++17 $(XINCLUDES) $(CFLAGS)
-LDFLAGS := -O2 $(LDFLAGS) $(PGO_FLAGS)
+LDFLAGS := -O2 -flto $(LDFLAGS) $(PGO_FLAGS)
 # filesystem
 ifndef SHARE
 LDFLAGS += -lstdc++fs -lstdc++ -lm

--- a/src/cpu/cpu-exec.c
+++ b/src/cpu/cpu-exec.c
@@ -41,6 +41,7 @@
 
 CPU_state cpu = {};
 uint64_t g_nr_guest_instr = 0;
+uint64_t g_nr_vst = 0, g_nr_vst_unit = 0, g_nr_vst_unit_optimized = 0;
 static uint64_t g_timer = 0; // unit: us
 static bool g_print_step = false;
 const rtlreg_t rzero = 0;
@@ -93,6 +94,8 @@ void monitor_statistic() {
   Log("host time spent = %'ld us", g_timer);
 #ifdef CONFIG_ENABLE_INSTR_CNT
   Log("total guest instructions = %'ld", g_nr_guest_instr);
+  Log("vst count = %'ld, vst unit count = %'ld, vst unit optimized count = %'ld",
+      g_nr_vst, g_nr_vst_unit, g_nr_vst_unit_optimized);
   if (g_timer > 0)
     Log("simulation frequency = %'ld instr/s",
         g_nr_guest_instr * 1000000 / g_timer);
@@ -102,6 +105,7 @@ void monitor_statistic() {
 #else
   Log("CONFIG_ENABLE_INSTR_CNT is not defined");
 #endif
+  fflush(stdout);
 }
 
 static word_t g_ex_cause = 0;
@@ -341,6 +345,8 @@ static int execute(int n) {
     // clear for recording next inst
     is_ctrl = false;
     Logti("prev pc = 0x%lx, pc = 0x%lx", prev_s->pc, s->pc);
+
+    IFDEF(CONFIG_DEBUG, g_nr_guest_instr += 1);
 
     save_globals(s);
     debug_difftest(this_s, s);

--- a/src/isa/riscv64/instr/rvv/vcompute.h
+++ b/src/isa/riscv64/instr/rvv/vcompute.h
@@ -380,11 +380,11 @@ def_EHelper(vpopc) {
   rtl_li(s, s1, 0);
   for(int idx = vstart->val; idx < vl->val; idx ++) {
         // mask
-    rtlreg_t mask = get_mask(0, idx, vtype->vsew, vtype->vlmul);
+    rtlreg_t mask = get_mask(0, idx);
     if(s->vm == 0 && mask == 0)
       continue;
 
-    *s0 = get_mask(id_src2->reg, idx, vtype->vsew, vtype->vlmul);
+    *s0 = get_mask(id_src2->reg, idx);
     *s0 &= 1;
 
     if(*s0 == 1)
@@ -400,9 +400,9 @@ def_EHelper(vfirst) {
 
   int pos = -1;
   for(int idx = vstart->val; idx < vl->val; idx ++) {
-    rtlreg_t mask = get_mask(0, idx, vtype->vsew, vtype->vlmul);
+    rtlreg_t mask = get_mask(0, idx);
     if (s->vm || mask) {
-      *s0 = get_mask(id_src2->reg, idx, vtype->vsew, vtype->vlmul);
+      *s0 = get_mask(id_src2->reg, idx);
       *s0 &= 1;
       if(*s0 == 1) {
         pos = idx;
@@ -427,7 +427,7 @@ def_EHelper(vmsbf) {
     // when vl = 0, do nothing
     bool first_one = false;
     for(int idx = vstart->val; idx < vl->val; idx ++) {
-      rtlreg_t mask = get_mask(0, idx, vtype->vsew, vtype->vlmul);
+      rtlreg_t mask = get_mask(0, idx);
       if(s->vm == 0 && mask == 0) {
         // it need v0 mask, but this element is not choosed by v0
         // if vma, set 1; others, continue
@@ -443,7 +443,7 @@ def_EHelper(vmsbf) {
       // or
       // s->vm == 0 && mask == 1: this element is choosed by v0
 
-      *s0 = get_mask(id_src2->reg, idx, vtype->vsew, vtype->vlmul);
+      *s0 = get_mask(id_src2->reg, idx);
       *s0 &= 1;
 
       if(!first_one && *s0 == 1) {
@@ -478,7 +478,7 @@ def_EHelper(vmsof) {
     // when vl = 0, do nothing
     bool first_one = false;
     for(int idx = vstart->val; idx < vl->val; idx ++) {
-      rtlreg_t mask = get_mask(0, idx, vtype->vsew, vtype->vlmul);
+      rtlreg_t mask = get_mask(0, idx);
       if(s->vm == 0 && mask == 0) {
         if (RVV_AGNOSTIC) {
           if (vtype->vma) {
@@ -488,7 +488,7 @@ def_EHelper(vmsof) {
         continue;
       }
 
-      *s0 = get_mask(id_src2->reg, idx, vtype->vsew, vtype->vlmul);
+      *s0 = get_mask(id_src2->reg, idx);
       *s0 &= 1;
 
       if(!first_one && *s0 == 1) {
@@ -519,7 +519,7 @@ def_EHelper(vmsif) {
     // when vl = 0, do nothing
     bool first_one = false;
     for(int idx = vstart->val; idx < vl->val; idx ++) {
-      rtlreg_t mask = get_mask(0, idx, vtype->vsew, vtype->vlmul);
+      rtlreg_t mask = get_mask(0, idx);
       if(s->vm == 0 && mask == 0) {
         if (RVV_AGNOSTIC) {
           if (vtype->vma) {
@@ -529,7 +529,7 @@ def_EHelper(vmsif) {
         continue;
       }
 
-      *s0 = get_mask(id_src2->reg, idx, vtype->vsew, vtype->vlmul);
+      *s0 = get_mask(id_src2->reg, idx);
       *s0 &= 1;
 
       if(first_one) {
@@ -562,7 +562,7 @@ def_EHelper(viota) {
   if(!check_vstart_ignore(s)) {
     rtl_li(s, s1, 0);
     for(int idx = vstart->val; idx < vl->val; idx ++) {
-      rtlreg_t mask = get_mask(0, idx, vtype->vsew, vtype->vlmul);
+      rtlreg_t mask = get_mask(0, idx);
       if(s->vm == 0 && mask == 0) {
         if (RVV_AGNOSTIC) {
           if (vtype->vma) {
@@ -574,7 +574,7 @@ def_EHelper(viota) {
         continue;
       }
 
-      *s0 = get_mask(id_src2->reg, idx, vtype->vsew, vtype->vlmul);
+      *s0 = get_mask(id_src2->reg, idx);
       *s0 &= 1;
 
       set_vreg(id_dest->reg, idx, *s1, vtype->vsew, vtype->vlmul, 1);
@@ -609,7 +609,7 @@ def_EHelper(vid) {
   if(!check_vstart_ignore(s)) {
     for(int idx = 0; idx < vl->val; idx ++) {
       // mask
-      rtlreg_t mask = get_mask(0, idx, vtype->vsew, vtype->vlmul);
+      rtlreg_t mask = get_mask(0, idx);
       // Masking does not change the index value written to active elements.
       if(s->vm == 0 && mask == 0) {
         if (RVV_AGNOSTIC) {
@@ -781,7 +781,7 @@ def_EHelper(vcompress) {
 
     rtl_li(s, s1, 0);
     for(int idx = vstart->val; idx < vl->val; idx ++) {
-      rtlreg_t mask = get_mask(id_src1->reg, idx, vtype->vsew, vtype->vlmul);
+      rtlreg_t mask = get_mask(id_src1->reg, idx);
 
       if (mask == 0) {
           continue;

--- a/src/isa/riscv64/instr/rvv/vcompute_impl.c
+++ b/src/isa/riscv64/instr/rvv/vcompute_impl.c
@@ -389,7 +389,7 @@ void arthimetic_instr(int opcode, int is_signed, int widening, int narrow, int d
   if(check_vstart_ignore(s)) return;
   for(idx = vstart->val; idx < vl->val; idx ++) {
     // mask
-    rtlreg_t mask = get_mask(0, idx, vtype->vsew, vtype->vlmul);
+    rtlreg_t mask = get_mask(0, idx);
     carry = 0;
     if(s->vm == 0) {
       carry = mask;
@@ -857,7 +857,7 @@ void permutaion_instr(int opcode, Decode *s) {
   int idx;
   for(idx = vstart->val; idx < vl->val; idx ++) {
     // mask
-    rtlreg_t mask = get_mask(0, idx, vtype->vsew, vtype->vlmul);
+    rtlreg_t mask = get_mask(0, idx);
     if(s->vm == 0) {
       // merge instr will exec no matter mask or not
       // masked and mask off exec will left dest unmodified.
@@ -1063,7 +1063,7 @@ void floating_arthimetic_instr(int opcode, int is_signed, int widening, int dest
   if(check_vstart_ignore(s)) return;
   for(idx = vstart->val; idx < vl->val; idx ++) {
     // mask
-    rtlreg_t mask = get_mask(0, idx, vtype->vsew, vtype->vlmul);
+    rtlreg_t mask = get_mask(0, idx);
     if(s->vm == 0) {
       // merge instr will exec no matter mask or not
       // masked and mask off exec will left dest unmodified.
@@ -1238,11 +1238,11 @@ void mask_instr(int opcode, Decode *s) {
   int idx;
   for(idx = vstart->val; idx < vl->val; idx++) {
     // operand - vs2
-    *s0 = get_mask(id_src2->reg, idx, vtype->vsew, vtype->vlmul); // unproper usage of s0
+    *s0 = get_mask(id_src2->reg, idx); // unproper usage of s0
     *s0 &= 1; // only LSB
 
     // operand - s1
-    *s1 = get_mask(id_src->reg, idx, vtype->vsew, vtype->vlmul); // unproper usage of s1
+    *s1 = get_mask(id_src->reg, idx); // unproper usage of s1
     *s1 &= 1; // only LSB
 
     // op
@@ -1296,7 +1296,7 @@ void reduction_instr(int opcode, int is_signed, int wide, Decode *s) {
   int idx;
   for(idx = vstart->val; idx < vl->val; idx ++) {
     // get mask
-    rtlreg_t mask = get_mask(0, idx, vtype->vsew, vtype->vlmul);
+    rtlreg_t mask = get_mask(0, idx);
     if(s->vm == 0 && mask==0) {
       continue;
     }
@@ -1358,7 +1358,7 @@ void float_reduction_instr(int opcode, int widening, Decode *s) {
   if(check_vstart_ignore(s)) return;
 
   for(idx = vstart->val; idx < vl->val; idx ++) {
-    rtlreg_t mask = get_mask(0, idx, vtype->vsew, vtype->vlmul);
+    rtlreg_t mask = get_mask(0, idx);
     if(s->vm == 0 && mask==0) {
       continue;
     }
@@ -1484,7 +1484,7 @@ void float_reduction_computing(Decode *s) {
   // copy the vector register to the temp register
   init_tmp_vreg(s, vtype->vsew);
   for(idx = vstart->val; idx < vl->val; idx ++) {
-    rtlreg_t mask = get_mask(0, idx, vtype->vsew, vtype->vlmul);
+    rtlreg_t mask = get_mask(0, idx);
     if(s->vm == 0 && mask==0) {
       continue;
     }

--- a/src/isa/riscv64/instr/rvv/vreg.h
+++ b/src/isa/riscv64/instr/rvv/vreg.h
@@ -28,6 +28,7 @@
 #define VENUM32 (VLEN/32)
 #define VENUM16 (VLEN/16)
 #define VENUM8  (VLEN/8)
+#define VLMAX_8 (VENUM8 * 8)  // The maximum number of elements when sew = 8 && lmul = 8
 #define SLEN 256
 #ifdef CONFIG_RVV_AGNOSTIC
 #define RVV_AGNOSTIC 1
@@ -70,7 +71,7 @@ static inline int check_reg_index2(int index2, int elen) {
 #define vreg_s(index1, index2) (cpu.vr[check_reg_index1(index1)]._16[check_reg_index2(index2, 16)])
 #define vreg_b(index1, index2) (cpu.vr[check_reg_index1(index1)]._8[check_reg_index2(index2,   8)])
 
-rtlreg_t get_mask(int reg, int idx, uint64_t vsew, uint64_t vlmul);
+rtlreg_t get_mask(int reg, int idx);
 
 static inline const char * vreg_name(int index, int width) {
   extern const char * vregsl[];
@@ -81,6 +82,7 @@ static inline const char * vreg_name(int index, int width) {
 int get_vlmax(int vsew, int vlmul);
 int get_vlen_max(int vsew, int vlmul, int widening);
 void get_vreg(uint64_t reg, int idx, rtlreg_t *dst, uint64_t vsew, uint64_t vlmul, int is_signed, int needAlign);
+void get_vreg_with_addr(uint64_t reg, int idx, rtlreg_t *dst, uint64_t vsew, uint64_t vlmul, int is_signed, int needAlign, void **reg_file_addr);
 void set_vreg(uint64_t reg, int idx, rtlreg_t src, uint64_t vsew, uint64_t vlmul, int needAlgin);
 
 void get_tmp_vreg(uint64_t reg, int idx, rtlreg_t *dst, uint64_t vsew);

--- a/src/isa/riscv64/instr/rvv/vreg_impl.c
+++ b/src/isa/riscv64/instr/rvv/vreg_impl.c
@@ -55,7 +55,7 @@ rtlreg_t check_vsetvl(rtlreg_t vtype_req, rtlreg_t vl_req, int mode) {
   }
 }
 
-rtlreg_t get_mask(int reg, int idx, uint64_t vsew, uint64_t vlmul) {
+rtlreg_t get_mask(int reg, int idx) {
   int idx1 = idx / 64;
   int idx2 = idx % 64;
   
@@ -138,6 +138,35 @@ void get_vreg(uint64_t reg, int idx, rtlreg_t *dst, uint64_t vsew, uint64_t vlmu
     case 1 : *dst = is_signed ? (int64_t)(int16_t)vreg_s(new_reg, new_idx) : vreg_s(new_reg, new_idx); break;
     case 2 : *dst = is_signed ? (int64_t)(int32_t)vreg_i(new_reg, new_idx) : vreg_i(new_reg, new_idx); break;
     case 3 : *dst = is_signed ? (int64_t)         vreg_l(new_reg, new_idx) : vreg_l(new_reg, new_idx); break;
+  }
+}
+
+void get_vreg_with_addr(uint64_t reg, int idx, rtlreg_t *dst, uint64_t vsew, uint64_t vlmul, int is_signed, int needAlign, void **addr) {
+  Assert(vlmul != 4, "vlmul = 4 is reserved\n");
+  Assert(vsew <= 3, "vsew should be less than 4\n");
+  isa_misalign_vreg_check(reg, vlmul, needAlign);
+  int new_reg = get_reg(reg, idx, vsew);
+  int new_idx = get_idx(reg, idx, vsew);
+  switch (vsew) {
+    case 0 :
+    *dst = is_signed ? (int64_t)(int8_t )vreg_b(new_reg, new_idx) : vreg_b(new_reg, new_idx);
+    *addr = (void *) &vreg_b(new_reg, new_idx);
+    break;
+
+    case 1 :
+    *dst = is_signed ? (int64_t)(int16_t)vreg_s(new_reg, new_idx) : vreg_s(new_reg, new_idx);
+    *addr = (void *) &vreg_s(new_reg, new_idx);
+    break;
+
+    case 2 :
+    *dst = is_signed ? (int64_t)(int32_t)vreg_i(new_reg, new_idx) : vreg_i(new_reg, new_idx);
+    *addr = (void *) &vreg_i(new_reg, new_idx);
+    break;
+
+    case 3 :
+    *dst = is_signed ? (int64_t)         vreg_l(new_reg, new_idx) : vreg_l(new_reg, new_idx);
+    *addr = (void *) &vreg_l(new_reg, new_idx);
+    break;
   }
 }
 

--- a/src/isa/riscv64/local-include/csr.h
+++ b/src/isa/riscv64/local-include/csr.h
@@ -1266,7 +1266,7 @@ CSR_STRUCT_START(vlenb)
 CSR_STRUCT_END(vlenb)
 
 rtlreg_t check_vsetvl(rtlreg_t vtype_req, rtlreg_t vl_req, int mode);
-rtlreg_t get_mask(int reg, int idx, uint64_t vsew, uint64_t vlmul);
+rtlreg_t get_mask(int reg, int idx);
 void set_mask(uint32_t reg, int idx, uint64_t mask, uint64_t vsew, uint64_t vlmul);
 
 #endif // CONFIG_RVV

--- a/src/memory/paddr.c
+++ b/src/memory/paddr.c
@@ -373,6 +373,7 @@ void store_commit_queue_push(uint64_t addr, uint64_t data, int len) {
     return;
   }
 #endif // CONFIG_DIFFTEST_STORE_COMMIT_AMO
+  Logm("push store addr = " FMT_PADDR ", data = " FMT_WORD ", len = %d", addr, data, len);
  store_commit_t store_commit;
   uint64_t offset = addr % 8ULL;
   store_commit.addr = addr - offset;

--- a/src/memory/vaddr.c
+++ b/src/memory/vaddr.c
@@ -14,6 +14,7 @@
 * See the Mulan PSL v2 for more details.
 ***************************************************************************************/
 
+#include "common.h"
 #include <isa.h>
 //#include <profiling/betapoint-ext.h>
 #include <profiling/profiling_control.h>
@@ -138,6 +139,29 @@ static inline word_t vaddr_read_internal(void *s, vaddr_t addr, int len, int typ
   return 0;
 }
 
+#ifdef CONFIG_RVV
+extern void dummy_hosttlb_translate(struct Decode *s, vaddr_t vaddr, int len, bool is_write);
+
+void dummy_vaddr_data_read(struct Decode *s, vaddr_t addr, int len, int mmu_mode) {
+  assert(!ISDEF(CONFIG_SHARE));
+#ifdef CONFIG_RVV
+  if (unlikely(mmu_mode == MMU_DYNAMIC || (mmu_mode == MMU_TRANSLATE && ((struct Decode*)s)->v_is_vx == 0) )) {
+#else
+  if (unlikely(mmu_mode == MMU_DYNAMIC || mmu_mode == MMU_TRANSLATE)) {
+#endif
+    Logm("Checking mmu when MMU_DYN for dummy read");
+    mmu_mode = isa_mmu_check(addr, len, MEM_TYPE_READ);
+  }
+
+  if (mmu_mode == MMU_DIRECT) {
+    return;
+  }
+  if (ISDEF(ENABLE_HOSTTLB)) {
+    dummy_hosttlb_translate(s, addr, len, false);
+  }
+}
+#endif // CONFIG_RVV
+
 word_t vaddr_ifetch(vaddr_t addr, int len) {
   return vaddr_read_internal(NULL, addr, len, MEM_TYPE_IFETCH, MMU_DYNAMIC);
 }
@@ -146,6 +170,21 @@ word_t vaddr_read(struct Decode *s, vaddr_t addr, int len, int mmu_mode) {
   Logm("Reading vaddr %lx", addr);
   return vaddr_read_internal(s, addr, len, MEM_TYPE_READ, mmu_mode);
 }
+
+#ifdef CONFIG_RVV
+void dummy_vaddr_write(struct Decode *s, vaddr_t addr, int len, int mmu_mode) {
+  assert(!ISDEF(CONFIG_SHARE));
+  if (unlikely(mmu_mode == MMU_DYNAMIC || mmu_mode == MMU_TRANSLATE)) {
+    mmu_mode = isa_mmu_check(addr, len, MEM_TYPE_WRITE);
+  }
+  if (mmu_mode == MMU_DIRECT) {
+    return;
+  }
+  if (ISDEF(ENABLE_HOSTTLB)) {
+    dummy_hosttlb_translate(s, addr, len, true);
+  }
+}
+#endif // CONFIG_RVV
 
 void vaddr_write(struct Decode *s, vaddr_t addr, int len, word_t data, int mmu_mode) {
 #ifdef CONFIG_SHARE


### PR DESCRIPTION
- Remove useless parameters for get_mask, which is misleading
- For unit-stride ld/st, perform a dummy memory access to obtain host addr. If host TLB miss or crossing page, then we fall back to the slow path. This avoids redundant address translation.
- Implement masked ld/st with bit operations instread of branches, which makes code easier to vectorize
- Always prefer bounded loop to make it easier to vectorize
- Add optimization flags: -flto -ftree-vectorize -march=native
- Allow to check fast vse with slow path and store commit difftest
- This patch improves the simualtion speed of vectorized h264_sss by 3x, improves the simualtion speed of early 2G instructions of vectorized h264_sss by 9x.