### PR TITLE
fix(mmu): raise PF if A/D/U bits of an non-leaf PTE is set

### DIFF
--- a/src/isa/riscv64/system/mmu.c
+++ b/src/isa/riscv64/system/mmu.c
@@ -325,9 +325,13 @@ static paddr_t ptw(vaddr_t vaddr, int type) {
     }
 #endif
     pg_base = PGBASE((uint64_t)pte.ppn);
-    if (!pte.v || (!pte.r && pte.w)) goto bad;
-    if (pte.r || pte.x || pte.pad) { break; }
-    else {
+    if (!pte.v || (!pte.r && pte.w) || pte.pad) {
+      goto bad;
+    }
+    if (pte.r || pte.x) { // is leaf
+      break;
+    } else { // not leaf
+      if (pte.a || pte.d || pte.u) { goto bad; }
       level --;
       if (level < 0) { goto bad; }
     }


### PR DESCRIPTION
According to RISC-V priv spec, only leaf PTE could have A/D/U bits. Otherwise, hardware would raises PF. This previous NEMU did not handle this.

This patch also fixes the incorrect check for reserved pads in PTE.