### PR TITLE
fix(rtl): incorrect usage of rtl_jr in other rtl

### DIFF
--- a/include/rtl/pseudo.h
+++ b/include/rtl/pseudo.h
@@ -80,8 +80,8 @@ static inline def_rtl(msb, rtlreg_t* dest, const rtlreg_t* src1, int width) {
 static inline def_rtl(trap, vaddr_t ret_pc, word_t NO) {
   rtl_li(s, t0, ret_pc);
   rtl_hostcall(s, HOSTCALL_TRAP, t0, t0, NULL, NO);
-  rtl_jr(s, t0);
 }
+
 static inline def_rtl(mux, rtlreg_t* dest, const rtlreg_t* cond, const rtlreg_t* src1, const rtlreg_t* src2) {
   // dest <- (cond ? src1 : src2)
   rtl_setrelopi(s, RELOP_EQ, t0, cond, 0);

--- a/src/engine/interpreter/rtl-basic.h
+++ b/src/engine/interpreter/rtl-basic.h
@@ -188,7 +188,10 @@ extern void simpoint_profiling(uint64_t pc, bool is_control, uint64_t abs_instr_
 #endif // CONFIG_SHARE
 extern uint64_t get_abs_instr_count();
 
-
+// This rtl_j is only used in normal mode.
+// rtl_j for PERF_OPT is defined as a marco in cpu-exec.c
+// Note: rtl_j can ONLY be called directly in EHelper.
+#ifndef CONFIG_PERF_OPT
 static inline def_rtl(j, vaddr_t target) {
   // uint64_t orig_pc = cpu.pc, real_target;
 #ifdef CONFIG_GUIDED_EXEC
@@ -219,7 +222,12 @@ end_of_rtl_j:
 ; // make compiler happy
 #endif
 }
+#endif // ndef CONFIG_PERF_OPT
 
+// This rtl_jr is only used in normal mode.
+// rtl_jr for PERF_OPT is defined as a marco in cpu-exec.c
+// Note: rtl_jr can ONLY be called directly in EHelper.
+#ifndef CONFIG_PERF_OPT
 static inline def_rtl(jr, rtlreg_t *target) {
 #ifdef CONFIG_BR_LOG
   uint64_t real_target;
@@ -257,13 +265,19 @@ end_of_rtl_jr:
 
   IFDEF(CONFIG_BR_LOG, br_log_commit(s->pc, real_target, 1, BR_JUMP));
 }
+#endif // ndef CONFIG_PERF_OPT
 
+// This rtl_jrelop is only used in normal mode.
+// rtl_jrelop for PERF_OPT is defined as a marco in cpu-exec.c
+// Note: rtl_jrelop can ONLY be called directly in EHelper.
+#ifndef CONFIG_PERF_OPT
 static inline def_rtl(jrelop, uint32_t relop,
     const rtlreg_t *src1, const rtlreg_t *src2, vaddr_t target) {
   bool is_jmp = interpret_relop(relop, *src1, *src2);
   IFDEF(CONFIG_BR_LOG, br_log_commit(s->pc, target, is_jmp, BR_BRANCH));
   rtl_j(s, (is_jmp ? target : s->snpc));
 }
+#endif // ndef CONFIG_PERF_OPT
 
 //#include "rtl-fp.h"
 #endif

--- a/src/isa/mips32/instr/system.h
+++ b/src/isa/mips32/instr/system.h
@@ -17,6 +17,7 @@
 
 def_EHelper(syscall) {
   rtl_trap(s, s->pc, EX_SYSCALL);
+  rtl_priv_jr(s, t0);
 }
 
 def_EHelper(eret) {


### PR DESCRIPTION
rtl_j, rtl_jr and rtl_jrelop are special rtl that could not only change guest's (workload's) execution flow but also affect host's (NEMU's) execution flow. They are defined seperately in PERF_OPT mode (as marcos in cpu-exec.c) and normal mode (as functions in rtl-basic.h). They are restricted to being used only directly within EHelper.

rtl_trap contained some legacy code where `rtl_jr` was used incorrectly. This patch removes that improper usages of rtl_jr. Each call to rtl_trap are reviewed to make sure its functionality remains unaffected. Now, every EHelper that calls rtl_trap also calls rtl_priv_jr afterward. (Although mips32 has already been broken and abandoned, a rtl_priv_jr is added to EHelper of syscall to keep consistency)