### PR TITLE
refactor vector Unit-stride Fault-Only-First Loads.

### DIFF
--- a/include/cpu/cpu.h
+++ b/include/cpu/cpu.h
@@ -17,6 +17,7 @@
 #define __CPU_CPU_H__
 
 #include <common.h>
+#include <setjmp.h>
 
 #define AHEAD_LENGTH 500
 
@@ -28,7 +29,21 @@ enum {
 };
 
 void cpu_exec(uint64_t n);
-__attribute__((noreturn)) void longjmp_exec(int cause);
+
+#define CONTEXT_STACK_SIZE 5
+extern int context_idx;
+extern jmp_buf context_stack[CONTEXT_STACK_SIZE];
+#define PUSH_CONTEXT(cause) \
+do{ \
+  if (context_idx + 1 >= CONTEXT_STACK_SIZE) { \
+    panic("Unexcepted exeception context idx = %d", context_idx); \
+  } \
+  context_idx++; \
+  *cause = setjmp(context_stack[context_idx]); \
+} while (0)
+
+void pop_context();
+__attribute__((noreturn)) void longjmp_context(int cause);
 __attribute__((noreturn)) void longjmp_exception(int ex_cause);
 
 enum {

--- a/src/cpu/cpu-exec.c
+++ b/src/cpu/cpu-exec.c
@@ -59,7 +59,6 @@ static inline void debug_hook(vaddr_t pc, const char *asmbuf) {
 }
 #endif
 
-static jmp_buf jbuf_exec = {};
 static uint64_t n_remain_total;
 static int n_remain;
 Decode *prev_s;
@@ -119,18 +118,37 @@ void mmu_tlb_flush(vaddr_t vaddr) {
     set_sys_state_flag(SYS_STATE_FLUSH_TCACHE);
 }
 
-_Noreturn void longjmp_exec(int cause) {
+jmp_buf context_stack[CONTEXT_STACK_SIZE] = {};
+int context_idx = -1;
+
+void pop_context() {
+  if (context_idx < 0) {
+    panic("Unexcepted exeception context idx = %d", context_idx);
+  }
+  context_idx--;
+}
+
+_Noreturn void longjmp_context(int cause) {
   Loge("Longjmp to jbuf_exec with cause: %i", cause);
-  longjmp(jbuf_exec, cause);
+  if (context_idx < 0) {
+    panic("Unexcepted exeception context idx = %d", context_idx);
+  }
+  longjmp(context_stack[context_idx], cause);
 }
 
 _Noreturn void longjmp_exception(int ex_cause) {
-#ifdef CONFIG_GUIDED_EXEC
-  cpu.guided_exec = false;
-#endif
-  g_ex_cause = ex_cause;
-  Loge("longjmp_exec(NEMU_EXEC_EXCEPTION)");
-  longjmp_exec(NEMU_EXEC_EXCEPTION);
+  if (context_idx == 0) {
+    // context_idx == 0 means only the execute loop context saved.
+  #ifdef CONFIG_GUIDED_EXEC
+    cpu.guided_exec = false;
+  #endif
+    g_ex_cause = ex_cause;
+    Loge("longjmp_context(NEMU_EXEC_EXCEPTION)");
+    longjmp_context(NEMU_EXEC_EXCEPTION);
+  } else {
+    // For other condition, we should pass parameter ex_cause to longjmp
+    longjmp_context(ex_cause);
+  }
 }
 
 #ifdef CONFIG_PERF_OPT
@@ -628,7 +646,8 @@ void cpu_exec(uint64_t n) {
   n_remain_total = n; // + AHEAD_LENGTH; // deal with setjmp()
   Loge("cpu_exec will exec %lu instrunctions", n_remain_total);
   int cause;
-  if ((cause = setjmp(jbuf_exec))) {
+  PUSH_CONTEXT(&cause);
+  if (cause) {
 #ifdef CONFIG_RVV
     //The processing logic when the fof instruction is abnormal but not trap.
     //TODO Rewrite him in a better way
@@ -752,4 +771,5 @@ void cpu_exec(uint64_t n) {
     break;
 #endif
   }
+  pop_context();
 }

--- a/src/cpu/cpu-exec.c
+++ b/src/cpu/cpu-exec.c
@@ -648,17 +648,6 @@ void cpu_exec(uint64_t n) {
   int cause;
   PUSH_CONTEXT(&cause);
   if (cause) {
-#ifdef CONFIG_RVV
-    //The processing logic when the fof instruction is abnormal but not trap.
-    //TODO Rewrite him in a better way
-    bool set_fofNoExceptionState(void);
-    if (set_fofNoExceptionState()){
-      // fof is committed, so the instruction count should be updated
-      cause = 0;
-      n_remain_total -= 1;
-      n_remain -= 1;
-    }
-#endif
     n_remain -= prev_s->idx_in_bb - 1;
     // Here is exception handle
 #ifdef CONFIG_PERF_OPT

--- a/src/cpu/difftest/dut.c
+++ b/src/cpu/difftest/dut.c
@@ -119,7 +119,7 @@ static void checkregs(CPU_state *ref, vaddr_t pc) {
     IFDEF(CONFIG_IQUEUE, iqueue_dump());
     nemu_state.state = NEMU_ABORT;
     nemu_state.halt_pc = pc;
-    longjmp_exec(NEMU_EXEC_END);
+    longjmp_context(NEMU_EXEC_END);
   }
 }
 

--- a/src/cpu/tcache.c
+++ b/src/cpu/tcache.c
@@ -236,7 +236,7 @@ full:
   save_globals(s);
   bb_now = bb_now_record = NULL;
   tcache_state = TCACHE_RUNNING;
-  longjmp_exec(NEMU_EXEC_AGAIN);
+  longjmp_context(NEMU_EXEC_AGAIN);
 }
 
 static Decode ex = {};

--- a/src/isa/mips32/instr/special.h
+++ b/src/isa/mips32/instr/special.h
@@ -16,11 +16,11 @@
 def_EHelper(inv) {
   save_globals(s);
   rtl_hostcall(s, HOSTCALL_INV, NULL, NULL, 0);
-  longjmp_exec(NEMU_EXEC_END);
+  longjmp_context(NEMU_EXEC_END);
 }
 
 def_EHelper(nemu_trap) {
   save_globals(s);
   rtl_hostcall(s, HOSTCALL_EXIT, NULL, &cpu.gpr[2]._32, 0); // gpr[2] is $v0
-  longjmp_exec(NEMU_EXEC_END);
+  longjmp_context(NEMU_EXEC_END);
 }

--- a/src/isa/mips32/system/mmu.c
+++ b/src/isa/mips32/system/mmu.c
@@ -100,7 +100,7 @@ static inline int32_t search_ppn(vaddr_t addr, int type) {
       if (!tlb[i].lo[a.lo_idx].V) {
         cpu.entryhi.VPN2 = a.vpn;
 //        Log("tlb[%d] invalid at cpu.pc = 0x%08x, badaddr = 0x%08x", i, cpu.pc, addr);
-        longjmp_exec(type == MEM_TYPE_WRITE ? EX_TLB_ST : EX_TLB_LD);
+        longjmp_context(type == MEM_TYPE_WRITE ? EX_TLB_ST : EX_TLB_LD);
       }
       //Assert(tlb[i].lo[a.lo_idx].V, "cpu.pc = 0x%08x, addr = 0x%08x, lo0 = 0x%08x, lo1 = 0x%08x",
       //    cpu.pc, addr, tlb[i].lo[0].val, tlb[i].lo[1].val);
@@ -109,7 +109,7 @@ static inline int32_t search_ppn(vaddr_t addr, int type) {
   }
   cpu.entryhi.VPN2 = a.vpn;
 //  Log("tlb refill at cpu.pc = 0x%08x, badaddr = 0x%08x", cpu.pc, addr);
-  longjmp_exec(TLB_REFILL | (type == MEM_TYPE_WRITE ? EX_TLB_ST : EX_TLB_LD));
+  longjmp_context(TLB_REFILL | (type == MEM_TYPE_WRITE ? EX_TLB_ST : EX_TLB_LD));
   return -1;
 }
 #endif

--- a/src/isa/riscv32/instr/special.h
+++ b/src/isa/riscv32/instr/special.h
@@ -16,11 +16,11 @@
 def_EHelper(inv) {
   save_globals(s);
   rtl_hostcall(s, HOSTCALL_INV, NULL, NULL, 0);
-  longjmp_exec(NEMU_EXEC_END);
+  longjmp_context(NEMU_EXEC_END);
 }
 
 def_EHelper(nemu_trap) {
   save_globals(s);
   rtl_hostcall(s, HOSTCALL_EXIT, NULL, &cpu.gpr[10]._32, 0); // gpr[10] is $a0
-  longjmp_exec(NEMU_EXEC_END);
+  longjmp_context(NEMU_EXEC_END);
 }

--- a/src/isa/riscv64/instr/priv/system.c
+++ b/src/isa/riscv64/instr/priv/system.c
@@ -43,7 +43,7 @@ int rtl_sys_slow_path(Decode *s, rtlreg_t *dest, const rtlreg_t *src1, uint32_t 
     } else if (id == 1) { // ebreak
       // Please keep the following lines same as in src/isa/riscv64/instr/special.h.
       rtl_hostcall(s, HOSTCALL_EXIT, NULL, &cpu.gpr[10]._64, NULL, 0); // gpr[10] is $a0
-      longjmp_exec(NEMU_EXEC_END);
+      longjmp_context(NEMU_EXEC_END);
 #endif
     } else {
       rtl_hostcall(s, HOSTCALL_PRIV, jpc, src1, NULL, id);

--- a/src/isa/riscv64/instr/rvc/exec.h
+++ b/src/isa/riscv64/instr/rvc/exec.h
@@ -75,7 +75,7 @@ def_EHelper(c_ebreak) {
 #elif defined(CONFIG_EBREAK_AS_TRAP)
   // Please keep the following lines same as in src/isa/riscv64/instr/special.h.
   rtl_hostcall(s, HOSTCALL_EXIT, NULL, &cpu.gpr[10]._64, NULL, 0); // gpr[10] is $a0
-  longjmp_exec(NEMU_EXEC_END);
+  longjmp_context(NEMU_EXEC_END);
 #endif
 }
 

--- a/src/isa/riscv64/instr/rvv/vldst_impl.c
+++ b/src/isa/riscv64/instr/rvv/vldst_impl.c
@@ -35,31 +35,6 @@ word_t vstvaltmp = 0;
 word_t stvaltmp  = 0;
 word_t mtvaltmp  = 0;
 
-bool set_fofNoExceptionState(void){
-  if (fofvl != 0){
-    vl->val     = fofvl;
-
-#ifdef CONFIG_RVH
-    *(word_t *)vstval = vstvaltmp;
-#endif // CONFIG_RVH
-    *(word_t *)stval  = stvaltmp;
-    *(word_t *)mtval  = mtvaltmp;
-
-    vstart->val = 0;
-    fofvl       = 0;
-    vstvaltmp   = 0;
-    stvaltmp    = 0;
-    mtvaltmp    = 0;
-
-#ifndef CONFIG_SHARE
-    difftest_skip_dut(1,0);
-#endif
-    return true;
-  }
-
-  return false;
-}
-
 void isa_vec_misalign_data_addr_check(vaddr_t vaddr, int len, int type);
 // reference: v_ext_macros.h in riscv-isa-sim
 
@@ -879,136 +854,151 @@ void vldff(Decode *s, int mode, int mmu_mode) {
 
   bool fast_vle = false;
 
-#if !defined(CONFIG_SHARE) && !defined(CONFIG_RV_SDTRIG)
-  uint64_t start_addr = base_addr + (vstart->val * nf) * s->v_width;
-  uint64_t last_addr = base_addr + (vl_val * nf - 1) * s->v_width;
-  uint64_t vle_size = last_addr - start_addr + s->v_width;
-  __attribute__((unused)) bool cross_page = last_addr / PAGE_SIZE != start_addr / PAGE_SIZE;
-  uint8_t masks[VLMAX_8] = {0};
-
-  Logm("vld start_addr: %#lx, v_width: %u, vl_val: %lu, vle size=%lu, vstart->val: %lu, nf=%lu",
-      base_addr, s->v_width, vl_val, vle_size, vstart->val, nf);
-
-  if (is_unit_stride && nf == 1 && vl_val > vstart->val && vtype->vlmul < 4 && !cross_page) {
-    s->last_access_host_addr = NULL;
-    extern void dummy_vaddr_data_read(struct Decode *s, vaddr_t addr, int len, int mmu_mode);
-    dummy_vaddr_data_read(s, start_addr, s->v_width, mmu_mode);
-    // Now we have the host address of first element in Decode *s->last_access_host_addr
-    if (s->last_access_host_addr != NULL) {
-
-      // get address of first element in register file
-      void *reg_file_addr = NULL;
-      get_vreg_with_addr(vd, vstart->val, &tmp_reg[1], eew, 0, 0, 0, &reg_file_addr);
-      Assert(reg_file_addr != NULL, "reg_file_addr is NULL");
-      uint8_t * restrict reg_file_addr_8 = reg_file_addr;
-
-      __attribute__((unused)) unsigned count = gen_mask_for_unit_stride(s, eew, vstart, vl_val, masks);
-
-      uint8_t invert_masks[VLMAX_8] = {0};
-      uint8_t * restrict last_access_host_addr_u8 = s->last_access_host_addr;
-
-#ifdef DEBUG_FAST_VLE
-      switch (s->v_width) {
-        case 1: for (int i = 0; i < vle_size; i++) {
-            Logm("Element %i, mask = %x, inv mask = %x, reg = %x, mem = %x", i,
-                 masks[i], invert_masks[i], reg_file_addr_8[i],
-                 last_access_host_addr[i]);
-          }
-          break;
-        case 2:
-          for (int i = 0; i < vle_size; i += 2) {
-            Logm("Element %i, mask = %x, inv mask = %x, reg = %x, mem = %x", i,
-                 *(uint16_t *)&masks[i], *(uint16_t *)&invert_masks[i],
-                 *(uint16_t *)&reg_file_addr_8[i],
-                 *(uint16_t *)&last_access_host_addr[i]);
-          }
-          break;
-        case 4:
-          for (int i = 0; i < vle_size; i += 4) {
-            Logm("Element %i, mask = %x, inv mask = %x, reg = %x, mem = %x", i,
-                 *(uint32_t *)&masks[i], *(uint32_t *)&invert_masks[i],
-                 *(uint32_t *)&reg_file_addr_8[i],
-                 *(uint32_t *)&last_access_host_addr[i]);
-          }
-          break;
-        case 8:
-          for (int i = 0; i < vle_size; i += 8) {
-            Logm("Element %i, mask = %lx, inv mask = %lx, reg = %lx, mem = %lx",
-                 i, *(uint64_t *)&masks[i], *(uint64_t *)&invert_masks[i],
-                 *(uint64_t *)&reg_file_addr_8[i],
-                 *(uint64_t *)&last_access_host_addr[i]);
-          }
-          break;
-        default:
-                panic("Unexpected vwidth = %d", s->v_width);
-      }
-# endif // DEBUG_FAST_VLE
-
-      for (int i = 0; i < VLMAX_8; i++) {
-        invert_masks[i] = ~masks[i];
-        masks[i] &= last_access_host_addr_u8[i];
-        if (RVV_AGNOSTIC && vtype->vma) {
-          invert_masks[i] = 0xff;
-        } else {
-          invert_masks[i] &= reg_file_addr_8[i];
-        }
-        masks[i] |= invert_masks[i];
-      }
-      memcpy(reg_file_addr, masks, vle_size);
-      fast_vle = true;
+  int cause;
+  PUSH_CONTEXT(&cause);
+  if (cause) {
+    if (fofvl) {
+      vl->val = fofvl;
+      #ifdef CONFIG_RVH
+      vstval->val = vstvaltmp;
+      #endif // CONFIG_RVH
+      stval->val = stvaltmp;
+      mtval->val = mtvaltmp;
+    } else {
+      pop_context();
+      longjmp_exception(cause);
     }
-  }
-#endif // !CONFIG_SHARE && !CONFIG_RV_SDTRIG
+  } else {
+  #if !defined(CONFIG_SHARE) && !defined(CONFIG_RV_SDTRIG)
+    uint64_t start_addr = base_addr + (vstart->val * nf) * s->v_width;
+    uint64_t last_addr = base_addr + (vl_val * nf - 1) * s->v_width;
+    uint64_t vle_size = last_addr - start_addr + s->v_width;
+    __attribute__((unused)) bool cross_page = last_addr / PAGE_SIZE != start_addr / PAGE_SIZE;
+    uint8_t masks[VLMAX_8] = {0};
 
-  // Store all seg8 intermediate data
-  uint64_t vloadBuf[8];
+    Logm("vld start_addr: %#lx, v_width: %u, vl_val: %lu, vle size=%lu, vstart->val: %lu, nf=%lu",
+        base_addr, s->v_width, vl_val, vle_size, vstart->val, nf);
 
-  if (!fast_vle) {  // this block is the original slow path
-    for (uint64_t idx = vstart->val; idx < vl_val; idx++) {
-      rtlreg_t mask = get_mask(0, idx);
-      if (s->vm == 0 && mask == 0) {
-        if (RVV_AGNOSTIC && vtype->vma) {
-          tmp_reg[1] = (uint64_t) -1;
-          for (fn = 0; fn < nf; fn++) {
-            set_vreg(vd + fn * emul, idx, tmp_reg[1], eew, 0, 0);
+    if (is_unit_stride && nf == 1 && vl_val > vstart->val && vtype->vlmul < 4 && !cross_page) {
+      s->last_access_host_addr = NULL;
+      extern void dummy_vaddr_data_read(struct Decode *s, vaddr_t addr, int len, int mmu_mode);
+      dummy_vaddr_data_read(s, start_addr, s->v_width, mmu_mode);
+      // Now we have the host address of first element in Decode *s->last_access_host_addr
+      if (s->last_access_host_addr != NULL) {
+
+        // get address of first element in register file
+        void *reg_file_addr = NULL;
+        get_vreg_with_addr(vd, vstart->val, &tmp_reg[1], eew, 0, 0, 0, &reg_file_addr);
+        Assert(reg_file_addr != NULL, "reg_file_addr is NULL");
+        uint8_t * restrict reg_file_addr_8 = reg_file_addr;
+
+        __attribute__((unused)) unsigned count = gen_mask_for_unit_stride(s, eew, vstart, vl_val, masks);
+
+        uint8_t invert_masks[VLMAX_8] = {0};
+        uint8_t * restrict last_access_host_addr_u8 = s->last_access_host_addr;
+
+  #ifdef DEBUG_FAST_VLE
+        switch (s->v_width) {
+          case 1: for (int i = 0; i < vle_size; i++) {
+              Logm("Element %i, mask = %x, inv mask = %x, reg = %x, mem = %x", i,
+                   masks[i], invert_masks[i], reg_file_addr_8[i],
+                   last_access_host_addr[i]);
+            }
+            break;
+          case 2:
+            for (int i = 0; i < vle_size; i += 2) {
+              Logm("Element %i, mask = %x, inv mask = %x, reg = %x, mem = %x", i,
+                   *(uint16_t *)&masks[i], *(uint16_t *)&invert_masks[i],
+                   *(uint16_t *)&reg_file_addr_8[i],
+                   *(uint16_t *)&last_access_host_addr[i]);
+            }
+            break;
+          case 4:
+            for (int i = 0; i < vle_size; i += 4) {
+              Logm("Element %i, mask = %x, inv mask = %x, reg = %x, mem = %x", i,
+                   *(uint32_t *)&masks[i], *(uint32_t *)&invert_masks[i],
+                   *(uint32_t *)&reg_file_addr_8[i],
+                   *(uint32_t *)&last_access_host_addr[i]);
+            }
+            break;
+          case 8:
+            for (int i = 0; i < vle_size; i += 8) {
+              Logm("Element %i, mask = %lx, inv mask = %lx, reg = %lx, mem = %lx",
+                   i, *(uint64_t *)&masks[i], *(uint64_t *)&invert_masks[i],
+                   *(uint64_t *)&reg_file_addr_8[i],
+                   *(uint64_t *)&last_access_host_addr[i]);
+            }
+            break;
+          default:
+                  panic("Unexpected vwidth = %d", s->v_width);
+        }
+  # endif // DEBUG_FAST_VLE
+
+        for (int i = 0; i < VLMAX_8; i++) {
+          invert_masks[i] = ~masks[i];
+          masks[i] &= last_access_host_addr_u8[i];
+          if (RVV_AGNOSTIC && vtype->vma) {
+            invert_masks[i] = 0xff;
+          } else {
+            invert_masks[i] &= reg_file_addr_8[i];
           }
+          masks[i] |= invert_masks[i];
         }
-        continue;
-      }
-      for (fn = 0; fn < nf; fn++) {
-        addr = base_addr + idx * stride + (idx * nf * is_unit_stride + fn) * s->v_width;
-
-        if (idx != 0) {
-          fofvl = idx;
-
-#ifdef CONFIG_RVH
-          vstvaltmp = *(word_t *)vstval;
-#endif // CONFIG_RVH
-          stvaltmp  = *(word_t *)stval;
-          mtvaltmp  = *(word_t *)mtval;
-        }
-
-        IFDEF(CONFIG_RV_SDTRIG, trigger_check(cpu.TM->check_timings.br, cpu.TM, TRIG_OP_LOAD, addr, TRIGGER_NO_VALUE));
-
-        isa_vec_misalign_data_addr_check(addr, s->v_width, MEM_TYPE_READ);
-        rtl_lm(s, &vloadBuf[fn], &addr, 0, s->v_width, mmu_mode);
-      }
-      for (fn = 0; fn < nf; fn++) {
-        set_vreg(vd + fn * emul, idx, vloadBuf[fn], eew, 0, 0);
+        memcpy(reg_file_addr, masks, vle_size);
+        fast_vle = true;
       }
     }
-  }
+  #endif // !CONFIG_SHARE && !CONFIG_RV_SDTRIG
 
-  // Tail agnostic is not handled in fast path
-  if (RVV_AGNOSTIC && (mode == MODE_MASK || vtype->vta)) {   // set tail of vector register to 1
-    int vlmax =  mode == MODE_MASK ? VLEN / 8 : get_vlen_max(eew, vemul, 0);
-    for(int idx = vl_val; idx < vlmax; idx++) {
-      tmp_reg[1] = (uint64_t) -1;
-      for (fn = 0; fn < nf; fn++) {
-        set_vreg(vd + fn * emul, idx, tmp_reg[1], eew, 0, 0);
+    // Store all seg8 intermediate data
+    uint64_t vloadBuf[8];
+
+    if (!fast_vle) {  // this block is the original slow path
+      for (uint64_t idx = vstart->val; idx < vl_val; idx++) {
+        fofvl = idx;
+        #ifdef CONFIG_RVH
+        vstvaltmp = vstval->val;
+        #endif // CONFIG_RVH
+        stvaltmp  = stval->val;
+        mtvaltmp  = mtval->val;
+
+        rtlreg_t mask = get_mask(0, idx);
+        if (s->vm == 0 && mask == 0) {
+          if (RVV_AGNOSTIC && vtype->vma) {
+            tmp_reg[1] = (uint64_t) -1;
+            for (fn = 0; fn < nf; fn++) {
+              set_vreg(vd + fn * emul, idx, tmp_reg[1], eew, 0, 0);
+            }
+          }
+          continue;
+        }
+        for (fn = 0; fn < nf; fn++) {
+          addr = base_addr + idx * stride + (idx * nf * is_unit_stride + fn) * s->v_width;
+
+          IFDEF(CONFIG_RV_SDTRIG, trigger_check(cpu.TM->check_timings.br, cpu.TM, TRIG_OP_LOAD, addr, TRIGGER_NO_VALUE));
+
+          isa_vec_misalign_data_addr_check(addr, s->v_width, MEM_TYPE_READ);
+          rtl_lm(s, &vloadBuf[fn], &addr, 0, s->v_width, mmu_mode);
+        }
+        for (fn = 0; fn < nf; fn++) {
+          set_vreg(vd + fn * emul, idx, vloadBuf[fn], eew, 0, 0);
+        }
       }
     }
+
+    // Tail agnostic is not handled in fast path
+    if (RVV_AGNOSTIC && (mode == MODE_MASK || vtype->vta)) {   // set tail of vector register to 1
+      int vlmax =  mode == MODE_MASK ? VLEN / 8 : get_vlen_max(eew, vemul, 0);
+      for(int idx = vl_val; idx < vlmax; idx++) {
+        tmp_reg[1] = (uint64_t) -1;
+        for (fn = 0; fn < nf; fn++) {
+          set_vreg(vd + fn * emul, idx, tmp_reg[1], eew, 0, 0);
+        }
+      }
+    }
+
   }
+  pop_context();
 
   vstart->val = 0;
   fofvl = 0;

--- a/src/isa/riscv64/instr/special.h
+++ b/src/isa/riscv64/instr/special.h
@@ -22,7 +22,7 @@ def_EHelper(inv) {
   save_globals(s);
 #ifdef CONFIG_REPORT_ILLEGAL_INSTR
   rtl_hostcall(s, HOSTCALL_INV, NULL, NULL, NULL, 0);
-  longjmp_exec(NEMU_EXEC_END);
+  longjmp_context(NEMU_EXEC_END);
 #else
   longjmp_exception(EX_II);
 #endif
@@ -48,6 +48,6 @@ def_EHelper(nemu_trap) {
     }
   } else {
       rtl_hostcall(s, HOSTCALL_EXIT,NULL, &cpu.gpr[10]._64, NULL, 0); // gpr[10] is $a0
-      longjmp_exec(NEMU_EXEC_END);
+      longjmp_context(NEMU_EXEC_END);
   }
 }

--- a/src/isa/x86/instr/special.h
+++ b/src/isa/x86/instr/special.h
@@ -19,10 +19,10 @@ def_EHelper(nop) {
 def_EHelper(inv) {
   save_globals(s);
   rtl_hostcall(s, HOSTCALL_INV, NULL, NULL, NULL, 0);
-  longjmp_exec(NEMU_EXEC_END);
+  longjmp_context(NEMU_EXEC_END);
 }
 
 def_EHelper(nemu_trap) {
   rtl_hostcall(s, HOSTCALL_EXIT, NULL, &cpu.eax, NULL, 0);
-  longjmp_exec(NEMU_EXEC_END);
+  longjmp_context(NEMU_EXEC_END);
 }

--- a/src/user/syscall.c
+++ b/src/user/syscall.c
@@ -59,7 +59,7 @@ static inline uint64_t gen_uint64(uint32_t lo, uint32_t hi) {
 static inline void user_sys_exit(int status) {
   void set_nemu_state(int state, vaddr_t pc, int halt_ret);
   set_nemu_state(NEMU_END, cpu.pc, status);
-  longjmp_exec(NEMU_EXEC_END);
+  longjmp_context(NEMU_EXEC_END);
 }
 
 static inline word_t user_sys_brk(word_t new_brk) {


### PR DESCRIPTION
* Use a env stack to record context saved by setjmp, and longjmp to corresponding context pointed by a context index.
* Refactor vector Unit-stride Fault-Only-First Loads by using context stack above.