### PR TITLE
fix(store_event): Undefined Behavior that shift

### DIFF
--- a/include/cpu/difftest.h
+++ b/include/cpu/difftest.h
@@ -72,11 +72,12 @@ static inline bool difftest_check_store(vaddr_t pc) {
 
     uint64_t dut_data = dut.data;
     uint64_t dut_addr = dut.addr;
+    uint8_t  dut_mask = dut.mask;
 
     if (ref_difftest_store_commit(&dut.addr, &dut.data, &dut.mask)) {
       Log("\n\t,is different memory executing instruction at pc = " FMT_WORD,pc);
-      Log(",ref addr = " FMT_WORD ", data = " FMT_WORD "\n\t dut addr = " FMT_WORD ", data = " FMT_WORD
-          ,dut.addr, dut.data, dut_addr, dut_data);
+      Log(",ref addr = " FMT_WORD ", data = " FMT_WORD ", mask = 0x%x" "\n\t dut addr = " FMT_WORD ", data = " FMT_WORD ", mask = 0x%x"
+          ,dut.addr, dut.data, dut.mask, dut_addr, dut_data, dut_mask);
       return false;
     }
 #ifdef CONFIG_RVV


### PR DESCRIPTION
In the specification, ` greater than or equal to the width of the promoted left operand, the behavior is undefined.`

In `gcc version 11.4.0 (Ubuntu 11.4.0-1ubuntu1~22.04)`, this may work correctly when using O2 optimization, but when using -O0, shifting left past the bit width of the data type will cause a loop.

![image](https://github.com/user-attachments/assets/b1544a5d-3c62-4505-a292-28e0c08ed365)

The mask is involved in the store check, so we need to print the mask out for debugging.