### PR TITLE
fix(cpu-exec): flush tcache when intr/excp happens

### DIFF
--- a/src/cpu/cpu-exec.c
+++ b/src/cpu/cpu-exec.c
@@ -665,7 +665,8 @@ void cpu_exec(uint64_t n) {
       IFDEF(CONFIG_TDATA1_ETRIGGER, trig_action_t action = check_triggers_etrigger(cpu.TM, g_ex_cause));
       cpu.pc = raise_intr(g_ex_cause, prev_s->pc);
       cpu.amo = false; // clean up
-      IFDEF(CONFIG_PERF_OPT, tcache_handle_exception(cpu.pc));
+      // It's necessary to flush tcache for exception: addr space may conflict in different priv/mmu mode.
+      IFDEF(CONFIG_PERF_OPT, tcache_handle_flush(cpu.pc));
       IFDEF(CONFIG_TDATA1_ETRIGGER, trigger_handler(TRIG_TYPE_ETRIG, action, 0));
       IFDEF(CONFIG_SHARE, break);
     } else {
@@ -678,9 +679,10 @@ void cpu_exec(uint64_t n) {
 #endif // CONFIG_TDATA1_ICOUNT
         IFDEF(CONFIG_TDATA1_ITRIGGER, trig_action_t itrigger_action = check_triggers_itrigger(cpu.TM, intr));
         cpu.pc = raise_intr(intr, cpu.pc);
+        // It's necessary to flush tcache for interrupt: addr space may conflict in different priv/mmu mode.
+        IFDEF(CONFIG_PERF_OPT, tcache_handle_flush(cpu.pc));
         IFDEF(CONFIG_TDATA1_ITRIGGER, trigger_handler(TRIG_TYPE_ITRIG, itrigger_action, 0));
         IFDEF(CONFIG_DIFFTEST, ref_difftest_raise_intr(intr));
-        IFDEF(CONFIG_PERF_OPT, tcache_handle_exception(cpu.pc));
       }
     }
 

--- a/src/isa/riscv64/system/intr.c
+++ b/src/isa/riscv64/system/intr.c
@@ -15,7 +15,6 @@
 ***************************************************************************************/
 
 #include <cpu/difftest.h>
-#include <cpu/cpu.h>
 #include "../local-include/trigger.h"
 #include "../local-include/csr.h"
 #include "../local-include/intr.h"
@@ -207,7 +206,6 @@ word_t raise_intr(word_t NO, vaddr_t epc) {
       hstatus->spvp = cpu.mode;
     }
     cpu.v = 0;
-    set_sys_state_flag(SYS_STATE_FLUSH_TCACHE);
 #else
   bool vs_EX_DT = false;
   if (delegS && !s_EX_DT) {
@@ -266,7 +264,7 @@ word_t raise_intr(word_t NO, vaddr_t epc) {
     bool is_mem_access_virtual = mstatus->mprv && mstatus->mpv && (mstatus->mpp != MODE_M);
     mstatus->gva = gen_gva(NO, hld_st_temp, is_mem_access_virtual);
     mstatus->mpv = cpu.v;
-    cpu.v = 0;set_sys_state_flag(SYS_STATE_FLUSH_TCACHE);
+    cpu.v = 0;
 #endif
     mcause->val = NO;
     mepc->val = epc;


### PR DESCRIPTION
Tcache of NEMU does not store the privilege mode or mmu mode for ifetch. If privilege mode changes and tcache is not flushed, tcache may return an incorrect basic block.

This won't be a problem before, as software of M/S/U mode always uses different address space. But after introducing hypervisor extension, S and VS mode software, U and VU mode software are likely to use same address space.

Previous PR #133 gave a fix that happens to work. It set_sys_state_flag (SYS_STATE_FLUSH_TCACHE) in raise_intr(). However, this flag won't flush tcache until next priv instruction.

Coincidentally, the first instruction of interrupt/exception handler is usually an csrrw tp, CSR_SCRATCH, tp, which is an priv instruction and is always the same in different OSs. This makes NEMU error free in most situations.

This patch revert some fix in #133, and ask tcache flush in cpu_exec() when trapping at interrupt or exception. For returning from trap, it is resolved in previous PR #133 (mret), #414 (sret).