### PR TITLE
fix(cpu-exec): record last insts when PERF_OPT disabled

### DIFF
--- a/src/cpu/cpu-exec.c
+++ b/src/cpu/cpu-exec.c
@@ -579,6 +579,7 @@ static int execute(int n) {
     }
 #endif // CONFIG_LIGHTQS_DEBUG
 #endif // CONFIG_BR_LOG
+    IFDEF(CONFIG_IQUEUE, iqueue_commit(s.pc, (void *)&s.isa.instr.val, s.snpc - s.pc));
     IFDEF(CONFIG_DEBUG, debug_hook(s.pc, s.logbuf));
     IFDEF(CONFIG_DIFFTEST, difftest_step(s.pc, cpu.pc));
     if (isa_query_intr() != INTR_EMPTY) {


### PR DESCRIPTION
Perviously, function iqueue_commit is only called in perf_opt exec(). This caused that the record last insts function does not work when PERF_OPT.