### PR TITLE
feat(misaligned): add config for mmio misaligned detect

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -259,6 +259,10 @@ config VECTOR_AC_SOFT
   bool "Detecting misaligned vector memory accessing"
   default y
 
+config MMIO_AC_SOFT
+  bool "Detecting misaligned mmio memory accessing"
+  default y
+
 menu "Processor difftest reference config"
 config SHARE
   bool "Build shared library as processor difftest reference"

--- a/configs/riscv64-dual-xs-ref_defconfig
+++ b/configs/riscv64-dual-xs-ref_defconfig
@@ -137,6 +137,7 @@ CONFIG_FPU_SOFT=y
 # CONFIG_AC_SOFT is not set
 CONFIG_AC_NONE=y
 CONFIG_VECTOR_AC_SOFT=y
+CONFIG_MMIO_AC_SOFT=y
 
 #
 # Processor difftest reference config

--- a/configs/riscv64-xs-cpt_defconfig
+++ b/configs/riscv64-xs-cpt_defconfig
@@ -162,6 +162,7 @@ CONFIG_FPU_SOFT=y
 # CONFIG_AC_SOFT is not set
 CONFIG_AC_NONE=y
 CONFIG_VECTOR_AC_SOFT=y
+CONFIG_MMIO_AC_SOFT=y
 
 #
 # Processor difftest reference config

--- a/configs/riscv64-xs-diff-spike_defconfig
+++ b/configs/riscv64-xs-diff-spike_defconfig
@@ -164,6 +164,7 @@ CONFIG_FPU_SOFT=y
 # CONFIG_AC_SOFT is not set
 CONFIG_AC_NONE=y
 # CONFIG_VECTOR_AC_SOFT is not set
+# CONFIG_MMIO_AC_SOFT is not set
 
 #
 # Processor difftest reference config

--- a/configs/riscv64-xs-ref_defconfig
+++ b/configs/riscv64-xs-ref_defconfig
@@ -140,6 +140,7 @@ CONFIG_FPU_SOFT=y
 # CONFIG_AC_SOFT is not set
 CONFIG_AC_NONE=y
 CONFIG_VECTOR_AC_SOFT=y
+CONFIG_MMIO_AC_SOFT=y
 
 #
 # Processor difftest reference config

--- a/configs/riscv64-xs_defconfig
+++ b/configs/riscv64-xs_defconfig
@@ -162,6 +162,7 @@ CONFIG_FPU_SOFT=y
 # CONFIG_AC_SOFT is not set
 CONFIG_AC_NONE=y
 CONFIG_VECTOR_AC_SOFT=y
+CONFIG_MMIO_AC_SOFT=y
 
 #
 # Processor difftest reference config

--- a/src/memory/paddr.c
+++ b/src/memory/paddr.c
@@ -148,10 +148,12 @@ static inline void raise_read_access_fault(int type, vaddr_t vaddr) {
 static inline void isa_mmio_misalign_data_addr_check(vaddr_t vaddr, int len, int type, int is_cross_page) {
   if (unlikely((vaddr & (len - 1)) != 0) || is_cross_page) {
     Logm("addr misaligned happened: vaddr:%lx len:%d type:%d pc:%lx", vaddr, len, type, cpu.pc);
-    int ex = cpu.amo || type == MEM_TYPE_WRITE ? EX_SAM : EX_LAM;
-    IFDEF(CONFIG_USE_XS_ARCH_CSRS, vaddr = INTR_TVAL_SV48_SEXT(vaddr));
-    INTR_TVAL_REG(ex) = vaddr;
-    longjmp_exception(ex);
+    if (ISDEF(CONFIG_MMIO_AC_SOFT)) {
+      int ex = cpu.amo || type == MEM_TYPE_WRITE ? EX_SAM : EX_LAM;
+      IFDEF(CONFIG_USE_XS_ARCH_CSRS, vaddr = INTR_TVAL_SV48_SEXT(vaddr));
+      INTR_TVAL_REG(ex) = vaddr;
+      longjmp_exception(ex);
+    }
   }
 }
 


### PR DESCRIPTION
XiangShan support misaligned memory access for normal load/store but not for mmio load/store, while spike could only enable misaligned memory access for all load/store. So this patch adds a config to determine whether mmio misaligned memory access is allowed.