### PR TITLE
fix(profiling): subtract base from instr count

### DIFF
--- a/src/engine/interpreter/rtl-basic.h
+++ b/src/engine/interpreter/rtl-basic.h
@@ -210,7 +210,7 @@ static inline def_rtl(j, vaddr_t target) {
 
 #ifndef CONFIG_SHARE
   if (profiling_state == SimpointProfiling && workload_loaded) {
-    simpoint_profiling(cpu.pc, true, get_abs_instr_count());
+    simpoint_profiling(cpu.pc, true, get_abs_instr_count() - checkpoint_icount_base);
   }
 #endif // CONFIG_SHARE
 
@@ -246,7 +246,7 @@ static inline def_rtl(jr, rtlreg_t *target) {
 
 #ifndef CONFIG_SHARE
   if (profiling_state == SimpointProfiling && workload_loaded) {
-    simpoint_profiling(cpu.pc, true, get_abs_instr_count());
+    simpoint_profiling(cpu.pc, true, get_abs_instr_count() - checkpoint_icount_base);
   }
 #endif // CONFIG_SHARE
 


### PR DESCRIPTION
PR #724 introduced an intrcution counting base for profiling, but at the time, the simpoint_profiling() in normal rtl_j and rtl_jr was not adjusted. This patch addresses that oversight.