### PR TITLE
fix(flash): use mmap to create the io space

### DIFF
--- a/src/device/flash.c
+++ b/src/device/flash.c
@@ -52,7 +52,6 @@ void load_flash_contents(const char *flash_img) {
       "img size %d is larger than flash size %d",
       size, CONFIG_FLASH_SIZE
     );
-    flash_base = new_space(CONFIG_FLASH_SIZE);
     ret = fread(flash_base, 1, size, fp);
     fclose(fp);
   }


### PR DESCRIPTION
The flash device is registered when `add_mmio_map` is called with the space pointer. The space pointer is fixed after this registration. However, there is a wrong `new_space` call when `flash_img` is not defined, which updates the flash space pointer. The flash contents are thus incorrectly loaded to the new pointer. However, the IO device table still uses the legacy pointer.

This commits fix it by using the mmap allocator and the fixed flash_base pointer.