### PR TITLE
fix(trigger): extern label should not be inside switch case block.

### DIFF
--- a/src/isa/riscv64/system/trigger.c
+++ b/src/isa/riscv64/system/trigger.c
@@ -315,7 +315,6 @@ bool trigger_reentrancy_check() {
 }
 
 void trigger_handler(const trig_type_t type, const trig_action_t action, word_t tval) {
-  extern Decode *prev_s;
   switch (action) {
     case TRIG_ACTION_NONE: /* no trigger hit, do nothing */; break;
     case TRIG_ACTION_BKPT_EXCPT:
@@ -325,8 +324,10 @@ void trigger_handler(const trig_type_t type, const trig_action_t action, word_t 
           if (!trigger_reentrancy_check()) {
             break;
           }
-        case TRIG_TYPE_ICOUNT:
+        case TRIG_TYPE_ICOUNT: {
+          extern Decode *prev_s;
           prev_s->pc = cpu.pc;
+        }
         case TRIG_TYPE_MCONTROL:
         case TRIG_TYPE_MCONTROL6:
           trigger_action = action;

--- a/src/isa/riscv64/system/trigger.c
+++ b/src/isa/riscv64/system/trigger.c
@@ -315,6 +315,7 @@ bool trigger_reentrancy_check() {
 }
 
 void trigger_handler(const trig_type_t type, const trig_action_t action, word_t tval) {
+  extern Decode *prev_s;
   switch (action) {
     case TRIG_ACTION_NONE: /* no trigger hit, do nothing */; break;
     case TRIG_ACTION_BKPT_EXCPT:
@@ -325,7 +326,6 @@ void trigger_handler(const trig_type_t type, const trig_action_t action, word_t 
             break;
           }
         case TRIG_TYPE_ICOUNT:
-          extern Decode *prev_s;
           prev_s->pc = cpu.pc;
         case TRIG_TYPE_MCONTROL:
         case TRIG_TYPE_MCONTROL6:


### PR DESCRIPTION
`extern Decode *prev_s;` inside a switch case block, which is not allowed because it is a declaration and not an executable statement.