### PR TITLE
build: enable -fPIC to avoid relocation against the same label

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ LDFLAGS += -lz
 endif
 
 ifndef CONFIG_SHARE
+CFLAGS += -fPIC
 LDFLAGS += -lreadline -ldl -pie
 else
 SHARE = 1


### PR DESCRIPTION
* without -fPIC, may have compile error when compile the NEMU as dut