### PR TITLE
feat(image load): support load image into flash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
           make riscv64-xs-diff-spike-agnostic_defconfig
           make -j
           set -x
-          ./build/riscv64-nemu-interpreter -b --diff ${SPIKE_SO} --restore $TEST_HOME/hmmer_retro_6200_0.0378585.gz -r $TEST_HOME/v-gcpt.bin -I 2000000 > crash.log  || exit_code=$?
+          ./build/riscv64-nemu-interpreter -b --diff ${SPIKE_SO} $TEST_HOME/hmmer_retro_6200_0.0378585.gz -r $TEST_HOME/v-gcpt.bin -I 2000000 > crash.log  || exit_code=$?
           if [ ${exit_code} -eq 0 ]; then echo "Difftest is broken, it should report error!" exit 1; fi
           match=$(grep "wrong.*=.*ffff" crash.log -c)
           if [ ${match} -eq 0 ]; then echo "Difftest is broken, it should report at least one agnostic related difference!" exit 1; fi
@@ -260,13 +260,13 @@ jobs:
 
       - name: Run Vector-spec06-checkpoint with Spike DiffTest
         run: |
-          ./build/riscv64-nemu-interpreter -b --diff ${SPIKE_SO} --restore $TEST_HOME/hmmer_nph3_1886_0.000268086.gz -r $TEST_HOME/v-gcpt.bin -I 40000000
-          ./build/riscv64-nemu-interpreter -b --diff ${SPIKE_SO} --restore $TEST_HOME/hmmer_retro_6200_0.0378585.gz -r $TEST_HOME/v-gcpt.bin -I 40000000
-          ./build/riscv64-nemu-interpreter -b --diff ${SPIKE_SO} --restore $TEST_HOME/h264ref_sss_88321_0.0346343.gz -r $TEST_HOME/v-gcpt.bin -I 40000000
-          ./build/riscv64-nemu-interpreter -b --diff ${SPIKE_SO} --restore $TEST_HOME/h264ref_foreman.baseline_8028_0.0414445.gz -r $TEST_HOME/v-gcpt.bin -I 40000000
-          ./build/riscv64-nemu-interpreter -b --diff ${SPIKE_SO} --restore $TEST_HOME/h264ref_foreman.main_3027_0.0443573.gz -r $TEST_HOME/v-gcpt.bin -I 40000000
-          ./build/riscv64-nemu-interpreter -b --diff ${SPIKE_SO} --restore $TEST_HOME/libquantum_41028_0.0840681.gz -r $TEST_HOME/v-gcpt.bin -I 40000000
-          ./build/riscv64-nemu-interpreter -b --diff ${SPIKE_SO} --restore $TEST_HOME/bzip2_402_0.00785398.gz -r $TEST_HOME/v-gcpt.bin -I 40000000
+          ./build/riscv64-nemu-interpreter -b --diff ${SPIKE_SO} $TEST_HOME/hmmer_nph3_1886_0.000268086.gz -r $TEST_HOME/v-gcpt.bin -I 40000000
+          ./build/riscv64-nemu-interpreter -b --diff ${SPIKE_SO} $TEST_HOME/hmmer_retro_6200_0.0378585.gz -r $TEST_HOME/v-gcpt.bin -I 40000000
+          ./build/riscv64-nemu-interpreter -b --diff ${SPIKE_SO} $TEST_HOME/h264ref_sss_88321_0.0346343.gz -r $TEST_HOME/v-gcpt.bin -I 40000000
+          ./build/riscv64-nemu-interpreter -b --diff ${SPIKE_SO} $TEST_HOME/h264ref_foreman.baseline_8028_0.0414445.gz -r $TEST_HOME/v-gcpt.bin -I 40000000
+          ./build/riscv64-nemu-interpreter -b --diff ${SPIKE_SO} $TEST_HOME/h264ref_foreman.main_3027_0.0443573.gz -r $TEST_HOME/v-gcpt.bin -I 40000000
+          ./build/riscv64-nemu-interpreter -b --diff ${SPIKE_SO} $TEST_HOME/libquantum_41028_0.0840681.gz -r $TEST_HOME/v-gcpt.bin -I 40000000
+          ./build/riscv64-nemu-interpreter -b --diff ${SPIKE_SO} $TEST_HOME/bzip2_402_0.00785398.gz -r $TEST_HOME/v-gcpt.bin -I 40000000
 
       - name: Run OpenSBI+Linux+Vectorized_h264 with Spike DiffTest
         run: |

