### PR TITLE
fix(mem_log): disable cross-page log by default

### DIFF
--- a/src/memory/vaddr.c
+++ b/src/memory/vaddr.c
@@ -89,7 +89,7 @@ static void vaddr_write_cross_page(vaddr_t addr, int len, word_t data, bool need
   word_t cur_pg_st_data = data & cur_pg_st_mask;
   word_t next_pg_st_data = data >> (cur_pg_st_len << 3);
   if (needTranslate) {
-    Log("vaddr_write_cross_page!");
+    Logm("vaddr_write_cross_page!");
     // make sure no page fault or access fault before real write
     bool cur_pg_st_exp = false;
     bool next_pg_st_exp = false;


### PR DESCRIPTION
This line of logging is printing too much when we don't want (when MEMLOG disabled).