### PR TITLE
opt(compile): allow aggressive inline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,12 @@ CFLAGS_BUILD += $(call remove_quote,$(CONFIG_CC_OPT))
 CFLAGS_BUILD += $(if $(CONFIG_CC_LTO),-flto=auto,)
 CFLAGS_BUILD += $(if $(CONFIG_CC_DEBUG),-ggdb3,)
 CFLAGS_BUILD += $(if $(CONFIG_CC_ASAN),-fsanitize=address,)
+
+# Fine-tuned compiler options
+ifeq ($(CC), gcc)
+	CFLAGS_BUILD += --param max-inline-insns-single=256 -falign-labels=32:9:64:15
+endif
+
 CFLAGS  += $(CFLAGS_BUILD)
 LDFLAGS += $(CFLAGS_BUILD)
 

--- a/src/isa/riscv64/system/mmu.c
+++ b/src/isa/riscv64/system/mmu.c
@@ -145,7 +145,7 @@ static inline bool check_permission(PTE *pte, bool ok, vaddr_t vaddr, int type) 
 }
 
 #ifndef CONFIG_RVH
-vaddr_t get_effective_address(vaddr_t vaddr, int type) {
+inline vaddr_t get_effective_address(vaddr_t vaddr, int type) {
   return vaddr;
 }
 #endif
@@ -183,7 +183,7 @@ void raise_guest_excep(paddr_t gpaddr, vaddr_t vaddr, int type, bool is_support_
   longjmp_exception(ex);
 }
 
-vaddr_t get_effective_address(vaddr_t vaddr, int type) {
+inline vaddr_t get_effective_address(vaddr_t vaddr, int type) {
   if (type == MEM_TYPE_IFETCH || hlvx) {
     return vaddr;
   }
@@ -540,7 +540,7 @@ int update_mmu_state() {
 
 void isa_misalign_data_addr_check(vaddr_t vaddr, int len, int type);
 
-int isa_mmu_check(vaddr_t vaddr, int len, int type) {
+inline int isa_mmu_check(vaddr_t vaddr, int len, int type) {
   Logtr("MMU checking addr %lx", vaddr);
   bool is_ifetch = type == MEM_TYPE_IFETCH;
 


### PR DESCRIPTION
this allows get_effective_address() and
isa_mmu_check() to be inlined.
this improves about 10% of speed on zen4