### PR TITLE
ci: enable crypto test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,6 @@ jobs:
             cache-management/softprefetchtest-riscv64-xs.bin
             H-extension-tests/riscv-hyp-tests/rvh_test.bin
           skip_tests: |
-            crypto/crypto-riscv64-noop.bin
             ext_intr/amtest-riscv64-xs.bin
             Svinval/rv64mi-p-svinval.bin
             pmp/pmp.riscv.bin


### PR DESCRIPTION
As the bug was solved in PR #454, this patch enable crypto test in CI.