### PR TITLE
fix(paddr): raise SAF if type is MEM_TYPE_WRITE

### DIFF
--- a/src/memory/paddr.c
+++ b/src/memory/paddr.c
@@ -142,8 +142,11 @@ static inline void raise_access_fault(int cause, vaddr_t vaddr) {
 
 static inline void raise_read_access_fault(int type, vaddr_t vaddr) {
   int cause = EX_LAF;
-  if (type == MEM_TYPE_IFETCH || type == MEM_TYPE_IFETCH_READ) { cause = EX_IAF; }
-  else if (cpu.amo || type == MEM_TYPE_WRITE_READ)             { cause = EX_SAF; }
+  if (type == MEM_TYPE_IFETCH || type == MEM_TYPE_IFETCH_READ) {
+    cause = EX_IAF;
+  } else if (cpu.amo || type == MEM_TYPE_WRITE || type == MEM_TYPE_WRITE_READ) {
+    cause = EX_SAF; 
+  }
   raise_access_fault(cause, vaddr);
 }
 


### PR DESCRIPTION
Although function raise_read_access_fault is named "read", it is used widely for any kind of access fault. A call with type = `MEM_TYPE_WRITE` raises LAF rather than SAF. This patch fixes this.