### PR TITLE
Support vector ld/st trigger.

### DIFF
--- a/src/isa/riscv64/instr/decode.c
+++ b/src/isa/riscv64/instr/decode.c
@@ -110,7 +110,7 @@ int isa_fetch_decode(Decode *s) {
   if (cpu.TM->check_timings.bf) {
     action = tm_check_hit(cpu.TM, TRIG_OP_EXECUTE, s->snpc, TRIGGER_NO_VALUE);
   }
-  trigger_handler(action);
+  trigger_handler(action, s->snpc);
 #endif
 
   s->isa.instr.val = instr_fetch(&s->snpc, 2);
@@ -131,7 +131,7 @@ int isa_fetch_decode(Decode *s) {
   if (cpu.TM->check_timings.af) {
     action = tm_check_hit(cpu.TM, (trig_op_t)(TRIG_OP_EXECUTE | TRIG_OP_TIMING), s->snpc, s->isa.instr.val);
   }
-  trigger_handler(action);
+  trigger_handler(action, s->snpc);
 #endif
 
   s->type = INSTR_TYPE_N;

--- a/src/isa/riscv64/instr/rvi/ldst_trig.h
+++ b/src/isa/riscv64/instr/rvi/ldst_trig.h
@@ -5,13 +5,13 @@
     if (cpu.TM->check_timings.br) { \
       action = tm_check_hit(cpu.TM, TRIG_OP_LOAD, vaddr, TRIGGER_NO_VALUE); \
     } \
-    trigger_handler(action); \
+    trigger_handler(action, vaddr); \
     concat(rtl_, rtl_instr) (s, ddest, dsrc1, id_src2->imm, width, mmu_mode); \
     const rtlreg_t data = *ddest; \
     if (cpu.TM->check_timings.ar) { \
       action = tm_check_hit(cpu.TM, (trig_op_t)(TRIG_OP_LOAD | TRIG_OP_TIMING), vaddr, data); \
     } \
-    trigger_handler(action); \
+    trigger_handler(action, vaddr); \
   }
 
 #define def_st_template_with_trigger(name, rtl_instr, width, mmu_mode) \
@@ -22,7 +22,7 @@
     if (cpu.TM->check_timings.bw) { \
       action = tm_check_hit(cpu.TM, TRIG_OP_STORE, vaddr, data); \
     } \
-    trigger_handler(action); \
+    trigger_handler(action, vaddr); \
     concat(rtl_, rtl_instr) (s, ddest, dsrc1, id_src2->imm, width, mmu_mode); \
   }
 

--- a/src/isa/riscv64/local-include/trigger.h
+++ b/src/isa/riscv64/local-include/trigger.h
@@ -190,6 +190,8 @@ void mcontrol6_checked_write(trig_mcontrol6_t* mcontrol6, word_t* wdata, const s
 
 void trigger_handler(const trig_action_t action);
 
+void trigger_check(uint64_t check_timings, struct TriggerModule* TM, trig_op_t op, vaddr_t addr, word_t data);
+
 // Used to avoid magic number
 #define TRIGGER_NO_VALUE (0)
 

--- a/src/isa/riscv64/local-include/trigger.h
+++ b/src/isa/riscv64/local-include/trigger.h
@@ -178,6 +178,9 @@ typedef struct TriggerModule {
   Trigger triggers[CONFIG_TRIGGER_NUM + 1];
 } TriggerModule;
 
+extern trig_action_t trigger_action;
+extern vaddr_t triggered_addr;
+
 void tm_update_timings(struct TriggerModule* TM);
 
 trig_action_t tm_check_hit(struct TriggerModule* TM, trig_op_t op, vaddr_t addr, word_t data);
@@ -188,7 +191,7 @@ bool trigger_value_match(Trigger* trig, word_t value);
 
 void mcontrol6_checked_write(trig_mcontrol6_t* mcontrol6, word_t* wdata, const struct TriggerModule* TM);
 
-void trigger_handler(const trig_action_t action);
+void trigger_handler(const trig_action_t action, vaddr_t addr);
 
 void trigger_check(uint64_t check_timings, struct TriggerModule* TM, trig_op_t op, vaddr_t addr, word_t data);
 

--- a/src/isa/riscv64/system/trigger.c
+++ b/src/isa/riscv64/system/trigger.c
@@ -198,4 +198,17 @@ void trigger_handler(const trig_action_t action) {
   }
 }
 
+void trigger_check(
+  uint64_t check_timings,
+  struct TriggerModule* TM,
+  trig_op_t op,
+  vaddr_t addr,
+  word_t data
+) {
+  if (check_timings) {
+    trig_action_t action = tm_check_hit(TM, op, addr, data);
+    trigger_handler(action);
+  }
+}
+
 #endif //CONFIG_RV_SDTRIG


### PR DESCRIPTION
* Support vector load/store trigger.
* Fix trap value when BreakPoint exception occurs. When a breakpoint exception occurs on an instruction fetch, load, or store,
	then mtval will contain the faulting virtual address.