### PR TITLE
fix(hideleg): fix the read value of the LCOFI bit of hideleg.

### DIFF
--- a/src/isa/riscv64/difftest/ref.c
+++ b/src/isa/riscv64/difftest/ref.c
@@ -73,7 +73,7 @@ void csr_prepare() {
   cpu.mtval2  = mtval2->val;
   cpu.mtinst  = mtinst->val;
   cpu.hstatus = hstatus->val;
-  cpu.hideleg = hideleg->val;
+  cpu.hideleg = get_hideleg();
   cpu.hedeleg = hedeleg->val;
   cpu.hcounteren = hcounteren->val;
   cpu.htval   = htval->val;

--- a/src/isa/riscv64/local-include/csr.h
+++ b/src/isa/riscv64/local-include/csr.h
@@ -1582,6 +1582,7 @@ void csr_prepare();
 
 word_t gen_status_sd(word_t status);
 word_t get_mip();
+word_t get_hideleg();
 word_t mstatus_read();
 word_t sstatus_read(bool vsreg_read, bool bare_read);
 #ifdef CONFIG_RV_IMSIC

--- a/src/isa/riscv64/reg.c
+++ b/src/isa/riscv64/reg.c
@@ -164,7 +164,7 @@ void isa_reg_display() {
   printf("\n");
 
   #ifdef CONFIG_RVH
-    DISPLAY_CSR("hideleg", hideleg->val);
+    DISPLAY_CSR("hideleg", get_hideleg());
     DISPLAY_CSR("hedeleg", hedeleg->val);
     printf("\n");
   #endif // CONFIG_RVH

--- a/src/isa/riscv64/system/intr.c
+++ b/src/isa/riscv64/system/intr.c
@@ -39,7 +39,7 @@ bool intr_deleg_S(word_t exceptionNO) {
 bool intr_deleg_VS(word_t exceptionNO){
   bool isNMI = MUXDEF(CONFIG_RV_SMRNMI, cpu.hasNMI && (exceptionNO & INTR_BIT), false);
   bool delegS = intr_deleg_S(exceptionNO);
-  word_t deleg = (exceptionNO & INTR_BIT ? hideleg->val : hedeleg->val);
+  word_t deleg = (exceptionNO & INTR_BIT ? get_hideleg() : hedeleg->val);
   bool delegVS = cpu.v && ((deleg & (1 << (exceptionNO & 0xff))) != 0) && (cpu.mode < MODE_M) && !isNMI;
   return delegS && delegVS;
 }
@@ -370,7 +370,7 @@ word_t isa_query_intr() {
     if (intr_vec & (1 << irq)) {
       bool deleg = (mideleg->val & (1 << irq)) != 0;
 #ifdef CONFIG_RVH
-      bool hdeleg = (hideleg->val & (1 << irq)) != 0;
+      bool hdeleg = (get_hideleg() & (1 << irq)) != 0;
       bool global_enable = (hdeleg & deleg)? (cpu.v && cpu.mode == MODE_S && vsstatus->sie) || (cpu.v && cpu.mode < MODE_S):
                            (deleg)? ((cpu.mode == MODE_S) && mstatus->sie) || (cpu.mode < MODE_S) || cpu.v:
                            ((cpu.mode == MODE_M) && mstatus->mie) || (cpu.mode < MODE_M);


### PR DESCRIPTION
For bits of mideleg that are zero, the corresponding bits in hideleg, hip, and hie are read-only zeros.

The VSSIP, VSTIP, VSEIP in mideleg are read-only ones when the H extension is implemented.

When the hypervisor extension is implemented, if a bit is zero in the same position in both mideleg
and mvien, then that bit is read-only zero in hideleg (in addition to being read-only zero in sip, sie,
hip, and hie). But if a bit for one of interrupts 13-63 is a one in either mideleg or mvien, then the same
bit in hideleg may be writable or may be read-only zero, depending on the implementation. No bits in
hideleg are ever read-only ones. The RISC-V Privileged Architecture further constrains bits 12:0 of
hideleg.