--- a/include/memory/image_loader.h
+++ b/include/memory/image_loader.h
@@ -25,4 +25,6 @@ long load_zstd_img(const char *filename);
 
 long load_img(char *img_name, const char *which_img, uint8_t* load_start, size_t img_size);
 
+void fill_memory(const char* img_file, const char* flash_image, const char* cpt_image, int64_t* img_size, int64_t* flash_size);
+
 #endif //  __IMAGE_LOADER_H__

--- a/include/profiling/profiling_control.h
+++ b/include/profiling/profiling_control.h
@@ -18,7 +18,6 @@ enum CheckpointState{
 
 extern int profiling_state;
 extern int checkpoint_state;
-extern bool checkpoint_restoring;
 extern uint64_t checkpoint_interval;
 extern uint64_t warmup_interval;
 extern uint64_t checkpoint_icount_base;

--- a/scripts/restore_zstd.sh
+++ b/scripts/restore_zstd.sh
@@ -16,5 +16,5 @@
 cpt=`find output_top/test/linux/50000000 -name "*.zstd"`
 ./build/riscv64-nemu-interpreter -b\
     --diff ${SPIKE_SO}\
-    --restore -I 100000000 \
+    -I 100000000 \
     $cpt

--- a/src/monitor/image_loader.c
+++ b/src/monitor/image_loader.c
@@ -19,6 +19,7 @@
 #include <macro.h>
 #include <memory/paddr.h>
 #include <memory/sparseram.h>
+#include <device/flash.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/mman.h>
@@ -198,8 +199,8 @@ long load_zstd_img(const char *filename, uint8_t* load_start, size_t img_size){
 
 // Will check the magic number in file, if not gz or zstd archive,
 // will read in as a raw image
-long load_img(char* img_name, char *which_img, uint8_t* load_start, size_t img_size) {
-  char *loading_img = img_name;
+long load_img(const char* img_name, char *which_img, uint8_t* load_start, size_t img_size) {
+  const char *loading_img = img_name;
   Log("Loading %s: %s\n", which_img, img_name);
   if (img_name == NULL) {
     Log("No image is given. Use the default built-in image/restorer.");
@@ -260,6 +261,43 @@ long load_img(char* img_name, char *which_img, uint8_t* load_start, size_t img_s
 
   fclose(fp);
   return size;
+}
+
+void fill_memory(const char* img_file, const char* flash_image, const char* cpt_image, int64_t* img_size, int64_t* flash_size) {
+  assert(img_file);
+  uint8_t* bbl_start = (uint8_t*)get_pmem();
+  *img_size = load_img(img_file, "image (checkpoint/bare metal app/bbl) form cmdline", bbl_start, 0);
+
+#ifdef CONFIG_HAS_FLASH
+  uint8_t* flash_start = get_flash_base();
+  if(flash_image) {
+    *flash_size = load_img(flash_image, "flash image from cmdline", flash_start, get_flash_size());
+  }
+#endif
+
+  if (cpt_image) {
+    FILE *restore_fp = fopen(cpt_image, "rb");
+    Assert(restore_fp, "Can not open '%s'", cpt_image);
+
+    int restore_size = 0;
+    int restore_jmp_inst = 0;
+
+    int ret = fread(&restore_jmp_inst, sizeof(int), 1, restore_fp);
+    assert(ret == 1);
+    assert(restore_jmp_inst != 0);
+
+    ret = fread(&restore_size, sizeof(int), 1, restore_fp);
+    assert(ret == 1);
+    assert(restore_size != 0);
+
+    fclose(restore_fp);
+
+#ifdef CONFIG_HAS_FLASH
+    load_img(cpt_image, "Gcpt restorer form cmdline", flash_start, restore_size);
+#else
+    load_img(cpt_image, "Gcpt restorer form cmdline", bbl_start, restore_size);
+#endif
+  }
 }
 
 #endif  // CONFIG_MODE_USER

--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -40,6 +40,7 @@ bool small_log = false;
 bool fast_log = false;
 static char *diff_so_file = NULL;
 static char *img_file = NULL;
+static char *flash_image = NULL;
 static int batch_mode = false;
 static int difftest_port = 1234;
 char *max_instr = NULL;
@@ -99,7 +100,7 @@ static inline int parse_args(int argc, char *argv[]) {
     {"config-name"        , required_argument, NULL, 'C'},
 
     // restore cpt
-    {"restore"            , no_argument      , NULL, 'c'},
+    {"flash-image"        , required_argument, NULL, 16},
     {"cpt-restorer"       , required_argument, NULL, 'r'},
     {"map-img-as-outcpt"  , no_argument      , NULL, 13},
 
@@ -148,14 +149,14 @@ static inline int parse_args(int argc, char *argv[]) {
       case 'w': workload_name = optarg; break;
       case 'C': config_name = optarg; break;
 
-      case 'c':
-        checkpoint_restoring = true;
-        Log("Restoring from checkpoint");
+      case 16:
+        flash_image = optarg;
         break;
 
       case 'r':
         restorer = optarg;
         break;
+
       case 13: {
         extern bool map_image_as_output_cpt;
         map_image_as_output_cpt = true;
@@ -179,7 +180,8 @@ static inline int parse_args(int argc, char *argv[]) {
       case 'M':
           mem_dump_file = optarg;
           break;
-      case 'A': 
+
+      case 'A':
           #ifdef CONFIG_MEMORY_REGION_ANALYSIS
           Log("Set mem analysis log path %s", optarg);
           memory_region_record_file = optarg;
@@ -259,7 +261,6 @@ static inline int parse_args(int argc, char *argv[]) {
         printf("\t-w,--workload=WORKLOAD  the name of sub_dir of this run in STAT_DIR\n");
         printf("\t-C,--config=CONFIG      running configuration\n");
 
-        printf("\t-c,--restore            restoring from CPT FILE\n");
         printf("\t-r,--cpt-restorer=R     binary of gcpt restorer\n");
 //        printf("\t--map-img-as-outcpt     map to image as output checkpoint, do not truncate it.\n"); //comming back soon
 
@@ -273,6 +274,7 @@ static inline int parse_args(int argc, char *argv[]) {
         printf("\t--checkpoint-format     Specify the checkpoint format('gz' or 'zstd'), default: 'gz'.\n");
 //        printf("\t--map-cpt               map to this file as pmem, which can be treated as a checkpoint.\n"); //comming back soon
 
+        printf("\t--flash-img             image of flash\n");
         printf("\t--simpoint-profile      simpoint profiling\n");
         printf("\t--dont-skip-boot        profiling/checkpoint immediately after boot\n");
         printf("\t--mem_use_record_file   result output file for analyzing the memory use segment\n");
@@ -310,7 +312,6 @@ void init_monitor(int argc, char *argv[]) {
   if (map_image_as_output_cpt) {
     assert(!mapped_cpt_file);
     mapped_cpt_file = img_file;
-    checkpoint_restoring = true;
   }
 
   extern void init_path_manager();
@@ -338,38 +339,15 @@ void init_monitor(int argc, char *argv[]) {
   /* Perform ISA dependent initialization. */
   init_isa();
 
+  /* Initialize devices. */
+  init_device();
+
   int64_t img_size = 0;
-
-  assert(img_file);
-
-  uint8_t* bbl_start = (uint8_t*)get_pmem();
-  img_size = load_img(img_file, "image (checkpoint/bare metal app/bbl) form cmdline", bbl_start, 0);
-
-  if (restorer) {
-    FILE *restore_fp = fopen(restorer, "rb");
-    Assert(restore_fp, "Can not open '%s'", restorer);
-
-    int restore_size = 0;
-    int restore_jmp_inst = 0;
-
-    int ret = fread(&restore_jmp_inst, sizeof(int), 1, restore_fp);
-    assert(ret == 1);
-    assert(restore_jmp_inst != 0);
-
-    ret = fread(&restore_size, sizeof(int), 1, restore_fp);
-    assert(ret == 1);
-    assert(restore_size != 0);
-
-    fclose(restore_fp);
-
-    load_img(restorer, "Gcpt restorer form cmdline", bbl_start, restore_size);
-  }
+  int64_t flash_size = 0;
+  fill_memory(img_file, flash_image, restorer, &img_size, &flash_size);
 
   /* Initialize differential testing. */
   init_difftest(diff_so_file, img_size, difftest_port);
-
-  /* Initialize devices. */
-  init_device();
 
 #endif
 


### PR DESCRIPTION
* delete `--restore` arg
* support load flash img from cmd line

NEMU could load checkpoint image directly, so we do not need `--restore` arg;
Add `--flash-img` arg, it could load flash image from cmd line, before that, the flash image path is hardcoded at compile time