### PR TITLE
fix(fp): set xstatus.fs unconditionally on fp comparision

### DIFF
--- a/src/isa/riscv64/instr/rvd/exec.h
+++ b/src/isa/riscv64/instr/rvd/exec.h
@@ -76,14 +76,20 @@ def_EHelper(fnmaddd) {
 
 def_EHelper(fled) {
   rtl_hostcall(s, HOSTCALL_FP, ddest, dsrc1, dsrc2, FPCALL_CMD(FPCALL_LE, FPCALL_W64));
+  void fp_set_dirty();
+  fp_set_dirty();
 }
 
 def_EHelper(fltd) {
   rtl_hostcall(s, HOSTCALL_FP, ddest, dsrc1, dsrc2, FPCALL_CMD(FPCALL_LT, FPCALL_W64));
+  void fp_set_dirty();
+  fp_set_dirty();
 }
 
 def_EHelper(feqd) {
   rtl_hostcall(s, HOSTCALL_FP, ddest, dsrc1, dsrc2, FPCALL_CMD(FPCALL_EQ, FPCALL_W64));
+  void fp_set_dirty();
+  fp_set_dirty();
 }
 
 def_EHelper(fcvt_d_w) {

--- a/src/isa/riscv64/instr/rvf/exec.h
+++ b/src/isa/riscv64/instr/rvf/exec.h
@@ -84,16 +84,20 @@ def_EHelper(fnmadds) {
 
 def_EHelper(fles) {
   rtl_hostcall(s, HOSTCALL_FP, ddest, dsrc1, dsrc2, FPCALL_CMD(FPCALL_LE, FPCALL_W32));
+  void fp_set_dirty();
+  fp_set_dirty();
 }
 
 def_EHelper(flts) {
-  rtl_mv(s, ddest, dsrc1);
   rtl_hostcall(s, HOSTCALL_FP, ddest, dsrc1, dsrc2, FPCALL_CMD(FPCALL_LT, FPCALL_W32));
+  void fp_set_dirty();
+  fp_set_dirty();
 }
 
 def_EHelper(feqs) {
-  rtl_mv(s, ddest, dsrc1);
   rtl_hostcall(s, HOSTCALL_FP, ddest, dsrc1, dsrc2, FPCALL_CMD(FPCALL_EQ, FPCALL_W32));
+  void fp_set_dirty();
+  fp_set_dirty();
 }
 
 def_EHelper(fcvt_s_w) {

--- a/src/isa/riscv64/instr/rvzfa/exec.h
+++ b/src/isa/riscv64/instr/rvzfa/exec.h
@@ -58,18 +58,26 @@ def_EHelper(fcvtmod_w_d) {
 
 def_EHelper(fleq_s) {
   rtl_hostcall(s, HOSTCALL_FP, ddest, dsrc1, dsrc2, FPCALL_CMD(FPCALL_FLEQ, FPCALL_W32));
+  void fp_set_dirty();
+  fp_set_dirty();
 }
 
 def_EHelper(fleq_d) {
   rtl_hostcall(s, HOSTCALL_FP, ddest, dsrc1, dsrc2, FPCALL_CMD(FPCALL_FLEQ, FPCALL_W64));
+  void fp_set_dirty();
+  fp_set_dirty();
 }
 
 def_EHelper(fltq_s) {
   rtl_hostcall(s, HOSTCALL_FP, ddest, dsrc1, dsrc2, FPCALL_CMD(FPCALL_FLTQ, FPCALL_W32));
+  void fp_set_dirty();
+  fp_set_dirty();
 }
 
 def_EHelper(fltq_d) {
   rtl_hostcall(s, HOSTCALL_FP, ddest, dsrc1, dsrc2, FPCALL_CMD(FPCALL_FLTQ, FPCALL_W64));
+  void fp_set_dirty();
+  fp_set_dirty();
 }
 
 #ifdef CONFIG_RV_ZFH
@@ -101,10 +109,14 @@ def_EHelper(froundnx_h) {
 
 def_EHelper(fleq_h) {
   rtl_hostcall(s, HOSTCALL_FP, ddest, dsrc1, dsrc2, FPCALL_CMD(FPCALL_FLEQ, FPCALL_W16));
+  void fp_set_dirty();
+  fp_set_dirty();
 }
 
 def_EHelper(fltq_h) {
-    rtl_hostcall(s, HOSTCALL_FP, ddest, dsrc1, dsrc2, FPCALL_CMD(FPCALL_FLTQ, FPCALL_W16));
+  rtl_hostcall(s, HOSTCALL_FP, ddest, dsrc1, dsrc2, FPCALL_CMD(FPCALL_FLTQ, FPCALL_W16));
+  void fp_set_dirty();
+  fp_set_dirty();
 }
 #endif // CONFIG_RV_ZFH
 #endif // CONFIG_RV_ZFA

--- a/src/isa/riscv64/instr/rvzfh/exec.h
+++ b/src/isa/riscv64/instr/rvzfh/exec.h
@@ -85,14 +85,20 @@ def_EHelper(fnmaddh) {
 
 def_EHelper(fleh) {
   rtl_hostcall(s, HOSTCALL_FP, ddest, dsrc1, dsrc2, FPCALL_CMD(FPCALL_LE, FPCALL_W16));
+  void fp_set_dirty();
+  fp_set_dirty();
 }
 
 def_EHelper(flth) {
   rtl_hostcall(s, HOSTCALL_FP, ddest, dsrc1, dsrc2, FPCALL_CMD(FPCALL_LT, FPCALL_W16));
+  void fp_set_dirty();
+  fp_set_dirty();
 }
 
 def_EHelper(feqh) {
   rtl_hostcall(s, HOSTCALL_FP, ddest, dsrc1, dsrc2, FPCALL_CMD(FPCALL_EQ, FPCALL_W16));
+  void fp_set_dirty();
+  fp_set_dirty();
 }
 
 def_EHelper(fcvt_h_w) {


### PR DESCRIPTION
Accroding to manual, either to set or not to set xstatus.fs when no fp exception is raised is ok. To align with XS, we change the behavior of NEMU.