### PR TITLE
fix: correct exception behaviour for misaligned superpage (GPF) & mtval (BP)

### DIFF
--- a/src/isa/riscv64/system/intr.c
+++ b/src/isa/riscv64/system/intr.c
@@ -208,8 +208,9 @@ word_t raise_intr(word_t NO, vaddr_t epc) {
         MUXDEF(CONFIG_RVH, mtval2->val = 0;, ;);
         break;
       case EX_BP:
-        mtval->val = epc; break;
+        mtval->val = epc;
         MUXDEF(CONFIG_RVH, mtval2->val = 0;, ;);
+        break;
       default:
         mtval->val = 0;
         MUXDEF(CONFIG_RVH, mtval2->val = 0;, ;);

--- a/src/isa/riscv64/system/mmu.c
+++ b/src/isa/riscv64/system/mmu.c
@@ -257,8 +257,8 @@ paddr_t gpa_stage(paddr_t gpaddr, vaddr_t vaddr, int type){
         // superpage
         word_t pg_mask = ((1ull << VPNiSHFT(level)) - 1);
         if ((pg_base & pg_mask) != 0) {
-          // missaligned superpage
-          return MEM_RET_FAIL;
+          // misaligned superpage
+          break;
         }
         pg_base = (pg_base & ~pg_mask) | (gpaddr & pg_mask & ~PGMASK);
       }


### PR DESCRIPTION
This PR fixes two problems:
- mtval2 is not clear properly in breakpoint exception.
- GPF exception is not raised properly for misaligned G-stage superpage.

See commit message for details.

Please use rebase to merge this PR.