### PR TITLE
feat(exception): Write full vaddr to *tval

### DIFF
--- a/src/isa/riscv64/local-include/intr.h
+++ b/src/isa/riscv64/local-include/intr.h
@@ -93,7 +93,3 @@ bool intr_deleg_VS(word_t exceptionNO);
 #define INTR_TVAL_REG(ex) (*((intr_deleg_S(ex)) ? (word_t *)stval : (word_t *)mtval))
 #endif
 #endif
-
-#ifdef CONFIG_USE_XS_ARCH_CSRS
-word_t INTR_TVAL_SV48_SEXT(word_t vaddr);
-#endif

--- a/src/isa/riscv64/system/intr.c
+++ b/src/isa/riscv64/system/intr.c
@@ -154,7 +154,7 @@ word_t raise_intr(word_t NO, vaddr_t epc) {
                     ((v || hld_st_temp) && ((0 <= NO && NO <= 7 && NO != 2) || NO == EX_IPF || NO == EX_LPF || NO == EX_SPF)));
     hstatus->spv = cpu.v;
     if(cpu.v){
-      hstatus->spvp = cpu.mode; 
+      hstatus->spvp = cpu.mode;
     }
     cpu.v = 0;
     set_sys_state_flag(SYS_STATE_FLUSH_TCACHE);
@@ -182,18 +182,18 @@ word_t raise_intr(word_t NO, vaddr_t epc) {
         MUXDEF(CONFIG_RVH, htval->val = 0, );
         MUXDEF(CONFIG_RVH, htinst->val = 0, );
         break;
-      case EX_BP : 
-        stval->val = epc; 
+      case EX_BP :
+        stval->val = epc;
         MUXDEF(CONFIG_RVH, htval->val = 0, );
         MUXDEF(CONFIG_RVH, htinst->val = 0, );
         break;
-      default: 
+      default:
         stval->val = 0;
         MUXDEF(CONFIG_RVH, htval->val = 0, );
         MUXDEF(CONFIG_RVH, htinst->val = 0, );
     }
     // When a trap (except GPF) is taken into HS-mode, htinst is written with 0.
-    // Todo: support tinst encoding descriped in section 
+    // Todo: support tinst encoding descriped in section
     // 18.6.3. Transformed Instruction or Pseudoinstruction for mtinst or htinst.
     cpu.mode = MODE_S;
     update_mmu_state();
@@ -285,7 +285,7 @@ word_t isa_query_intr() {
   };
 #ifdef CONFIG_RV_SSCOFPMF
   intr_num = 14;
-#else 
+#else
   intr_num = 13;
 #endif
 #else
@@ -306,7 +306,7 @@ word_t isa_query_intr() {
       bool hdeleg = (hideleg->val & (1 << irq)) != 0;
       bool global_enable = (hdeleg & deleg)? (cpu.v && cpu.mode == MODE_S && vsstatus->sie) || (cpu.v && cpu.mode < MODE_S):
                            (deleg)? ((cpu.mode == MODE_S) && mstatus->sie) || (cpu.mode < MODE_S) || cpu.v:
-                           ((cpu.mode == MODE_M) && mstatus->mie) || (cpu.mode < MODE_M);  
+                           ((cpu.mode == MODE_M) && mstatus->mie) || (cpu.mode < MODE_M);
 #else
       bool global_enable = (deleg ? ((cpu.mode == MODE_S) && mstatus->sie) || (cpu.mode < MODE_S) :
           ((cpu.mode == MODE_M) && mstatus->mie) || (cpu.mode < MODE_M));
@@ -316,16 +316,3 @@ word_t isa_query_intr() {
   }
   return INTR_EMPTY;
 }
-
-#ifdef CONFIG_USE_XS_ARCH_CSRS
-// Should be fixed later
-word_t INTR_TVAL_SV48_SEXT(word_t vaddr) {
-#ifdef CONFIG_RV_SV48
-  vaddr = vaddr & (vaddr_t)0xFFFFFFFFFFFF;
-  return SEXT(vaddr, 48); // USE SV48 VADDR
-#else
-  vaddr = vaddr & (vaddr_t)0x7FFFFFFFFF;
-  return SEXT(vaddr, 39); // USE SV39 VADDR
-#endif // CONFIG_RV_SV48
-}
-#endif

--- a/src/memory/paddr.c
+++ b/src/memory/paddr.c
@@ -150,7 +150,6 @@ static inline void isa_mmio_misalign_data_addr_check(vaddr_t vaddr, int len, int
     Logm("addr misaligned happened: vaddr:%lx len:%d type:%d pc:%lx", vaddr, len, type, cpu.pc);
     if (ISDEF(CONFIG_MMIO_AC_SOFT)) {
       int ex = cpu.amo || type == MEM_TYPE_WRITE ? EX_SAM : EX_LAM;
-      IFDEF(CONFIG_USE_XS_ARCH_CSRS, vaddr = INTR_TVAL_SV48_SEXT(vaddr));
       INTR_TVAL_REG(ex) = vaddr;
       longjmp_exception(ex);
     }


### PR DESCRIPTION
Commit https://github.com/OpenXiangShan/NEMU/commit/2cca2bafa90b9f6221158f01e535be0930323c75 truncates value writing to *tval from 64-bit to 48-bit, thus adapting to RTL.
This reverts commit https://github.com/OpenXiangShan/NEMU/commit/2cca2bafa90b9f6221158f01e535be0930323c75 as RTL can save high address bits to *val