### PR TITLE
fix(mmu): incorrect tval update when delegating to VS

### DIFF
--- a/src/isa/riscv64/local-include/intr.h
+++ b/src/isa/riscv64/local-include/intr.h
@@ -92,6 +92,8 @@ bool intr_deleg_S(word_t exceptionNO);
 bool intr_deleg_VS(word_t exceptionNO);
 #ifdef CONFIG_RVH
 #define INTR_TVAL_REG(ex) (*((intr_deleg_VS(ex)) ? (word_t *)vstval :(intr_deleg_S(ex)) ? (word_t *)stval : (word_t *)mtval))
+#define INTR_TVAL2_REG(ex) (*((intr_deleg_S(ex)) ? (word_t *)htval : (word_t *)mtval2))
+#define INTR_TINST_REG(ex) (*((intr_deleg_S(ex)) ? (word_t *)htinst : (word_t *)mtinst))
 #else
 #define INTR_TVAL_REG(ex) (*((intr_deleg_S(ex)) ? (word_t *)stval : (word_t *)mtval))
 #endif


### PR DESCRIPTION
When delegating PF to VS, it should update vstval; when delegating PF to S, it should update stval; otherwise, it should update mtval. However, the previous NEMU sometimes updates vstval when delegating PF to VS. It's really strange that we did not find this bug brefore.

This patch also adds INTR_TVAL2_REG / INTR_TINST_REG macro and uses them to refractor some other codes.