### PR TITLE
Revert "fix(priv): do not check xstimecmp if normal permit is violated (#571)"

### DIFF
--- a/src/isa/riscv64/system/priv.c
+++ b/src/isa/riscv64/system/priv.c
@@ -1824,7 +1824,7 @@ static inline void csr_permit_check(uint32_t addr, bool is_write) {
   has_vi |= csr_readonly_permit_check(addr, is_write);
 
   // Attempts to access unprivileged counters without s/h/mcounteren
-  if (!has_vi && ((addr >= 0xC00 && addr <= 0xC1F) || (addr == 0x14D) || (addr == 0x24D))) {
+  if ((addr >= 0xC00 && addr <= 0xC1F) || (addr == 0x14D) || (addr == 0x24D)) {
     has_vi |= csr_counter_enable_check(addr);
   }
   // check smstateen


### PR DESCRIPTION
This reverts commit ffe101a53d5479253377eb662b0012426c61290e.

when access vstimecmp in vs-mode with menvcfg.STCE==0 || mcounteren.TM==0 , raise EX_II instead of EX_VI