### PR TITLE
Fix(vaddr): cross page write check should use original vaddr

### DIFF
--- a/src/memory/vaddr.c
+++ b/src/memory/vaddr.c
@@ -32,7 +32,7 @@
 #ifndef ENABLE_HOSTTLB
 
 static paddr_t vaddr_trans_and_check_exception(vaddr_t vaddr, int len, int type, bool* exp) {
-  paddr_t mmu_ret = isa_mmu_translate(vaddr & ~PAGE_MASK, len, type);
+  paddr_t mmu_ret = isa_mmu_translate(vaddr, len, type);
   *exp = (mmu_ret & PAGE_MASK) != MEM_RET_OK;
   paddr_t paddr = (mmu_ret & ~PAGE_MASK) | (vaddr & PAGE_MASK);
   if (*exp) {


### PR DESCRIPTION
In our design, requests that cross page are split into two non-cross page requests in `vaddr_write_cross_page`, which are handled separately in `vaddr_trans_and_check_exception`.

However, in previous design, `vaddr_trans_and_check_exception` would pass a page-aligned vaddr (`vaddr & ~PAGE_MASK`) into `isa_mmu_translate`, which would result in the lower 12 bits of exception address (page offset) written to *tval going to all zeros. This will result in an error against rtl if an exception occurs. This commit fixes it.