### PR TITLE
feat(store_event): add 'pc' output for store event check

### DIFF
--- a/include/memory/paddr.h
+++ b/include/memory/paddr.h
@@ -84,6 +84,7 @@ typedef struct {
     uint64_t addr;
     uint64_t data;
     uint8_t  mask;
+    uint64_t pc;
 } store_commit_t;
 
 /**
@@ -99,7 +100,7 @@ void store_commit_queue_push(uint64_t addr, uint64_t data, int len, int cross_pa
  * @return store_commit_t struct
  */
 store_commit_t store_commit_queue_pop(int *flag);
-int check_store_commit(uint64_t *addr, uint64_t *data, uint8_t *mask);
+int check_store_commit(uint64_t *addr, uint64_t *data, uint8_t *mask, uint64_t *pc);
 #endif
 
 //#define CONFIG_MEMORY_REGION_ANALYSIS

--- a/src/cpu/cpu-exec.c
+++ b/src/cpu/cpu-exec.c
@@ -62,7 +62,7 @@ static inline void debug_hook(vaddr_t pc, const char *asmbuf) {
 static jmp_buf jbuf_exec = {};
 static uint64_t n_remain_total;
 static int n_remain;
-static Decode *prev_s;
+Decode *prev_s;
 
 void save_globals(Decode *s) { IFDEF(CONFIG_PERF_OPT, prev_s = s); }
 

--- a/src/cpu/difftest/ref.c
+++ b/src/cpu/difftest/ref.c
@@ -146,9 +146,9 @@ void difftest_uarchstatus_cpy(void *dut, bool direction) {
 }
 #endif // CONFIG_LIGHTQS
 
-int difftest_store_commit(uint64_t *saddr, uint64_t *sdata, uint8_t *smask) {
+int difftest_store_commit(uint64_t *saddr, uint64_t *sdata, uint8_t *smask, uint64_t *spc) {
 #ifdef CONFIG_DIFFTEST_STORE_COMMIT
-  return check_store_commit(saddr, sdata, smask);
+  return check_store_commit(saddr, sdata, smask, spc);
 #else
   return 0;
 #endif


### PR DESCRIPTION
To make the store event information more efficient, we now add 'pc' to the store event. The changes need to be used with the new difftest changes.