### PR TITLE
fix(dbltrp): fix sdt/sie interaction logic

### DIFF
--- a/src/isa/riscv64/system/priv.c
+++ b/src/isa/riscv64/system/priv.c
@@ -1647,7 +1647,7 @@ static void csr_write(uint32_t csrid, word_t src) {
       write_sdt = new_val.sdt;
       if (menvcfg->dte == 0 ) {
         sstatus_wmask &= ~SSTATUS_SDT;
-        write_sdt = 0;
+        write_sdt = mstatus->sdt;
       }
 #endif //CONFIG_RV_SSDBLTRP
       mstatus->val = mask_bitset(mstatus->val, sstatus_wmask, new_val.val); // xiangshan pass mstatus.rdata ,so clear mstatus->sdt


### PR DESCRIPTION
This pr fix sdt/sie interaction logic:
  For the write behavior of `mstatus/vsstatus.sdt`, since it is directly written, the `sdt` field in `new_val` can be used to determine whether to write `sdt` and affect `sie`. For the write behavior of `sstatus.sdt`, due to changes in the write mask when `DTEclose` is enabled, the original value of `sstatus.sdt` must be considered for its impact on `sie` when `new_val.sdt` cannot be written.