### PR TITLE
fix(mmu): paddr for root page table entries in Sv48x4

### DIFF
--- a/src/isa/riscv64/system/mmu.c
+++ b/src/isa/riscv64/system/mmu.c
@@ -57,8 +57,8 @@ static inline uintptr_t VPNi(vaddr_t va, int i) {
   return (va >> VPNiSHFT(i)) & VPNMASK;
 }
 #ifdef CONFIG_RVH
-static inline uintptr_t GVPNi(vaddr_t va, int i) {
-  return (i == 2)?  (va >> VPNiSHFT(i)) & GPVPNMASK : (va >> VPNiSHFT(i)) & VPNMASK;
+static inline uintptr_t GVPNi(vaddr_t va, int i, int max_level) {
+  return (i == max_level - 1)?  (va >> VPNiSHFT(i)) & GPVPNMASK : (va >> VPNiSHFT(i)) & VPNMASK;
 }
 bool hlvx = 0;
 bool hld_st = 0;
@@ -198,7 +198,7 @@ paddr_t gpa_stage(paddr_t gpaddr, vaddr_t vaddr, int type, int trap_type, bool i
   word_t p_pte;
   PTE pte;
   for (level = max_level - 1; level >= 0; ) {
-    p_pte = pg_base + GVPNi(gpaddr, level) * PTE_SIZE;
+    p_pte = pg_base + GVPNi(gpaddr, level, max_level) * PTE_SIZE;
     pte.val	= paddr_read(p_pte, PTE_SIZE,
     type == MEM_TYPE_IFETCH ? MEM_TYPE_IFETCH_READ :
     type == MEM_TYPE_WRITE ? MEM_TYPE_WRITE_READ : MEM_TYPE_READ, trap_type, MODE_S, vaddr);


### PR DESCRIPTION
The RISC-V Hypervisor extension introduces Sv39x4/Sv48x4 translation scheme, in which the virtual page number (VPN) of the root page table is widened by 2 bits. For Sv39x4, VPN[2] is widened, while for Sv48x4, VPN[3] is widened. This should be handled when NEMU is generating the physical address for G-stage PTEs.

In our earlier implementation of Sv48/Sv48x4 support, we overlooked the handling of the GVPNi function. This oversight led to incorrect PTE address calculations at levels 2 and 3 for Sv48x4. This patch resolves the issue.