### PR TITLE
fix: bump spike in ready-to-run and align misaligned issue

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -255,6 +255,10 @@ config AC_NONE
   bool "Disable"
 endchoice
 
+config VECTOR_AC_SOFT
+  bool "Detecting misaligned vector memory accessing"
+  default y
+
 menu "Processor difftest reference config"
 config SHARE
   bool "Build shared library as processor difftest reference"

--- a/configs/riscv64-dual-xs-ref_defconfig
+++ b/configs/riscv64-dual-xs-ref_defconfig
@@ -136,6 +136,7 @@ CONFIG_FPU_SOFT=y
 # CONFIG_AC_HOST is not set
 # CONFIG_AC_SOFT is not set
 CONFIG_AC_NONE=y
+CONFIG_VECTOR_AC_SOFT=y
 
 #
 # Processor difftest reference config

--- a/configs/riscv64-xs-cpt_defconfig
+++ b/configs/riscv64-xs-cpt_defconfig
@@ -159,8 +159,9 @@ CONFIG_SDCARD_IMG_PATH=""
 CONFIG_FPU_SOFT=y
 # CONFIG_FPU_NONE is not set
 # CONFIG_AC_HOST is not set
-CONFIG_AC_SOFT=y
-# CONFIG_AC_NONE is not set
+# CONFIG_AC_SOFT is not set
+CONFIG_AC_NONE=y
+CONFIG_VECTOR_AC_SOFT=y
 
 #
 # Processor difftest reference config

--- a/configs/riscv64-xs-diff-spike_defconfig
+++ b/configs/riscv64-xs-diff-spike_defconfig
@@ -161,8 +161,9 @@ CONFIG_SDCARD_IMG_PATH=""
 CONFIG_FPU_SOFT=y
 # CONFIG_FPU_NONE is not set
 # CONFIG_AC_HOST is not set
-CONFIG_AC_SOFT=y
-# CONFIG_AC_NONE is not set
+# CONFIG_AC_SOFT is not set
+CONFIG_AC_NONE=y
+# CONFIG_VECTOR_AC_SOFT is not set
 
 #
 # Processor difftest reference config

--- a/configs/riscv64-xs-ref_defconfig
+++ b/configs/riscv64-xs-ref_defconfig
@@ -139,6 +139,7 @@ CONFIG_FPU_SOFT=y
 # CONFIG_AC_HOST is not set
 # CONFIG_AC_SOFT is not set
 CONFIG_AC_NONE=y
+CONFIG_VECTOR_AC_SOFT=y
 
 #
 # Processor difftest reference config

--- a/configs/riscv64-xs_defconfig
+++ b/configs/riscv64-xs_defconfig
@@ -159,8 +159,9 @@ CONFIG_SDCARD_IMG_PATH=""
 CONFIG_FPU_SOFT=y
 # CONFIG_FPU_NONE is not set
 # CONFIG_AC_HOST is not set
-CONFIG_AC_SOFT=y
-# CONFIG_AC_NONE is not set
+# CONFIG_AC_SOFT is not set
+CONFIG_AC_NONE=y
+CONFIG_VECTOR_AC_SOFT=y
 
 #
 # Processor difftest reference config

--- a/src/isa/riscv64/system/mmu.c
+++ b/src/isa/riscv64/system/mmu.c
@@ -705,10 +705,12 @@ void isa_misalign_data_addr_check(vaddr_t vaddr, int len, int type) {
 void isa_vec_misalign_data_addr_check(vaddr_t vaddr, int len, int type) {
   if (unlikely((vaddr & (len - 1)) != 0)) {
     Logm("addr misaligned happened: vaddr:%lx len:%d type:%d pc:%lx", vaddr, len, type, cpu.pc);
-    int ex = cpu.amo || type == MEM_TYPE_WRITE ? EX_SAM : EX_LAM;
-    IFDEF(CONFIG_USE_XS_ARCH_CSRS, vaddr = INTR_TVAL_SV48_SEXT(vaddr));
-    INTR_TVAL_REG(ex) = vaddr;
-    longjmp_exception(ex);
+    if (ISDEF(CONFIG_VECTOR_AC_SOFT)) {
+      int ex = cpu.amo || type == MEM_TYPE_WRITE ? EX_SAM : EX_LAM;
+      IFDEF(CONFIG_USE_XS_ARCH_CSRS, vaddr = INTR_TVAL_SV48_SEXT(vaddr));
+      INTR_TVAL_REG(ex) = vaddr;
+      longjmp_exception(ex);
+    }
   }
 }
 


### PR DESCRIPTION
This PR bumps the spike in ready-to-run and spike changes a lot. One important change is enabling misaligned memory access for XiangShan. So this PR does something on config. See commit message for details.