### PR TITLE
fix(cbo): bump ready-to-run to support CBO extension and fix xenvcfg

### DIFF
--- a/src/isa/riscv64/init.c
+++ b/src/isa/riscv64/init.c
@@ -96,6 +96,20 @@ void init_isa() {
   henvcfg->pbmte = 0;
 #endif //CONFIG_RV_SVPBMT
 
+#ifdef CONFIG_RV_CBO
+  menvcfg->cbze = 1;
+  menvcfg->cbcfe = 1;
+  menvcfg->cbie = 3;
+  senvcfg->cbze = 1;
+  senvcfg->cbcfe = 1;
+  senvcfg->cbie = 3;
+#ifdef CONFIG_RVH
+  henvcfg->cbze = 1;
+  henvcfg->cbcfe = 1;
+  henvcfg->cbie = 3;
+#endif
+#endif
+
 #ifdef CONFIG_RV_PMP_ENTRY_16
   pmpcfg0->val = 0;
   pmpcfg2->val = 0;

--- a/src/isa/riscv64/local-include/csr.h
+++ b/src/isa/riscv64/local-include/csr.h
@@ -931,6 +931,19 @@ CSR_STRUCT_START(stval)
 CSR_STRUCT_END(stval)
 
 CSR_STRUCT_START(senvcfg)
+  uint64_t fiom   : 1; // [0]
+  uint64_t pad0   : 3; // [3:1]
+  uint64_t cbie   : 2; // [5:4]
+  uint64_t cbcfe  : 1; // [6]
+  uint64_t cbze   : 1; // [7]
+  uint64_t pad1   : 24;// [31:8]
+  uint64_t pmm    : 2; // [33:32]
+  uint64_t pad3   : 25;// [58:34]
+  uint64_t dte    : 1; // [59]
+  uint64_t cde    : 1; // [60]
+  uint64_t adue   : 1; // [61]
+  uint64_t pbmte  : 1; // [62]
+  uint64_t stce   : 1; // [63]
 CSR_STRUCT_END(senvcfg)
 
 CSR_STRUCT_START(satp)


### PR DESCRIPTION
This PR initializes the xenvcfg.cbo bits and fix xenvcfg wmask.
Add senvcfg csr read/write.
MeanWhile, when xenvcfg.CBIE = 2 is reserved and cannot be written.

Bump ready-to-run to support CBO extension.