### PR TITLE
fix(mmu, RVH): s2xlate which support VS-stage is load rather than original access type

### DIFF
--- a/include/memory/paddr.h
+++ b/include/memory/paddr.h
@@ -60,9 +60,9 @@ static inline bool in_pmem(paddr_t addr) {
   }
 }
 
-word_t paddr_read(paddr_t addr, int len, int type, int mode, vaddr_t vaddr);
+word_t paddr_read(paddr_t addr, int len, int type, int trap_type, int mode, vaddr_t vaddr);
 void paddr_write(paddr_t addr, int len, word_t data, int mode, vaddr_t vaddr);
-bool check_paddr(paddr_t addr, int len, int type, int mode, vaddr_t vaddr);
+bool check_paddr(paddr_t addr, int len, int type, int trap_type, int mode, vaddr_t vaddr);
 uint8_t *get_pmem();
 
 #if CONFIG_ENABLE_MEM_DEDUP || CONFIG_USE_MMAP

--- a/src/checkpoint/serializer.cpp
+++ b/src/checkpoint/serializer.cpp
@@ -66,7 +66,7 @@ Serializer::Serializer() :
 
 extern "C" {
 uint8_t *get_pmem();
-word_t paddr_read(paddr_t addr, int len, int type, int mode, vaddr_t vaddr);
+word_t paddr_read(paddr_t addr, int len, int type, int trap_type, int mode, vaddr_t vaddr);
 uint8_t *guest_to_host(paddr_t paddr);
 #include <debug.h>
 extern bool log_enable();

--- a/src/checkpoint/serializer.cpp
+++ b/src/checkpoint/serializer.cpp
@@ -259,11 +259,11 @@ void Serializer::serializeRegs() {
 
   auto *mtime = (uint64_t *) (get_pmem() + MTIMEAddr);
   extern word_t paddr_read(paddr_t addr, int len, int type, int mode, vaddr_t vaddr);
-  *mtime = ::paddr_read(CLINT_MMIO+0xBFF8, 8, MEM_TYPE_READ, MODE_M, CLINT_MMIO+0xBFF8);
+  *mtime = ::paddr_read(CLINT_MMIO+0xBFF8, 8, MEM_TYPE_READ, MEM_TYPE_READ, MODE_M, CLINT_MMIO+0xBFF8);
   Log("Record time: 0x%lx at addr 0x%x", cpu.mode, MTIME_CPT_ADDR);
 
   auto *mtime_cmp = (uint64_t *) (get_pmem() + MTIMECMPAddr);
-  *mtime_cmp = ::paddr_read(CLINT_MMIO+0x4000, 8, MEM_TYPE_READ, MODE_M, CLINT_MMIO+0x4000);
+  *mtime_cmp = ::paddr_read(CLINT_MMIO+0x4000, 8, MEM_TYPE_READ, MEM_TYPE_READ, MODE_M, CLINT_MMIO+0x4000);
   Log("Record time: 0x%lx at addr 0x%x", cpu.mode, MTIME_CMP_CPT_ADDR);
 
   regDumped = true;

--- a/src/memory/host-tlb.c
+++ b/src/memory/host-tlb.c
@@ -74,7 +74,7 @@ static paddr_t va2pa(struct Decode *s, vaddr_t vaddr, int len, int type) {
 __attribute__((noinline))
 static word_t hosttlb_read_slowpath(struct Decode *s, vaddr_t vaddr, int len, int type) {
   paddr_t paddr = va2pa(s, vaddr, len, type);
-  word_t data = paddr_read(paddr, len, type, cpu.mode, vaddr);
+  word_t data = paddr_read(paddr, len, type, type, cpu.mode, vaddr);
   if (likely(in_pmem(paddr))) {
     HostTLBEntry *e = type == MEM_TYPE_IFETCH ?
       &hostxtlb[hosttlb_idx(vaddr)] : &hostrtlb[hosttlb_idx(vaddr)];
@@ -110,7 +110,7 @@ word_t hosttlb_read(struct Decode *s, vaddr_t vaddr, int len, int type) {
   extern bool has_two_stage_translation();
   if(has_two_stage_translation()){
     paddr_t paddr = va2pa(s, vaddr, len, type);
-    return paddr_read(paddr, len, type, cpu.mode, vaddr);
+    return paddr_read(paddr, len, type, type, cpu.mode, vaddr);
   }
 #endif
   vaddr_t gvpn = hosttlb_vpn(vaddr);


### PR DESCRIPTION
In riscv-privileged, it is load or store in G-stage which support VS-stage, such as to get the non-leaf pte of VS-stage

> For G-stage address translation, all memory accesses (including those made to access data structures for VS-stage address translation) are considered to be user-level accesses, as though executed in U-mode. Access type permissions—readable, writable, or executable—are checked during G-stage translation the same as for VS-stage translation. For a memory access made to support VS-stage address translation (such as to read/write a VS-level page table), permissions and the need to set A and/or D bits at the G-stage level are checked as though for an implicit load or store, not for the original access type. However, any exception is always reported for the original access type (instruction, load, or store/AMO).