### PR TITLE
fix(store_queue): clear the queue when init_mem

### DIFF
--- a/include/memory/store_queue_wrapper.h
+++ b/include/memory/store_queue_wrapper.h
@@ -10,6 +10,7 @@
 extern "C" {
 #endif
 
+void store_queue_reset();
 void store_queue_push(store_commit_t store_commit);
 void store_queue_pop();
 store_commit_t store_queue_fornt();

--- a/src/memory/paddr.c
+++ b/src/memory/paddr.c
@@ -146,7 +146,7 @@ static inline void raise_read_access_fault(int type, vaddr_t vaddr) {
   if (type == MEM_TYPE_IFETCH || type == MEM_TYPE_IFETCH_READ) {
     cause = EX_IAF;
   } else if (cpu.amo || type == MEM_TYPE_WRITE || type == MEM_TYPE_WRITE_READ) {
-    cause = EX_SAF; 
+    cause = EX_SAF;
   }
   raise_access_fault(cause, vaddr);
 }
@@ -187,6 +187,11 @@ void allocate_memory_with_mmap()
 
 void init_mem() {
   allocate_memory_with_mmap();
+
+#ifdef CONFIG_DIFFTEST_STORE_COMMIT
+  store_queue_reset();
+#endif
+
 #ifdef CONFIG_MEM_RANDOM
   srand(time(0));
   uint32_t *p = (uint32_t *)pmem;
@@ -572,5 +577,3 @@ void dump_pmem() {
   }
   fwrite(pmem, sizeof(char), MEMORY_SIZE, fp);
 }
-
-

--- a/src/memory/store_queue_wrapper.cpp
+++ b/src/memory/store_queue_wrapper.cpp
@@ -6,6 +6,10 @@
 
 std::queue<store_commit_t> cpp_store_event_queue;
 
+void store_queue_reset() {
+  cpp_store_event_queue = {};
+}
+
 void store_queue_push(store_commit_t store_commit) {
   cpp_store_event_queue.push(store_commit);
 }


### PR DESCRIPTION
This commit adds the reset function for the store queue. It is called during init_mem.