### PR TITLE
refactor: remove the macro __ICS_EXPORT

### DIFF
--- a/include/rtl/pseudo.h
+++ b/include/rtl/pseudo.h
@@ -33,27 +33,16 @@ static inline def_rtl(mv, rtlreg_t* dest, const rtlreg_t *src1) {
 
 static inline def_rtl(not, rtlreg_t *dest, const rtlreg_t* src1) {
   // dest <- ~src1
-#ifdef __ICS_EXPORT
-  TODO();
-#else
   rtl_xori(s, dest, src1, -1);
-#endif
 }
 
 static inline def_rtl(neg, rtlreg_t *dest, const rtlreg_t* src1) {
   // dest <- -src1
-#ifdef __ICS_EXPORT
-  TODO();
-#else
   rtl_sub(s, dest, rz, src1);
-#endif
 }
 
 static inline def_rtl(sext, rtlreg_t* dest, const rtlreg_t* src1, int width) {
   // dest <- signext(src1[(width * 8 - 1) .. 0])
-#ifdef __ICS_EXPORT
-  TODO();
-#else
   const int word_size = sizeof(word_t);
   if (width == word_size) {
     rtl_mv(s, dest, src1);
@@ -64,14 +53,10 @@ static inline def_rtl(sext, rtlreg_t* dest, const rtlreg_t* src1, int width) {
     rtl_shli(s, dest, src1, (word_size - width) * 8);
     rtl_sari(s, dest, dest, (word_size - width) * 8);
   }
-#endif
 }
 
 static inline def_rtl(zext, rtlreg_t* dest, const rtlreg_t* src1, int width) {
   // dest <- zeroext(src1[(width * 8 - 1) .. 0])
-#ifdef __ICS_EXPORT
-  TODO();
-#else
   const int word_size = sizeof(word_t);
   if (width == word_size) {
     rtl_mv(s, dest, src1);
@@ -82,19 +67,14 @@ static inline def_rtl(zext, rtlreg_t* dest, const rtlreg_t* src1, int width) {
     rtl_shli(s, dest, src1, (word_size - width) * 8);
     rtl_shri(s, dest, dest, (word_size - width) * 8);
   }
-#endif
 }
 
 static inline def_rtl(msb, rtlreg_t* dest, const rtlreg_t* src1, int width) {
   // dest <- src1[width * 8 - 1]
-#ifdef __ICS_EXPORT
-  TODO();
-#else
   rtl_shri(s, dest, src1, width * 8 - 1);
   if (width != 4) {
     rtl_andi(s, dest, dest, 0x1);
   }
-#endif
 }
 
 static inline def_rtl(trap, vaddr_t ret_pc, word_t NO) {
@@ -104,7 +84,6 @@ static inline def_rtl(trap, vaddr_t ret_pc, word_t NO) {
 }
 static inline def_rtl(mux, rtlreg_t* dest, const rtlreg_t* cond, const rtlreg_t* src1, const rtlreg_t* src2) {
   // dest <- (cond ? src1 : src2)
-//  TODO();
   rtl_setrelopi(s, RELOP_EQ, t0, cond, 0);
   rtl_subi(s, t0, t0, 1);
   // t0 = mask

--- a/src/cpu/difftest/dut.c
+++ b/src/cpu/difftest/dut.c
@@ -34,16 +34,12 @@ static bool is_skip_ref = false;
 static int skip_dut_nr_instr = 0;
 void (*patch_fn)(void *arg) = NULL;
 static void* patch_arg = NULL;
-#ifndef __ICS_EXPORT
 static bool is_detach = false;
-#endif
 
 // this is used to let ref skip instructions which
 // can not produce consistent behavior with NEMU
 void difftest_skip_ref() {
-#ifndef __ICS_EXPORT
   if (is_detach) return;
-#endif
   is_skip_ref = true;
   // If such an instruction is one of the instruction packing in QEMU
   // (see below), we end the process of catching up with QEMU's pc to
@@ -62,9 +58,7 @@ void difftest_skip_ref() {
 //   Let REF run `nr_ref` instructions first.
 //   We expect that DUT will catch up with REF within `nr_dut` instructions.
 void difftest_skip_dut(int nr_ref, int nr_dut) {
-#ifndef __ICS_EXPORT
   if (is_detach) return;
-#endif
   skip_dut_nr_instr += nr_dut;
   while (nr_ref -- > 0) {
     ref_difftest_exec(1);
@@ -126,10 +120,8 @@ static void checkregs(CPU_state *ref, vaddr_t pc) {
 void difftest_step(vaddr_t pc, vaddr_t npc) {
   CPU_state ref_r;
 
-#ifndef __ICS_EXPORT
   if (is_detach) return;
 
-#endif
   if (skip_dut_nr_instr > 0) {
     ref_difftest_regcpy(&ref_r, DIFFTEST_TO_DUT);
     if (ref_r.pc == npc) {
@@ -162,7 +154,6 @@ void difftest_step(vaddr_t pc, vaddr_t npc) {
   // Log("run ref %lx, %lx, %ld", pc, ref_r.pc, cpu.v);
   checkregs(&ref_r, pc);
 }
-#ifndef __ICS_EXPORT
 void difftest_detach() {
   is_detach = true;
 }
@@ -174,7 +165,6 @@ void difftest_attach() {
 
   isa_difftest_attach();
 }
-#endif
 
 #else
 void init_difftest(char *ref_so_file, long img_size, int port) { }

--- a/src/device/audio.c
+++ b/src/device/audio.c
@@ -29,12 +29,9 @@ enum {
 
 static uint8_t *sbuf = NULL;
 static uint32_t *audio_base = NULL;
-#ifndef __ICS_EXPORT
 static int tail = 0;
-#endif
 
 static inline void audio_play(void *userdata, uint8_t *stream, int len) {
-#ifndef __ICS_EXPORT
   int nread = len;
   int count = audio_base[reg_count];
   if (count < len) nread = count;
@@ -50,11 +47,9 @@ static inline void audio_play(void *userdata, uint8_t *stream, int len) {
   }
   audio_base[reg_count] -= nread;
   if (len > nread) memset(stream + nread, 0, len - nread);
-#endif
 }
 
 static void audio_io_handler(uint32_t offset, int len, bool is_write) {
-#ifndef __ICS_EXPORT
   if (offset == reg_init * sizeof(uint32_t) && len == 4 && is_write) {
     SDL_AudioSpec s = {};
     s.freq = audio_base[reg_freq];
@@ -70,7 +65,6 @@ static void audio_io_handler(uint32_t offset, int len, bool is_write) {
     SDL_OpenAudio(&s, NULL);
     SDL_PauseAudio(0);
   }
-#endif
 }
 
 void init_audio() {
@@ -78,9 +72,7 @@ void init_audio() {
   audio_base = (uint32_t *)new_space(space_size);
   add_pio_map ("audio", CONFIG_AUDIO_CTL_PORT, audio_base, space_size, audio_io_handler);
   add_mmio_map("audio", CONFIG_AUDIO_CTL_MMIO, audio_base, space_size, audio_io_handler);
-#ifndef __ICS_EXPORT
   audio_base[reg_sbuf_size] = CONFIG_SB_SIZE;
-#endif
 
   sbuf = (uint8_t *)new_space(CONFIG_SB_SIZE);
   add_mmio_map("audio-sbuf", CONFIG_SB_ADDR, sbuf, CONFIG_SB_SIZE, NULL);

--- a/src/device/disk.c
+++ b/src/device/disk.c
@@ -32,7 +32,6 @@ static uint32_t *disk_base = NULL;
 static FILE *fp = NULL;
 
 static void disk_io_handler(uint32_t offset, int len, bool is_write) {
-#ifndef __ICS_EXPORT
   if (offset == CMD * sizeof(uint32_t) && len == 4 && is_write) {
     assert(disk_base[CMD] == 0);
     fseek(fp, disk_base[START] * 512, SEEK_SET);
@@ -46,7 +45,6 @@ static void disk_io_handler(uint32_t offset, int len, bool is_write) {
     assert(ret == 1);
     #endif
   }
-#endif
 }
 
 void init_disk() {

--- a/src/device/intr.c
+++ b/src/device/intr.c
@@ -16,7 +16,5 @@
 #include <isa.h>
 
 void dev_raise_intr() {
-#ifndef __ICS_EXPORT
   cpu.INTR = true;
-#endif
 }

--- a/src/device/vga.c
+++ b/src/device/vga.c
@@ -51,15 +51,12 @@ static inline void update_screen() {
 #endif
 
 void vga_update_screen() {
-#ifdef __ICS_EXPORT
-  // TODO: call `update_screen()` when the sync register is non-zero,
+  // call `update_screen()` when the sync register is non-zero,
   // then zero out the sync register
-#else
   if (vgactl_port_base[1]) {
     IFDEF(CONFIG_VGA_SHOW_SCREEN, update_screen());
     vgactl_port_base[1] = 0;
   }
-#endif
 }
 
 void init_vga() {

--- a/src/memory/vaddr.c
+++ b/src/memory/vaddr.c
@@ -28,7 +28,6 @@
 #include <memory/host-tlb.h>
 #include <cpu/decode.h>
 
-#ifndef __ICS_EXPORT
 #ifndef ENABLE_HOSTTLB
 
 static paddr_t vaddr_trans_and_check_exception(vaddr_t vaddr, int len, int type, bool* exp) {
@@ -144,7 +143,6 @@ static void vaddr_mmu_write(struct Decode *s, vaddr_t addr, int len, word_t data
   }
 }
 #endif
-#endif
 
 static inline word_t vaddr_read_internal(void *s, vaddr_t addr, int len, int type, int mmu_mode) {
   void isa_misalign_data_addr_check(vaddr_t vaddr, int len, int type);
@@ -159,7 +157,6 @@ static inline word_t vaddr_read_internal(void *s, vaddr_t addr, int len, int typ
     Logm("Paddr reading directly");
     return paddr_read(addr, len, type, type, cpu.mode, addr);
   }
-#ifndef __ICS_EXPORT
 #ifdef CONFIG_RVH
   if(type != MEM_TYPE_IFETCH){
     extern int rvh_hlvx_check(struct Decode *s, int type);
@@ -167,7 +164,6 @@ static inline word_t vaddr_read_internal(void *s, vaddr_t addr, int len, int typ
   }
 #endif
   return MUXDEF(ENABLE_HOSTTLB, hosttlb_read, vaddr_mmu_read) ((struct Decode *)s, addr, len, type);
-#endif
   return 0;
 }
 
@@ -224,9 +220,7 @@ void vaddr_write(struct Decode *s, vaddr_t addr, int len, word_t data, int mmu_m
     paddr_write(addr, len, data, cpu.mode, addr);
     return;
   }
-#ifndef __ICS_EXPORT
   MUXDEF(ENABLE_HOSTTLB, hosttlb_write, vaddr_mmu_write) (s, addr, len, data);
-#endif
 }
 
 word_t vaddr_read_safe(vaddr_t addr, int len) {

--- a/src/monitor/ui.c
+++ b/src/monitor/ui.c
@@ -17,11 +17,9 @@
 #include <isa.h>
 #include <utils.h>
 #include <cpu/cpu.h>
-#ifndef __ICS_EXPORT
 #include <memory/paddr.h>
 #include <memory/vaddr.h>
 #include <cpu/difftest.h>
-#endif
 
 #ifndef CONFIG_SHARE
 #include <stdlib.h>
@@ -56,7 +54,6 @@ static int cmd_c(char *args) {
   return 0;
 }
 
-#ifndef __ICS_EXPORT
 static int cmd_si(char *args) {
   /* extract the first argument */
   char *arg = strtok(NULL, " ");
@@ -212,8 +209,6 @@ static int cmd_load(char *args) {
 #else
 #endif
 
-#endif
-
 static int cmd_q(char *args) {
   return -1;
 }
@@ -227,7 +222,6 @@ static struct {
 } cmd_table [] = {
   { "help", "Display information about all supported commands", cmd_help },
   { "c", "Continue the execution of the program", cmd_c },
-#ifndef __ICS_EXPORT
   { "si", "step", cmd_si },
   { "info", "info r - print register values; info w - show watch point state", cmd_info },
   { "x", "Examine memory", cmd_x },
@@ -239,7 +233,6 @@ static struct {
   { "attach", "attach diff test", cmd_attach },
   { "save", "save snapshot", cmd_save },
   { "load", "load snapshot", cmd_load },
-#endif
 #endif
   { "q", "Exit NEMU", cmd_q },
 

--- a/src/monitor/watchpoint.c
+++ b/src/monitor/watchpoint.c
@@ -14,9 +14,7 @@
 ***************************************************************************************/
 
 #include <common.h>
-#ifndef __ICS_EXPORT
 #include <stdlib.h>
-#endif
 
 #define NR_WP 32
 
@@ -26,10 +24,8 @@ typedef struct watchpoint {
 
   /* TODO: Add more members if necessary */
 
-#ifndef __ICS_EXPORT
   char *expr;
   word_t old_val;
-#endif
 } WP;
 
 static WP wp_pool[NR_WP] = {};
@@ -49,7 +45,6 @@ void init_wp_pool() {
 
 /* TODO: Implement the functionality of watchpoint */
 
-#ifndef __ICS_EXPORT
 static WP* new_WP() {
   assert(free_ != NULL);
   WP *p = free_;
@@ -120,4 +115,3 @@ void scan_watchpoint(vaddr_t pc) {
     }
   }
 }
-#endif

--- a/src/utils/expr.c
+++ b/src/utils/expr.c
@@ -14,10 +14,8 @@
 ***************************************************************************************/
 
 #include <isa.h>
-#ifndef __ICS_EXPORT
 #include <memory/vaddr.h>
 #include <stdlib.h>
-#endif
 
 /* We use the POSIX regex functions to process regular expressions.
  * Type 'man regex' for more information about POSIX regex functions.
@@ -29,9 +27,7 @@ enum {
 
   /* TODO: Add more token types */
 
-#ifndef __ICS_EXPORT
   TK_NEQ, TK_OR, TK_AND, TK_NUM, TK_REG, TK_REF, TK_NEG
-#endif
 };
 
 static struct rule {
@@ -46,7 +42,6 @@ static struct rule {
   {" +", TK_NOTYPE},    // spaces
   {"\\+", '+'},         // plus
   {"==", TK_EQ},        // equal
-#ifndef __ICS_EXPORT
   {"0x[0-9a-fA-F]{1,16}", TK_NUM},  // hex
   {"[0-9]{1,10}", TK_NUM},         // dec
   {"\\$[a-z0-9]{1,31}", TK_REG},   // register names
@@ -62,7 +57,6 @@ static struct rule {
   {"!", '!'},
   {"\\(", '('},
   {"\\)", ')'}
-#endif
 };
 
 #define NR_REGEX ARRLEN(rules)
@@ -108,13 +102,8 @@ static bool make_token(char *e) {
         char *substr_start = e + position;
         int substr_len = pmatch.rm_eo;
 
-#ifdef __ICS_EXPORT
-        Log("match rules[%d] = \"%s\" at position %d with len %d: %.*s",
-            i, rules[i].regex, position, substr_len, substr_len, substr_start);
-#else
         //Log("match rules[%d] = \"%s\" at position %d with len %d: %.*s",
         //    i, rules[i].regex, position, substr_len, substr_len, substr_start);
-#endif
 
         position += substr_len;
 
@@ -124,15 +113,11 @@ static bool make_token(char *e) {
          */
 
         switch (rules[i].token_type) {
-#ifdef __ICS_EXPORT
-          default: TODO();
-#else
           case TK_NOTYPE: break;
           case TK_NUM:
           case TK_REG: sprintf(tokens[nr_token].str, "%.*s", substr_len, substr_start);
           default: tokens[nr_token].type = rules[i].token_type;
                    nr_token ++;
-#endif
         }
 
         break;
@@ -148,7 +133,6 @@ static bool make_token(char *e) {
   return true;
 }
 
-#ifndef __ICS_EXPORT
 static int op_prec(int t) {
   switch (t) {
     case '!': case TK_NEG: case TK_REF: return 0;
@@ -263,20 +247,12 @@ static rtlreg_t eval(int s, int e, bool *success) {
     }
   }
 }
-#endif
 
 word_t expr(char *e, bool *success) {
   if (!make_token(e)) {
     *success = false;
     return 0;
   }
-
-  /* TODO: Insert codes to evaluate the expression. */
-#ifdef __ICS_EXPORT
-  TODO();
-
-  return 0;
-#else
 
   /* Detect TK_REF and TK_NEG tokens */
   int i;
@@ -310,5 +286,4 @@ word_t expr(char *e, bool *success) {
   }
 
   return eval(0, nr_token - 1, success);
-#endif
 }

--- a/tools/gen-expr/gen-expr.c
+++ b/tools/gen-expr/gen-expr.c
@@ -31,11 +31,6 @@ static char *code_format =
 "  return 0; "
 "}";
 
-#ifdef __ICS_EXPORT
-static inline void gen_rand_expr() {
-  buf[0] = '\0';
-}
-#else
 static char *pbuf;
 
 #define format_buf(fmt, ...) pbuf += sprintf(pbuf, fmt, ##__VA_ARGS__)
@@ -100,7 +95,6 @@ void remove_u(char *p) {
     strcpy(q, code_buf);
   }
 }
-#endif
 
 int main(int argc, char *argv[]) {
   int seed = time(0);
@@ -111,10 +105,8 @@ int main(int argc, char *argv[]) {
   }
   int i;
   for (i = 0; i < loop; i ++) {
-#ifndef __ICS_EXPORT
     nr_op = 0;
     pbuf = buf;
-#endif
     gen_rand_expr();
 
     sprintf(code_buf, code_format, buf);
@@ -132,14 +124,10 @@ int main(int argc, char *argv[]) {
 
     int result;
     fscanf(fp, "%d", &result);
-#ifndef __ICS_EXPORT
     ret = pclose(fp);
     if (ret != 0) continue;
 
     remove_u(buf);
-#else
-    pclose(fp);
-#endif
 
     printf("%u %s\n", result, buf);
   }


### PR DESCRIPTION
The __ICS_EXPORT macro is used to generate the code framework for ICS course of NJU. Since the OpenXiangShan/NEMU no longer undertakes this task, this macro could be removed.

This patch only removed the __ICS_EXPORT in public and riscv64 codes, because riscv32, mips and x86 are excepted to be deprecated in the feature.