### PR TITLE
fix(mmu, RVH): fix the bug that ppn moves to the left and the high bit disappears

### DIFF
--- a/src/isa/riscv64/system/mmu.c
+++ b/src/isa/riscv64/system/mmu.c
@@ -43,7 +43,7 @@ typedef union PageTableEntry {
 
 #define PGSHFT 12
 #define PGMASK ((1ull << PGSHFT) - 1)
-#define PGBASE(pn) (pn << PGSHFT)
+#define PGBASE(pn) ((uint64_t) pn << PGSHFT)
 
 // Sv39 & Sv48 page walk
 #define PTE_SIZE 8


### PR DESCRIPTION
If ppn is greater than 32 bits and ppn moves to the left, the high bit will disapear. Need to turn ppn into the uint64 first.