### PR TITLE
fix(device): init_flash should be called only once

### DIFF
--- a/src/cpu/difftest/ref.c
+++ b/src/cpu/difftest/ref.c
@@ -20,9 +20,7 @@
 #include <cpu/cpu.h>
 #include <difftest.h>
 
-extern void init_flash();
 extern void load_flash_contents(const char *flash_img);
-
 
 #ifdef CONFIG_LARGE_COPY
 #ifndef CONFIG_USE_SPARSEMM
@@ -107,7 +105,6 @@ void difftest_load_flash(void *flash_bin, size_t f_size){
   printf("nemu does not enable flash fetch!\n");
 #else
   load_flash_contents((const char *)flash_bin);
-  init_flash();
 #endif
 }
 

--- a/src/device/device.c
+++ b/src/device/device.c
@@ -94,9 +94,9 @@ void init_device() {
   IFDEF(CONFIG_HAS_AUDIO, init_audio());
   IFDEF(CONFIG_HAS_DISK, init_disk());
   IFDEF(CONFIG_HAS_SDCARD, init_sdcard());
+  IFDEF(CONFIG_HAS_FLASH, init_flash());
 #ifndef CONFIG_SHARE
   IFDEF(CONFIG_HAS_FLASH, load_flash_contents(CONFIG_FLASH_IMG_PATH));
-  IFDEF(CONFIG_HAS_FLASH, init_flash());
 #endif
 
 #ifndef CONFIG_SHARE


### PR DESCRIPTION
init_flash should be put in init_device and called only once during multiple difftest runs. At every difftest run, only load_flash_contents should be called.