### PR TITLE
feat(profiling): record instr count as base

### DIFF
--- a/include/profiling/profiling_control.h
+++ b/include/profiling/profiling_control.h
@@ -21,6 +21,7 @@ extern int checkpoint_state;
 extern bool checkpoint_restoring;
 extern uint64_t checkpoint_interval;
 extern uint64_t warmup_interval;
+extern uint64_t checkpoint_icount_base;
 
 extern bool recvd_manual_oneshot_cpt;
 extern bool recvd_manual_uniform_cpt;
@@ -30,6 +31,6 @@ extern bool force_cpt_mmode;
 extern bool workload_loaded;
 extern bool donot_skip_boot;
 
-void reset_inst_counters();
+void start_profiling();
 
 #endif // __PROFILING_CONTROL_H__

--- a/src/cpu/cpu-exec.c
+++ b/src/cpu/cpu-exec.c
@@ -234,7 +234,9 @@ static inline void debug_difftest(Decode *_this, Decode *next) {
 
 #ifndef CONFIG_SHARE
 uint64_t per_bb_profile(Decode *prev_s, Decode *s, bool control_taken) {
-  uint64_t abs_inst_count = get_abs_instr_count();
+  // checkpoint_icount_base is set from nemu_trap.
+  // Profiling and checkpointing use this as the starting point for instruction counting.
+  uint64_t abs_inst_count = get_abs_instr_count() - checkpoint_icount_base;
   // workload_loaded set from nemu_trap
   if (profiling_state == SimpointProfiling && (workload_loaded||donot_skip_boot)) {
     simpoint_profiling(prev_s->pc, true, abs_inst_count);

--- a/src/isa/riscv64/instr/special.h
+++ b/src/isa/riscv64/instr/special.h
@@ -43,7 +43,7 @@ def_EHelper(nemu_trap) {
       difftest_skip_ref();
   } else if (cpu.gpr[10]._64 == 0x101) {
     if (!workload_loaded) {
-      reset_inst_counters();
+      start_profiling();
       difftest_skip_ref();
     }
   } else {

--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -73,7 +73,7 @@ void sig_handler(int signum) {
       recvd_manual_oneshot_cpt = true;
     } else if (checkpoint_state==ManualUniformCheckpointing) {
       recvd_manual_uniform_cpt = true;
-      reset_inst_counters();
+      start_profiling();
     } else {
       panic("Received SIGINT when not waiting for it");
     }

--- a/src/profiling/profiling_control.c
+++ b/src/profiling/profiling_control.c
@@ -6,6 +6,7 @@ bool checkpoint_taking = false;
 bool checkpoint_restoring = false;
 uint64_t checkpoint_interval = 0;
 uint64_t warmup_interval = 0;
+uint64_t checkpoint_icount_base = 0;
 
 bool recvd_manual_oneshot_cpt = false;
 bool recvd_manual_uniform_cpt = false;
@@ -15,12 +16,11 @@ bool force_cpt_mmode = false;
 bool donot_skip_boot=false;
 bool workload_loaded=false;
 
-void reset_inst_counters() {
-  extern uint64_t g_nr_guest_instr;
-  extern bool workload_loaded;
-  Log("Start profiling, resetting inst count from %lu to 1, (n_remain_total will not be cleared)\n", g_nr_guest_instr);
-  g_nr_guest_instr = 1;
+void start_profiling() {
   workload_loaded=true;
+  uint64_t get_abs_instr_count();
+  checkpoint_icount_base = get_abs_instr_count();
+  Log("Start profiling. Setting inst count base to Current inst count %lu.", checkpoint_icount_base);
 }
 
 #ifdef CONFIG_SHARE


### PR DESCRIPTION
Previously, the global instruction counter variable (g_nr_guest_instr) would be reset to 1 when executing nemu_trap 0x101 (start profiling) or receiving ctrl-c signal to start checkpointing, so that profiling and profiling mechanism could create checkpoints in specified intervals.

However, g_nr_guest_instr is a very important variable, which are and will be used in CSRs (minstret, mtime, mcycle) and timer device (clint). It's not good to reset it during running.

This patch modifies the original reset_inst_counters(): it now records current instr count as base with get_abs_instr_count(), and rename the function to start_profiling(). per_bb_profile() is also modified to use the difference between origin count and base as new instr count.