### PR TITLE
fix(snprintf),refactor(small/fast log): fix truncated writing warning, refactor output to log file

### DIFF
--- a/include/cpu/decode.h
+++ b/include/cpu/decode.h
@@ -44,6 +44,10 @@ enum {
   INSTR_TYPE_I, // indirect
 };
 
+IFDEF(CONFIG_DEBUG, extern char log_bytebuf[80];)
+// max size is (strlen(str(instr)) + strlen(suffix_char(id_dest->width)) + sizeof(id_dest->str) + sizeof(id_src2->str) + sizeof(id_src1->str))
+IFDEF(CONFIG_DEBUG, extern char log_asmbuf[80 + (sizeof(((Operand*)0)->str) * 3)]);
+
 typedef struct Decode {
   union {
     struct {
@@ -64,7 +68,7 @@ typedef struct Decode {
   uint16_t idx_in_bb; // the number of instruction in the basic block, start from 1
   uint8_t type;
   ISADecodeInfo isa;
-  IFDEF(CONFIG_DEBUG, char logbuf[80]);
+  IFDEF(CONFIG_DEBUG, char logbuf[80 + sizeof(log_asmbuf) + sizeof(log_bytebuf)]);
   #ifdef CONFIG_RVV
   // for vector
   int v_width;
@@ -178,7 +182,6 @@ finish:
 #define def_INSTR_TABW(pattern, tab, width) def_INSTR_IDTABW(pattern, empty, tab, width)
 #define def_INSTR_TAB(pattern, tab)         def_INSTR_IDTABW(pattern, empty, tab, 0)
 
-
 #define print_Dop(...) IFDEF(CONFIG_DEBUG, snprintf(__VA_ARGS__))
 #define print_asm(...) IFDEF(CONFIG_DEBUG, snprintf(log_asmbuf, sizeof(log_asmbuf), __VA_ARGS__))
 
@@ -187,20 +190,20 @@ finish:
 #endif
 
 #define print_asm_template0(instr) \
-  print_asm(str(instr) "%c", suffix_char(id_dest->width))
+  print_asm("%s %c", str(instr), suffix_char(id_dest->width))
 
 #define print_asm_template1(instr) \
-  print_asm(str(instr) "%c %s", suffix_char(id_dest->width), id_dest->str)
+  print_asm("%s %c %s", str(instr), suffix_char(id_dest->width), id_dest->str)
 
 #define print_asm_template2(instr) \
-  print_asm(str(instr) "%c %s,%s", suffix_char(id_dest->width), id_dest->str, id_src1->str)
+  print_asm("%s %c %s,%s", str(instr), suffix_char(id_dest->width), id_dest->str, id_src1->str)
 
 #define print_asm_template3(instr) \
-  print_asm(str(instr) "%c %s,%s,%s", suffix_char(id_dest->width), id_dest->str, id_src1->str, id_src2->str)
+  print_asm("%s %c %s,%s,%s", str(instr), suffix_char(id_dest->width), id_dest->str, id_src1->str, id_src2->str)
 
 #if defined(CONFIG_ISA_riscv64) || defined(CONFIG_ISA_riscv32)
 #define print_asm_template3_csr(instr) \
-  print_asm(str(instr) "%c %s,%s,%s", suffix_char(id_dest->width), id_dest->str, id_src2->str, id_src1->str)
+  print_asm("%s %c %s,%s,%s", str(instr), suffix_char(id_dest->width), id_dest->str, id_src2->str, id_src1->str)
 #endif
 
 #endif

--- a/include/cpu/ifetch.h
+++ b/include/cpu/ifetch.h
@@ -26,6 +26,7 @@ static inline uint32_t instr_fetch(vaddr_t *pc, int len) {
 #ifdef CONFIG_DEBUG
   uint8_t *p_instr = (void *)&instr;
   int i;
+  extern char log_bytebuf[80];
   for (i = 0; i < len; i ++) {
     int l = strlen(log_bytebuf);
     snprintf(log_bytebuf + l, sizeof(log_bytebuf) - l, "%02x ", p_instr[i]);

--- a/include/utils.h
+++ b/include/utils.h
@@ -49,6 +49,13 @@ uint64_t get_time();
 
 // ----------- log -----------
 
+// control when the log is printed, unit: number of instructions
+#define LOG_START (0)
+#define LOG_END   (1024 * 1024 * 50)
+
+#define SMALL_LOG_ROW_NUM (50 * 1024 * 1024) // row number, 50M instructions
+#define SMALL_LOG_ROW_BYTES 512
+
 /* #define log_write(...) MUXDEF(CONFIG_DEBUG, \
   do { \
     extern FILE* log_fp; \
@@ -67,17 +74,17 @@ uint64_t get_time();
  )*/
 #define log_write(...) \
   do { \
+    extern bool enable_fast_log; \
     extern bool enable_small_log; \
-    extern FILE* log_fp; \
+    extern FILE *log_fp; \
     extern char *log_filebuf; \
     extern uint64_t record_row_number; \
-    extern bool log_enable(); \
-    extern void log_flush(); \
+    extern void log_buffer_flush(); \
     if (log_fp != NULL) { \
-      if (enable_small_log) { \
-        snprintf(log_filebuf + record_row_number * 300, 300, __VA_ARGS__);\
-        log_flush(); \
-      } else if (log_enable()){ \
+      if (enable_fast_log || enable_small_log) { \
+        snprintf(log_filebuf + record_row_number * SMALL_LOG_ROW_BYTES, SMALL_LOG_ROW_BYTES, __VA_ARGS__);\
+        log_buffer_flush(); \
+      } else { \
         fprintf(log_fp, __VA_ARGS__); \
         fflush(log_fp); \
       } \
@@ -90,9 +97,6 @@ uint64_t get_time();
   do { \
     log_write(__VA_ARGS__); \
   } while (0)
-
-extern char log_bytebuf[80];
-extern char log_asmbuf[80];
 
 // ----------- expr -----------
 

--- a/src/checkpoint/path_manager.cpp
+++ b/src/checkpoint/path_manager.cpp
@@ -31,7 +31,8 @@ using namespace std;
 extern "C" {
 #include <debug.h>
 extern bool log_enable();
-extern void log_flush();
+extern void log_buffer_flush();
+extern void log_file_flush();
 }
 
 void PathManager::init() {

--- a/src/checkpoint/serializer.cpp
+++ b/src/checkpoint/serializer.cpp
@@ -69,8 +69,8 @@ uint8_t *get_pmem();
 word_t paddr_read(paddr_t addr, int len, int type, int trap_type, int mode, vaddr_t vaddr);
 uint8_t *guest_to_host(paddr_t paddr);
 #include <debug.h>
-extern bool log_enable();
-extern void log_flush();
+extern void log_buffer_flush();
+extern void log_file_flush();
 extern unsigned long MEMORY_SIZE;
 }
 

--- a/src/checkpoint/simpoint.cpp
+++ b/src/checkpoint/simpoint.cpp
@@ -53,11 +53,12 @@ namespace SimPointNS
 
 extern "C" {
 #include <debug.h>
-extern bool log_enable();
-extern void log_flush();
-extern char *log_filebuf;
 extern uint64_t record_row_number;
 extern FILE *log_fp;
+extern char *log_filebuf;
+extern void log_buffer_flush();
+extern void log_file_flush();
+extern bool enable_fast_log;
 extern bool enable_small_log;
 }
 

--- a/src/cpu/cpu-exec.c
+++ b/src/cpu/cpu-exec.c
@@ -575,13 +575,17 @@ static int execute(int n) {
 }
 #endif
 
+IFDEF(CONFIG_DEBUG, char log_bytebuf[80] = {};)
+// max size is (strlen(str(instr)) + strlen(suffix_char(id_dest->width)) + sizeof(id_dest->str) + sizeof(id_src2->str) + sizeof(id_src1->str))
+IFDEF(CONFIG_DEBUG, char log_asmbuf[80 + (sizeof(((Operand*)0)->str) * 3)] = {};)
+
 void fetch_decode(Decode *s, vaddr_t pc) {
   s->pc = pc;
   s->snpc = pc;
   IFDEF(CONFIG_DEBUG, log_bytebuf[0] = '\0');
   int idx = isa_fetch_decode(s);
-  Logtid(FMT_WORD ":   %s%*.s%s", s->pc, log_bytebuf,
-         40 - (12 + 3 * (int)(s->snpc - s->pc)), "", log_asmbuf);
+  Logtid(FMT_WORD ":   %s%*.s%s", s->pc, MUXDEF(CONFIG_DEBUG, log_bytebuf, ""),
+         40 - (12 + 3 * (int)(s->snpc - s->pc)), "", MUXDEF(CONFIG_DEBUG, log_asmbuf, ""));
   IFDEF(CONFIG_DEBUG,
         snprintf(s->logbuf, sizeof(s->logbuf), FMT_WORD ":   %s%*.s%s", s->pc,
                  log_bytebuf, 40 - (12 + 3 * (int)(s->snpc - s->pc)), "",

--- a/src/memory/paddr.c
+++ b/src/memory/paddr.c
@@ -518,7 +518,7 @@ void store_commit_queue_push(uint64_t addr, uint64_t data, int len, int cross_pa
 
 store_commit_t store_commit_queue_pop(int *flag) {
   *flag = 1;
-  store_commit_t result;
+  store_commit_t result = {.addr=0, .data=0, .mask=0};
   if (store_queue_empty()) {
     *flag = 0;
     return result;


### PR DESCRIPTION
When snprintf dest buffer is a static array with fixed length, and src
also a static array with fixed length, compiler will tell if there will
be a write truncation and warn about it. This commit could fix this warn.

The logic for outputting the log to a file was a bit hard to understand,
refactored this part of the code.