### PR TITLE
fix(cpu-exec): capture instr for mtval in perf_opt

### DIFF
--- a/src/cpu/cpu-exec.c
+++ b/src/cpu/cpu-exec.c
@@ -593,6 +593,9 @@ void fetch_decode(Decode *s, vaddr_t pc) {
 static void update_global() {
   update_instr_cnt();
   cpu.pc = prev_s->pc;
+  #ifdef CONFIG_TVAL_EX_II
+    cpu.instr = prev_s->isa.instr.val;
+  #endif // CONFIG_TVAL_EX_II
 }
 #endif
 


### PR DESCRIPTION
NEMU updates cpu.instr every instruction only if PERF_OPT is disabled, so that *tval could not get proper instuction info in PERF_OPT mode. This patch update cpu.instr in update_global() function, so that cpu.instr could be udpated properly without performance degradation.