### PR TITLE
fix(mip): fix rtl guidance for mip.lcofi logic

### DIFF
--- a/include/isa.h
+++ b/include/isa.h
@@ -86,5 +86,6 @@ void *isa_difftest_query_br_log(void);
 #ifdef CONFIG_MULTICORE_DIFF
 void isa_difftest_set_mhartid(int n);
 #endif
+void isa_update_mip(unsigned lcofip);
 
 #endif

--- a/src/cpu/difftest/ref.c
+++ b/src/cpu/difftest/ref.c
@@ -248,6 +248,7 @@ void difftest_virtual_interrupt_is_hvictl_inject(bool virtualInterruptIsHvictlIn
 
 void difftest_non_reg_interrupt_pending(void *nonRegInterruptPending) {
   memcpy(&cpu.non_reg_interrupt_pending, nonRegInterruptPending, sizeof(struct NonRegInterruptPending));
+  isa_update_mip(cpu.non_reg_interrupt_pending.lcofi_req);
 }
 
 void difftest_enable_debug() {

--- a/src/isa/riscv64/difftest/ref.c
+++ b/src/isa/riscv64/difftest/ref.c
@@ -416,3 +416,7 @@ void isa_difftest_set_mhartid(int n) {
   mhartid->val = n;
 }
 #endif
+
+void isa_update_mip(unsigned lcofip) {
+  mip->lcofip = lcofip;
+}

--- a/src/isa/riscv64/local-include/csr.h
+++ b/src/isa/riscv64/local-include/csr.h
@@ -581,19 +581,20 @@ CSR_STRUCT_START(mideleg)
 CSR_STRUCT_END(mideleg)
 
 CSR_STRUCT_START(mip)
-  uint64_t usip : 1;
-  uint64_t ssip : 1;
-  uint64_t vssip: 1;
-  uint64_t msip : 1;
-  uint64_t utip : 1;
-  uint64_t stip : 1;
-  uint64_t vstip: 1;
-  uint64_t mtip : 1;
-  uint64_t ueip : 1;
-  uint64_t seip : 1;
-  uint64_t vseip: 1;
-  uint64_t meip : 1;
-  uint64_t sgeip: 1;
+  uint64_t usip  : 1;  // [0]
+  uint64_t ssip  : 1;  // [1]
+  uint64_t vssip : 1;  // [2]
+  uint64_t msip  : 1;  // [3]
+  uint64_t utip  : 1;  // [4]
+  uint64_t stip  : 1;  // [5]
+  uint64_t vstip : 1;  // [6]
+  uint64_t mtip  : 1;  // [7]
+  uint64_t ueip  : 1;  // [8]
+  uint64_t seip  : 1;  // [9]
+  uint64_t vseip : 1;  // [10]
+  uint64_t meip  : 1;  // [11]
+  uint64_t sgeip : 1;  // [12]
+  uint64_t lcofip: 1;  // [13]
 CSR_STRUCT_END(mip)
 
 CSR_STRUCT_START(mie)


### PR DESCRIPTION
lcofi is reg-interrupt-pending, which needs to write to mip reg