### PR TITLE
fix(mmu): still raise misalign exception when access mmio

### DIFF
--- a/include/memory/paddr.h
+++ b/include/memory/paddr.h
@@ -31,6 +31,8 @@ extern unsigned int PMEM_HARTID;
 /* Used to indicate whether the write is non-aligned across pages write. Reuse this flag inside mode*/
 #define CROSS_PAGE_ST_SHIFT 12
 #define CROSS_PAGE_ST_FLAG  (1u << CROSS_PAGE_ST_SHIFT)
+#define CROSS_PAGE_LD_SHIFT 12
+#define CROSS_PAGE_LD_FLAG  (1u << CROSS_PAGE_LD_SHIFT)
 
 #define RESET_VECTOR (CONFIG_MBASE + CONFIG_PC_RESET_OFFSET)
 
@@ -117,6 +119,7 @@ extern uint8_t* golden_pmem;
 
 static inline word_t golden_pmem_read(paddr_t addr, int len, int type, int mode, vaddr_t vaddr) {
   assert(golden_pmem != NULL);
+  mode &= ~CROSS_PAGE_LD_FLAG;
 #ifdef CONFIG_USE_SPARSEMM
   return sparse_mem_wread((void *)golden_pmem, addr, len)
 #else

--- a/src/isa/riscv64/instr/rvv/vldst_impl.c
+++ b/src/isa/riscv64/instr/rvv/vldst_impl.c
@@ -47,16 +47,16 @@ void isa_vec_misalign_data_addr_check(vaddr_t vaddr, int len, int type);
 
 static void isa_emul_check(int emul, int nfields) {
   if (emul > 3) {
-    Log("vector EMUL > 8 happen: EMUL:%d\n", (1 << emul));
+    Loge("vector EMUL > 8 happen: EMUL:%d\n", (1 << emul));
     longjmp_exception(EX_II);
   }
   if (emul < -3) {
-    Log("vector EMUL < 1/8 happen: EMUL:1/%d\n", 1 << (-emul));
+    Loge("vector EMUL < 1/8 happen: EMUL:1/%d\n", 1 << (-emul));
     longjmp_exception(EX_II);
   }
   int real_emul = 1 << (emul < 0 ? 0 : emul);
   if (real_emul * nfields > 8) {
-    Log("vector EMUL * NFIELDS > 8 happen: EMUL:%s%d NFIELDS:%d\n",
+    Loge("vector EMUL * NFIELDS > 8 happen: EMUL:%s%d NFIELDS:%d\n",
       emul > 0 ? "" : "1/",
       emul > 0 ? real_emul : (1 << (-emul)),
       nfields
@@ -668,11 +668,11 @@ void vstx(Decode *s, int mmu_mode) {
 
 static void isa_whole_reg_check(uint64_t vd, uint64_t nfields) {
   if (nfields != 1 && nfields != 2 && nfields != 4 && nfields != 8) {
-    Log("illegal NFIELDS for whole register instrs: NFIELDS:%lu", nfields);
+    Loge("illegal NFIELDS for whole register instrs: NFIELDS:%lu", nfields);
     longjmp_exception(EX_II);
   }
   if (vd % nfields) {
-    Log("vector register group misaligned for whole register instrs: NFIELDS:%lu vd:%lu",
+    Loge("vector register group misaligned for whole register instrs: NFIELDS:%lu vd:%lu",
       nfields, vd);
     longjmp_exception(EX_II);
   }

--- a/src/memory/vaddr.c
+++ b/src/memory/vaddr.c
@@ -52,9 +52,9 @@ static word_t vaddr_read_cross_page(vaddr_t addr, int len, int type) {
     if (ret != MEM_RET_OK) return 0;
     paddr_t paddr = (mmu_ret & ~PAGE_MASK) | (addr & PAGE_MASK);
 #ifdef CONFIG_MULTICORE_DIFF
-    word_t byte = (type == MEM_TYPE_IFETCH ? golden_pmem_read : paddr_read)(paddr, 1, type, cpu.mode, vaddr);
+    word_t byte = (type == MEM_TYPE_IFETCH ? golden_pmem_read : paddr_read)(paddr, 1, type, cpu.mode | CROSS_PAGE_LD_FLAG, vaddr);
 #else
-    word_t byte = (type == MEM_TYPE_IFETCH ? paddr_read : paddr_read)(paddr, 1, type, cpu.mode, vaddr);
+    word_t byte = (type == MEM_TYPE_IFETCH ? paddr_read : paddr_read)(paddr, 1, type, cpu.mode | CROSS_PAGE_LD_FLAG, vaddr);
 #endif
     data |= byte << (i << 3);
   }


### PR DESCRIPTION
* the priority of misalign is higher than access fault when access mmio
* fix some log and printf, not display them in default config