### PR TITLE
try-fix(difftest attach): Add 'pmp' and 'pmp_cpy' API to difftest_attach, but functionality remains incomplete

### DIFF
--- a/include/cpu/difftest.h
+++ b/include/cpu/difftest.h
@@ -41,6 +41,9 @@ extern void (*ref_difftest_regcpy)(void *c, bool direction);
 extern void (*ref_difftest_exec)(uint64_t n);
 extern void (*ref_difftest_raise_intr)(uint64_t NO);
 extern void (*ref_difftest_dirty_fsvs)(const uint64_t dirties);
+extern void (*ref_difftest_pmpcpy)(void *dut, bool direction);
+extern void (*ref_difftest_pmp_cfg_cpy)(void *dut, bool direction);
+
 #ifdef CONFIG_DIFFTEST_STORE_COMMIT
 extern int  (*ref_difftest_store_commit)(uint64_t *addr, uint64_t *data, uint8_t *mask);
 #endif

--- a/src/cpu/difftest/dut.c
+++ b/src/cpu/difftest/dut.c
@@ -29,6 +29,8 @@ void (*ref_difftest_raise_intr)(uint64_t NO) = NULL;
 void (*ref_difftest_dirty_fsvs)(const uint64_t dirties) = NULL;
 int  (*ref_difftest_store_commit)(uint64_t *addr, uint64_t *data, uint8_t *mask) = NULL;
 void (*ref_difftest_flash_cpy)(uint8_t* flash_bin, size_t size) = NULL;
+void (*ref_difftest_pmpcpy)(void *dut, bool direction) = NULL;
+void (*ref_difftest_pmp_cfg_cpy)(void *dut, bool direction) = NULL;
 #ifdef CONFIG_DIFFTEST
 
 IFDEF(CONFIG_DIFFTEST_REF_QEMU_DL, __thread uint8_t resereve_for_qemu_tls[4096]);
@@ -109,6 +111,12 @@ void init_difftest(char *ref_so_file, long img_size, long flash_size, int port) 
   ref_difftest_flash_cpy = dlsym(handle, "difftest_load_flash_v2");
   assert(ref_difftest_flash_cpy);
 #endif
+
+  ref_difftest_pmpcpy = dlsym(handle, "difftest_pmpcpy");
+  assert(ref_difftest_pmpcpy);
+  ref_difftest_pmp_cfg_cpy = dlsym(handle, "difftest_pmp_cfg_cpy");
+  assert(ref_difftest_pmp_cfg_cpy);
+
   Log("Differential testing: \33[1;32m%s\33[0m", "ON");
   Log("The result of every instruction will be compared with %s. "
       "This will help you a lot for debugging, but also significantly reduce the performance. "
@@ -179,6 +187,12 @@ void difftest_attach() {
   skip_dut_nr_instr = 0;
 
   isa_difftest_attach();
+
+  // There are multiple non-register states for spike,
+  // and entering attach from any execution phase requires
+  // the ability to correctly implement the settings for
+  // these states, and the expected repair effort would be enormous
+  assert(0); // fix me
 }
 
 #else

--- a/src/cpu/difftest/dut.c
+++ b/src/cpu/difftest/dut.c
@@ -188,10 +188,10 @@ void difftest_attach() {
 
   isa_difftest_attach();
 
-  // There are multiple non-register states for spike,
-  // and entering attach from any execution phase requires
-  // the ability to correctly implement the settings for
-  // these states, and the expected repair effort would be enormous
+  // This function remains non-functional even after applying this patch, so we assert it.
+  // Spike has multiple non-register states, and to ensure correctness when attaching
+  // from any execution phase, all these non-register states need to be synchronized.
+  // Addressing this properly in the future could require significant effort.
   assert(0); // fix me
 }
 

--- a/src/isa/riscv64/difftest/dut.c
+++ b/src/isa/riscv64/difftest/dut.c
@@ -118,6 +118,8 @@ bool isa_difftest_checkregs(CPU_state *ref_r, vaddr_t pc) {
 void isa_difftest_attach() {
   csr_prepare();
   ref_difftest_memcpy(CONFIG_MBASE, guest_to_host(CONFIG_MBASE), MEMORY_SIZE, DIFFTEST_TO_REF);
+  ref_difftest_pmpcpy(&csr_array[CSR_PMPADDR_BASE], DIFFTEST_TO_REF);
+  ref_difftest_pmp_cfg_cpy(csr_array, DIFFTEST_TO_REF);
   assert(0); //FIXME
   ref_difftest_regcpy(&cpu, DIFFTEST_TO_REF);
 }


### PR DESCRIPTION
this patch add two api to copy pmp and pmp cfg registers to spike when execute `difftest_attach`, but spike still have many non-register states not sync totally, so this patch just reduce size of the problem, not fix it