### PR TITLE
fix(amo-diff): report misalign exception in amo instruction

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -263,6 +263,10 @@ config MMIO_AC_SOFT
   bool "Detecting misaligned mmio memory accessing"
   default y
 
+config AMO_AC_SOFT
+  bool "Detecting misaligned amo memory accessing"
+  default y
+
 menu "Processor difftest reference config"
 config SHARE
   bool "Build shared library as processor difftest reference"

--- a/configs/riscv64-dual-xs-ref_defconfig
+++ b/configs/riscv64-dual-xs-ref_defconfig
@@ -140,6 +140,7 @@ CONFIG_FPU_SOFT=y
 CONFIG_AC_NONE=y
 CONFIG_VECTOR_AC_SOFT=y
 CONFIG_MMIO_AC_SOFT=y
+CONFIG_AMO_AC_SOFT=y
 
 #
 # Processor difftest reference config

--- a/configs/riscv64-xs-cpt_defconfig
+++ b/configs/riscv64-xs-cpt_defconfig
@@ -164,6 +164,7 @@ CONFIG_FPU_SOFT=y
 CONFIG_AC_NONE=y
 CONFIG_VECTOR_AC_SOFT=y
 CONFIG_MMIO_AC_SOFT=y
+CONFIG_AMO_AC_SOFT=y
 
 #
 # Processor difftest reference config

--- a/configs/riscv64-xs-diff-spike_defconfig
+++ b/configs/riscv64-xs-diff-spike_defconfig
@@ -166,6 +166,7 @@ CONFIG_FPU_SOFT=y
 CONFIG_AC_NONE=y
 # CONFIG_VECTOR_AC_SOFT is not set
 # CONFIG_MMIO_AC_SOFT is not set
+# CONFIG_AMO_AC_SOFT is not set
 
 #
 # Processor difftest reference config

--- a/configs/riscv64-xs-ref_defconfig
+++ b/configs/riscv64-xs-ref_defconfig
@@ -143,6 +143,7 @@ CONFIG_FPU_SOFT=y
 CONFIG_AC_NONE=y
 CONFIG_VECTOR_AC_SOFT=y
 CONFIG_MMIO_AC_SOFT=y
+CONFIG_AMO_AC_SOFT=y
 
 #
 # Processor difftest reference config

--- a/configs/riscv64-xs_defconfig
+++ b/configs/riscv64-xs_defconfig
@@ -164,6 +164,7 @@ CONFIG_FPU_SOFT=y
 CONFIG_AC_NONE=y
 CONFIG_VECTOR_AC_SOFT=y
 CONFIG_MMIO_AC_SOFT=y
+CONFIG_AMO_AC_SOFT=y
 
 #
 # Processor difftest reference config

--- a/src/isa/riscv64/instr/rva/amo.c
+++ b/src/isa/riscv64/instr/rva/amo.c
@@ -24,6 +24,11 @@ def_rtl(amo_slow_path, rtlreg_t *dest, const rtlreg_t *src1, const rtlreg_t *src
   uint32_t funct5 = s->isa.instr.r.funct7 >> 2;
   int width = s->isa.instr.r.funct3 & 1 ? 8 : 4;
 
+  // AMO does not support misalign operation
+  // So check misalign before real memory access
+  void isa_amo_misalign_data_addr_check(vaddr_t vaddr, int len, int type);
+  isa_amo_misalign_data_addr_check(*src1, width, (funct5 == 0b00010) ? MEM_TYPE_READ : MEM_TYPE_WRITE);
+
   if (funct5 == 0b00010) { // lr
     assert(!cpu.amo);
     cpu.lr_addr = *src1;

--- a/src/isa/riscv64/system/mmu.c
+++ b/src/isa/riscv64/system/mmu.c
@@ -726,6 +726,18 @@ void isa_vec_misalign_data_addr_check(vaddr_t vaddr, int len, int type) {
   }
 }
 
+// AMO access currently does not support hardware misalignment.
+void isa_amo_misalign_data_addr_check(vaddr_t vaddr, int len, int type) {
+  if (unlikely((vaddr & (len - 1)) != 0)) {
+    Logm("addr misaligned happened: vaddr:%lx len:%d type:%d pc:%lx", vaddr, len, type, cpu.pc);
+    if (ISDEF(CONFIG_AMO_AC_SOFT)) {
+      int ex = cpu.amo || type == MEM_TYPE_WRITE ? EX_SAM : EX_LAM;
+      INTR_TVAL_REG(ex) = vaddr;
+      longjmp_exception(ex);
+    }
+  }
+}
+
 paddr_t isa_mmu_translate(vaddr_t vaddr, int len, int type) {
   bool is_cross_page = ((vaddr & PAGE_MASK) + len) > PAGE_SIZE;
   if (is_cross_page) return MEM_RET_CROSS_PAGE;

--- a/src/memory/paddr.c
+++ b/src/memory/paddr.c
@@ -147,6 +147,7 @@ static inline void raise_read_access_fault(int type, vaddr_t vaddr) {
   raise_access_fault(cause, vaddr);
 }
 
+// MMIO access currently does not support hardware misalignment.
 static inline void isa_mmio_misalign_data_addr_check(paddr_t paddr, vaddr_t vaddr, int len, int type, int is_cross_page) {
   if (unlikely((paddr & (len - 1)) != 0) || is_cross_page) {
     Logm("addr misaligned happened: paddr:" FMT_PADDR " vaddr:" FMT_WORD " len:%d type:%d pc:%lx", paddr, vaddr, len, type, cpu.pc);


### PR DESCRIPTION
Since Xiangshan atomic instructions do not support hardware misaligned memory access, so if nemu finds that the addresses are misaligned before executing the atomic instructions, directly reports an exception to make the behavior of both sides consistent.