### PR TITLE
fix(store_event): revert destructive changes to the store event  check api

### DIFF
--- a/include/memory/paddr.h
+++ b/include/memory/paddr.h
@@ -100,7 +100,7 @@ void store_commit_queue_push(uint64_t addr, uint64_t data, int len, int cross_pa
  * @return store_commit_t struct
  */
 store_commit_t store_commit_queue_pop(int *flag);
-int check_store_commit(uint64_t *addr, uint64_t *data, uint8_t *mask, uint64_t *pc);
+int check_store_commit(uint64_t *addr, uint64_t *data, uint8_t *mask);
 #endif
 
 //#define CONFIG_MEMORY_REGION_ANALYSIS

--- a/src/cpu/difftest/ref.c
+++ b/src/cpu/difftest/ref.c
@@ -146,9 +146,9 @@ void difftest_uarchstatus_cpy(void *dut, bool direction) {
 }
 #endif // CONFIG_LIGHTQS
 
-int difftest_store_commit(uint64_t *saddr, uint64_t *sdata, uint8_t *smask, uint64_t *spc) {
+int difftest_store_commit(uint64_t *saddr, uint64_t *sdata, uint8_t *smask) {
 #ifdef CONFIG_DIFFTEST_STORE_COMMIT
-  return check_store_commit(saddr, sdata, smask, spc);
+  return check_store_commit(saddr, sdata, smask);
 #else
   return 0;
 #endif

--- a/src/memory/paddr.c
+++ b/src/memory/paddr.c
@@ -533,7 +533,7 @@ store_commit_t store_commit_queue_pop(int *flag) {
   return result;
 }
 
-int check_store_commit(uint64_t *addr, uint64_t *data, uint8_t *mask, uint64_t *pc) {
+int check_store_commit(uint64_t *addr, uint64_t *data, uint8_t *mask) {
   int result = 0;
   if (store_queue_empty()) {
     printf("NEMU does not commit any store instruction.\n");
@@ -546,7 +546,6 @@ int check_store_commit(uint64_t *addr, uint64_t *data, uint8_t *mask, uint64_t *
       *addr = commit.addr;
       *data = commit.data;
       *mask = commit.mask;
-      *pc   = commit.pc;
       result = 1;
     }
   }


### PR DESCRIPTION
Temporarily revert destructive changes to the store event api check.
Add pc and robidx output of store events for difftest and rtl using other means.