### PR TITLE
fix(sstc): fix time interrupt

### DIFF
--- a/src/isa/riscv64/clint.c
+++ b/src/isa/riscv64/clint.c
@@ -52,11 +52,13 @@ void update_clint() {
   uint64_t uptime = get_time();
   clint_base[CLINT_MTIME] = uptime / US_PERCYCLE;
 #endif
+#ifndef CONFIG_SHARE
   mip->mtip = (clint_base[CLINT_MTIME] >= clint_base[CLINT_MTIMECMP]);
 
 #ifdef CONFIG_RV_SSTC
   mip->stip = (clint_base[CLINT_MTIME] >= stimecmp->val);
   IFDEF(CONFIG_RVH, mip->vstip = (clint_base[CLINT_MTIME] + htimedelta->val >= vstimecmp->val));
+#endif
 #endif
 }
 

--- a/src/isa/riscv64/system/priv.c
+++ b/src/isa/riscv64/system/priv.c
@@ -779,18 +779,23 @@ inline word_t get_mip() {
 
   tmp |= cpu.non_reg_interrupt_pending.platform_irp_msip << 3;
 
+#ifdef CONFIG_SHARE
 #ifdef CONFIG_RV_SSTC
   if (menvcfg->stce) {
     tmp |= cpu.non_reg_interrupt_pending.platform_irp_stip << 5;
+  } else {
+    tmp |= mip->val & MIP_STIP;
   }
-#endif // CONFIG_RV_SSTC
+#else
   tmp |= mip->val & MIP_STIP;
+#endif // CONFIG_RV_SSTC
+#else
+  tmp |= mip->val & (MIP_STIP | MIP_VSTIP | MIP_MTIP);
+#endif
 
   IFDEF(CONFIG_RVH, tmp |= (hvip->vstip | cpu.non_reg_interrupt_pending.platform_irp_vstip) << 6);
-  tmp |= mip->val & MIP_VSTIP;
 
   tmp |= cpu.non_reg_interrupt_pending.platform_irp_mtip << 7;
-  tmp |= mip->val & MIP_MTIP;
 
 #ifdef CONFIG_RV_AIA
   if (mvien->seie) {


### PR DESCRIPTION
* When Diff between XiangShan and NEMU, the time interrupt signal comes from XiangShan
* When NEMU is running alone, the time interrupt signal can be generated by itself