### PR TITLE
fix(fcvt): set xstatus.fs unconditionally on fcvt

### DIFF
--- a/src/isa/riscv64/instr/rvd/exec.h
+++ b/src/isa/riscv64/instr/rvd/exec.h
@@ -115,19 +115,27 @@ def_EHelper(fcvt_d_lu) {
 def_EHelper(fcvt_w_d) {
   rtl_hostcall(s, HOSTCALL_FP, ddest, dsrc1, rz, FPCALL_CMD(FPCALL_FToI32, FPCALL_W64));
   rtl_sext(s, ddest, ddest, 4);
+  void fp_set_dirty();
+  fp_set_dirty();
 }
 
 def_EHelper(fcvt_wu_d) {
   rtl_hostcall(s, HOSTCALL_FP, ddest, dsrc1, rz, FPCALL_CMD(FPCALL_FToU32, FPCALL_W64));
   rtl_sext(s, ddest, ddest, 4);
+  void fp_set_dirty();
+  fp_set_dirty();
 }
 
 def_EHelper(fcvt_l_d) {
   rtl_hostcall(s, HOSTCALL_FP, ddest, dsrc1, rz, FPCALL_CMD(FPCALL_FToI64, FPCALL_W64));
+  void fp_set_dirty();
+  fp_set_dirty();
 }
 
 def_EHelper(fcvt_lu_d) {
   rtl_hostcall(s, HOSTCALL_FP, ddest, dsrc1, rz, FPCALL_CMD(FPCALL_FToU64, FPCALL_W64));
+  void fp_set_dirty();
+  fp_set_dirty();
 }
 
 def_EHelper(fcvt_d_s) {

--- a/src/isa/riscv64/instr/rvf/exec.h
+++ b/src/isa/riscv64/instr/rvf/exec.h
@@ -123,19 +123,27 @@ def_EHelper(fcvt_s_lu) {
 def_EHelper(fcvt_w_s) {
   rtl_hostcall(s, HOSTCALL_FP, ddest, dsrc1, rz, FPCALL_CMD(FPCALL_FToI32, FPCALL_W32));
   rtl_sext(s, ddest, ddest, 4);
+  void fp_set_dirty();
+  fp_set_dirty();
 }
 
 def_EHelper(fcvt_wu_s) {
   rtl_hostcall(s, HOSTCALL_FP, ddest, dsrc1, rz, FPCALL_CMD(FPCALL_FToU32, FPCALL_W32));
   rtl_sext(s, ddest, ddest, 4);
+  void fp_set_dirty();
+  fp_set_dirty();
 }
 
 def_EHelper(fcvt_l_s) {
   rtl_hostcall(s, HOSTCALL_FP, ddest, dsrc1, rz, FPCALL_CMD(FPCALL_FToI64, FPCALL_W32));
+  void fp_set_dirty();
+  fp_set_dirty();
 }
 
 def_EHelper(fcvt_lu_s) {
   rtl_hostcall(s, HOSTCALL_FP, ddest, dsrc1, rz, FPCALL_CMD(FPCALL_FToU64, FPCALL_W32));
+  void fp_set_dirty();
+  fp_set_dirty();
 }
 
 def_EHelper(fsgnjs) {

--- a/src/isa/riscv64/instr/rvv/vcompute.h
+++ b/src/isa/riscv64/instr/rvv/vcompute.h
@@ -1180,38 +1180,26 @@ def_EHelper(vfmerge) {
 
 def_EHelper(vmfeq) {
   FLOAT_ARTHI_MASK(MFEQ)
-  void fp_set_dirty();
-  fp_set_dirty();
 }
 
 def_EHelper(vmfle) {
   FLOAT_ARTHI_MASK(MFLE)
-  void fp_set_dirty();
-  fp_set_dirty();
 }
 
 def_EHelper(vmflt) {
   FLOAT_ARTHI_MASK(MFLT)
-  void fp_set_dirty();
-  fp_set_dirty();
 }
 
 def_EHelper(vmfne) {
   FLOAT_ARTHI_MASK(MFNE)
-  void fp_set_dirty();
-  fp_set_dirty();
 }
 
 def_EHelper(vmfgt) {
   FLOAT_ARTHI_MASK(MFGT)
-  void fp_set_dirty();
-  fp_set_dirty();
 }
 
 def_EHelper(vmfge) {
   FLOAT_ARTHI_MASK(MFGE)
-  void fp_set_dirty();
-  fp_set_dirty();
 }
 
 def_EHelper(vfdiv) {

--- a/src/isa/riscv64/instr/rvv/vcompute_impl.c
+++ b/src/isa/riscv64/instr/rvv/vcompute_impl.c
@@ -1089,7 +1089,11 @@ void floating_arthimetic_instr(int opcode, int is_signed, int widening, int dest
     default: Loge("other fp type not supported"); longjmp_exception(EX_II); break;
   }
   check_vstart_exception(s);
-  if(check_vstart_ignore(s)) return;
+  if(check_vstart_ignore(s)) {
+    fp_set_dirty();
+    vp_set_dirty();
+    return;
+  }
   for(word_t idx = vstart->val; idx < vl->val; idx ++) {
     // mask
     rtlreg_t mask = get_mask(0, idx);

--- a/src/isa/riscv64/instr/rvzfa/exec.h
+++ b/src/isa/riscv64/instr/rvzfa/exec.h
@@ -54,6 +54,8 @@ def_EHelper(froundnx_d) {
 def_EHelper(fcvtmod_w_d) {
   rtl_hostcall(s, HOSTCALL_FP, ddest, dsrc1, rz, FPCALL_CMD(FPCALL_FCVTMOD, FPCALL_W64));
   rtl_sext(s, ddest, ddest, 4);
+  void fp_set_dirty();
+  fp_set_dirty();
 }
 
 def_EHelper(fleq_s) {

--- a/src/isa/riscv64/instr/rvzfh/exec.h
+++ b/src/isa/riscv64/instr/rvzfh/exec.h
@@ -124,21 +124,29 @@ def_EHelper(fcvt_h_lu) {
 def_EHelper(fcvt_w_h) {
   rtl_hostcall(s, HOSTCALL_FP, ddest, dsrc1, rz, FPCALL_CMD(FPCALL_FToI32, FPCALL_W16));
   rtl_sext(s, ddest, ddest, 4);
+  void fp_set_dirty();
+  fp_set_dirty();
 }
 
 def_EHelper(fcvt_wu_h) {
   rtl_hostcall(s, HOSTCALL_FP, ddest, dsrc1, rz, FPCALL_CMD(FPCALL_FToU32, FPCALL_W16));
   rtl_sext(s, ddest, ddest, 4);
+  void fp_set_dirty();
+  fp_set_dirty();
 }
 
 def_EHelper(fcvt_l_h) {
   rtl_hostcall(s, HOSTCALL_FP, ddest, dsrc1, rz, FPCALL_CMD(FPCALL_FToI64, FPCALL_W16));
   rtl_fsr(s, ddest, ddest, FPCALL_W64);
+  void fp_set_dirty();
+  fp_set_dirty();
 }
 
 def_EHelper(fcvt_lu_h) {
   rtl_hostcall(s, HOSTCALL_FP, ddest, dsrc1, rz, FPCALL_CMD(FPCALL_FToU64, FPCALL_W16));
   rtl_fsr(s, ddest, ddest, FPCALL_W64);
+  void fp_set_dirty();
+  fp_set_dirty();
 }
 
 


### PR DESCRIPTION
This commit also fixes a bug where fs and vs are not set to dirty when `check_vstart_ignore(s)` returns 1.