### PR TITLE
feat: accuracy instret and cycle CSR

### DIFF
--- a/include/cpu/cpu.h
+++ b/include/cpu/cpu.h
@@ -29,6 +29,7 @@ enum {
 };
 
 uint64_t get_abs_instr_count();
+uint64_t get_abs_instr_count_csr();
 
 void cpu_exec(uint64_t n);
 

--- a/src/isa/riscv64/instr/priv/system.c
+++ b/src/isa/riscv64/instr/priv/system.c
@@ -53,6 +53,7 @@ int rtl_sys_slow_path(Decode *s, rtlreg_t *dest, const rtlreg_t *src1, uint32_t 
     return is_jmp;
   }
 
+  // This is important for get accuracy instruction counts for csrrw.
   save_globals(s);
   // IFNDEF(CONFIG_DIFFTEST_REF_NEMU, difftest_skip_dut(1, 3));
 

--- a/src/isa/riscv64/system/priv.c
+++ b/src/isa/riscv64/system/priv.c
@@ -30,7 +30,6 @@ void fp_set_dirty();
 void fp_update_rm_cache(uint32_t rm);
 void vp_set_dirty();
 
-uint64_t get_abs_instr_count();
 inline word_t get_mip();
 inline word_t mstatus_read();
 inline word_t sstatus_read(bool vsreg_read, bool bare_read);
@@ -712,7 +711,7 @@ static inline word_t get_mcycle() {
       return mcycle->val;
     }
   #endif // CONFIG_RV_CSR_MCOUNTINHIBIT_CNTR
-  return mcycle->val + get_abs_instr_count();
+  return mcycle->val + get_abs_instr_count_csr();
 }
 
 static inline word_t get_minstret() {
@@ -721,7 +720,7 @@ static inline word_t get_minstret() {
       return minstret->val;
     }
   #endif // CONFIG_RV_CSR_MCOUNTINHIBIT_CNTR
-  return minstret->val + get_abs_instr_count();
+  return minstret->val + get_abs_instr_count_csr();
 }
 
 static inline word_t set_mcycle(word_t src) {
@@ -730,7 +729,7 @@ static inline word_t set_mcycle(word_t src) {
       return src;
     }
   #endif // CONFIG_RV_CSR_MCOUNTINHIBIT_CNTR
-  return src - get_abs_instr_count();
+  return src - get_abs_instr_count_csr();
 }
 
 static inline word_t set_minstret(word_t src) {
@@ -739,7 +738,7 @@ static inline word_t set_minstret(word_t src) {
       return src;
     }
   #endif // CONFIG_RV_CSR_MCOUNTINHIBIT_CNTR
-  return src - get_abs_instr_count();
+  return src - get_abs_instr_count_csr();
 }
 
 static inline word_t gen_mask(word_t begin, word_t end) {
@@ -1155,17 +1154,20 @@ static inline void update_counter_mcountinhibit(word_t old, word_t new) {
     bool new_cy = new & 0x1;
     bool new_ir = new & 0x4;
 
+
+    uint64_t abs_instr_count = get_abs_instr_count_csr();
+
     if (old_cy && !new_cy) { // CY: 1 -> 0
-      mcycle->val = mcycle->val - get_abs_instr_count();
+      mcycle->val = mcycle->val - abs_instr_count;
     }
     if (!old_cy && new_cy) { // CY: 0 -> 1
-      mcycle->val = mcycle->val + get_abs_instr_count();
+      mcycle->val = mcycle->val + abs_instr_count;
     }
     if (old_ir && !new_ir) { // IR: 1 -> 0
-      minstret->val = minstret->val - get_abs_instr_count();
+      minstret->val = minstret->val - abs_instr_count;
     }
     if (!old_ir && new_ir) { // IR: 0 -> 1
-      minstret->val = minstret->val + get_abs_instr_count();
+      minstret->val = minstret->val + abs_instr_count;
     }
   #endif // CONFIG_RV_CSR_MCOUNTINHIBIT_CNTR
 }


### PR DESCRIPTION
This patch adds support for accuracy minstret, instret, mcycle and cycle CSRs for INST_CNT_BY_BB modes, based on PR #350 and #727. Please refer to comments for technical details.

This patch has passed the countertest in [OpenXiangShan/nexus-am](https://github.com/OpenXiangShan/nexus-am).