### PR TITLE
refactor(Makefile): Migrate builds from other repos to separate makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,22 +118,7 @@ LDFLAGS += -lSDL2
 endif
 endif
 
-ifdef CONFIG_FPU_SOFT
-SOFTFLOAT = resource/softfloat/build/softfloat.a
-ifeq ($(ISA),riscv64)
-SPECIALIZE_TYPE = RISCV
-else
-SPECIALIZE_TYPE = 8086-SSE
-endif
-ifdef CONFIG_SHARE
-SOFTFLOAT_OPTS_DEFAULT = -DSOFTFLOAT_ROUND_ODD -DINLINE_LEVEL=5 \
-  -DSOFTFLOAT_FAST_DIV32TO16 -DSOFTFLOAT_FAST_DIV64TO32
-SOFTFLOAT_OPTS_OVERRIDE = SOFTFLOAT_OPTS="$(SOFTFLOAT_OPTS_DEFAULT) -fPIC"
-endif
-
-clean-all: clean-repos
-
-else ifdef CONFIG_FPU_HOST
+ifdef CONFIG_FPU_HOST
 LDFLAGS += -lm
 endif
 
@@ -184,6 +169,6 @@ clean-tools = $(dir $(shell find ./tools -name "Makefile"))
 $(clean-tools):
 	-@$(MAKE) -s -C $@ clean
 clean-tools: $(clean-tools)
-clean-all: clean distclean clean-tools
+clean-all: clean distclean clean-tools clean-repos
 
 .PHONY: run gdb run-env clean-tools clean-all $(clean-tools)

--- a/Makefile
+++ b/Makefile
@@ -131,29 +131,13 @@ SOFTFLOAT_OPTS_DEFAULT = -DSOFTFLOAT_ROUND_ODD -DINLINE_LEVEL=5 \
 SOFTFLOAT_OPTS_OVERRIDE = SOFTFLOAT_OPTS="$(SOFTFLOAT_OPTS_DEFAULT) -fPIC"
 endif
 
-SOFTFLOAT_REPO_PATH = resource/softfloat/repo
-ifeq ($(wildcard $(SOFTFLOAT_REPO_PATH)/COPYING.txt),)
-  $(shell git clone --depth=1 https://github.com/ucb-bar/berkeley-softfloat-3 $(SOFTFLOAT_REPO_PATH))
-endif
-SOFTFLOAT_BUILD_PATH = $(abspath $(SOFTFLOAT_REPO_PATH)/build/Linux-x86_64-GCC)
+clean-all: clean-repos
 
-INC_DIR += $(SOFTFLOAT_REPO_PATH)/source/include
-INC_DIR += $(SOFTFLOAT_REPO_PATH)/source/$(SPECIALIZE_TYPE)
-LIBS += $(SOFTFLOAT)
-$(SOFTFLOAT):
-	SPECIALIZE_TYPE=$(SPECIALIZE_TYPE) $(SOFTFLOAT_OPTS_OVERRIDE) $(MAKE) -s -C $(SOFTFLOAT_BUILD_PATH) all
-	mkdir -p $(@D)
-	ln -sf $(SOFTFLOAT_BUILD_PATH)/softfloat.a $@
-
-clean-softfloat:
-	$(MAKE) -s -C $(SOFTFLOAT_BUILD_PATH) clean
-clean-all: clean-softfloat
-
-.PHONY: $(SOFTFLOAT) clean-softfloat
 else ifdef CONFIG_FPU_HOST
 LDFLAGS += -lm
 endif
 
+include $(NEMU_HOME)/scripts/repos.mk
 include $(NEMU_HOME)/scripts/git.mk
 include $(NEMU_HOME)/scripts/config.mk
 include $(NEMU_HOME)/scripts/isa.mk

--- a/scripts/LibcheckpointAlpha.mk
+++ b/scripts/LibcheckpointAlpha.mk
@@ -10,7 +10,7 @@ $(CPT_LAYOUT_HEADER):
 $(CPT_BIN): $(CPT_LAYOUT_HEADER)
 	$(Q)$(MAKE) $(silent) -C $(LIB_CPT_PATH) CROSS_COMPILE=$(CPT_CROSS_COMPILE)
 
-clean-libcheckpointalpha:
+clean-libcheckpointalpha: $(CPT_LAYOUT_HEADER)
 	$(Q)$(MAKE) -s -C $(LIB_CPT_PATH) clean
 
 .PHONY: clean-libcheckpointalpha

--- a/scripts/LibcheckpointAlpha.mk
+++ b/scripts/LibcheckpointAlpha.mk
@@ -10,3 +10,7 @@ $(CPT_LAYOUT_HEADER):
 $(CPT_BIN): $(CPT_LAYOUT_HEADER)
 	$(Q)$(MAKE) $(silent) -C $(LIB_CPT_PATH) CROSS_COMPILE=$(CPT_CROSS_COMPILE)
 
+clean-libcheckpointalpha:
+	$(Q)$(MAKE) -s -C $(LIB_CPT_PATH) clean
+
+.PHONY: clean-libcheckpointalpha

--- a/scripts/LibcheckpointAlpha.mk
+++ b/scripts/LibcheckpointAlpha.mk
@@ -1,0 +1,12 @@
+LIB_CPT_PATH = resource/gcpt_restore
+CPT_BIN = $(LIB_CPT_PATH)/build/gcpt.bin
+CPT_LAYOUT_HEADER = $(LIB_CPT_PATH)/src/restore_rom_addr.h
+
+CPT_CROSS_COMPILE ?= riscv64-unknown-linux-gnu-
+
+$(CPT_LAYOUT_HEADER):
+	$(shell git clone https://github.com/OpenXiangShan/LibCheckpointAlpha.git $(LIB_CPT_PATH))
+
+$(CPT_BIN): $(CPT_LAYOUT_HEADER)
+	$(Q)$(MAKE) $(silent) -C $(LIB_CPT_PATH) CROSS_COMPILE=$(CPT_CROSS_COMPILE)
+

--- a/scripts/build.mk
+++ b/scripts/build.mk
@@ -93,6 +93,6 @@ $(BUILD_DIR)/lib$(NAME).a: $(OBJS) $(LIBS)
 	@ar rcs $@ $(TEMP_EXTRACT_DIR)/*.o $(OBJS)
 	@rm -rf $(TEMP_EXTRACT_DIR)
 
-.PHONY: clean-softfloat
-clean: clean-softfloat
+.PHONY:
+clean:
 	-rm -rf $(BUILD_DIR)

--- a/scripts/config.mk
+++ b/scripts/config.mk
@@ -32,18 +32,6 @@ CONF   := $(KCONFIG_PATH)/build/conf
 MCONF  := $(KCONFIG_PATH)/build/mconf
 FIXDEP := $(FIXDEP_PATH)/build/fixdep
 
-LIB_CPT_PATH = resource/gcpt_restore
-CPT_BIN = $(LIB_CPT_PATH)/build/gcpt.bin
-CPT_LAYOUT_HEADER = $(LIB_CPT_PATH)/src/restore_rom_addr.h
-
-CPT_CROSS_COMPILE ?= riscv64-unknown-linux-gnu-
-
-$(CPT_LAYOUT_HEADER):
-	$(shell git clone https://github.com/OpenXiangShan/LibCheckpointAlpha.git $(LIB_CPT_PATH))
-
-$(CPT_BIN): $(CPT_LAYOUT_HEADER)
-	$(Q)$(MAKE) $(silent) -C $(LIB_CPT_PATH) CROSS_COMPILE=$(CPT_CROSS_COMPILE)
-
 $(CONF):
 	$(Q)$(MAKE) $(silent) -C $(KCONFIG_PATH) NAME=conf
 

--- a/scripts/repos.mk
+++ b/scripts/repos.mk
@@ -1,0 +1,4 @@
+include $(NEMU_HOME)/scripts/softfloat.mk
+include $(NEMU_HOME)/scripts/LibcheckpointAlpha.mk
+
+clean-repos: clean-softfloat

--- a/scripts/repos.mk
+++ b/scripts/repos.mk
@@ -1,4 +1,4 @@
 include $(NEMU_HOME)/scripts/softfloat.mk
 include $(NEMU_HOME)/scripts/LibcheckpointAlpha.mk
 
-clean-repos: clean-softfloat
+clean-repos: clean-softfloat clean-libcheckpointalpha

--- a/scripts/softfloat.mk
+++ b/scripts/softfloat.mk
@@ -1,3 +1,6 @@
+ifdef CONFIG_FPU_SOFT
+
+SOFTFLOAT = resource/softfloat/build/softfloat.a
 
 SOFTFLOAT_REPO_PATH = resource/softfloat/repo
 ifeq ($(wildcard $(SOFTFLOAT_REPO_PATH)/COPYING.txt),)
@@ -10,12 +13,29 @@ INC_DIR += $(SOFTFLOAT_REPO_PATH)/source/include
 INC_DIR += $(SOFTFLOAT_REPO_PATH)/source/$(SPECIALIZE_TYPE)
 LIBS += $(SOFTFLOAT)
 
+ifeq ($(ISA),riscv64)
+SPECIALIZE_TYPE = RISCV
+else
+SPECIALIZE_TYPE = 8086-SSE
+endif
+
+ifdef CONFIG_SHARE
+SOFTFLOAT_OPTS_DEFAULT = -DSOFTFLOAT_ROUND_ODD -DINLINE_LEVEL=5 \
+  -DSOFTFLOAT_FAST_DIV32TO16 -DSOFTFLOAT_FAST_DIV64TO32
+SOFTFLOAT_OPTS_OVERRIDE = SOFTFLOAT_OPTS="$(SOFTFLOAT_OPTS_DEFAULT) -fPIC"
+endif
+
 $(SOFTFLOAT):
 	SPECIALIZE_TYPE=$(SPECIALIZE_TYPE) $(SOFTFLOAT_OPTS_OVERRIDE) $(MAKE) -s -C $(SOFTFLOAT_BUILD_PATH) all
 	mkdir -p $(@D)
 	ln -sf $(SOFTFLOAT_BUILD_PATH)/softfloat.a $@
 
-clean-softfloat:
-	$(MAKE) -s -C $(SOFTFLOAT_BUILD_PATH) clean
+endif
 
-.PHONY: $(SOFTFLOAT) clean-softfloat
+clean-softfloat:
+ifdef CONFIG_FPU_SOFT
+	$(MAKE) -s -C $(SOFTFLOAT_BUILD_PATH) clean
+endif
+
+.PHONY: clean-softfloat
+	

--- a/scripts/softfloat.mk
+++ b/scripts/softfloat.mk
@@ -1,0 +1,21 @@
+
+SOFTFLOAT_REPO_PATH = resource/softfloat/repo
+ifeq ($(wildcard $(SOFTFLOAT_REPO_PATH)/COPYING.txt),)
+  $(shell git clone --depth=1 https://github.com/ucb-bar/berkeley-softfloat-3 $(SOFTFLOAT_REPO_PATH))
+endif
+
+SOFTFLOAT_BUILD_PATH = $(abspath $(SOFTFLOAT_REPO_PATH)/build/Linux-x86_64-GCC)
+
+INC_DIR += $(SOFTFLOAT_REPO_PATH)/source/include
+INC_DIR += $(SOFTFLOAT_REPO_PATH)/source/$(SPECIALIZE_TYPE)
+LIBS += $(SOFTFLOAT)
+
+$(SOFTFLOAT):
+	SPECIALIZE_TYPE=$(SPECIALIZE_TYPE) $(SOFTFLOAT_OPTS_OVERRIDE) $(MAKE) -s -C $(SOFTFLOAT_BUILD_PATH) all
+	mkdir -p $(@D)
+	ln -sf $(SOFTFLOAT_BUILD_PATH)/softfloat.a $@
+
+clean-softfloat:
+	$(MAKE) -s -C $(SOFTFLOAT_BUILD_PATH) clean
+
+.PHONY: $(SOFTFLOAT) clean-softfloat


### PR DESCRIPTION
Simply migrate the other repo's build process to a separate makefile, and will continue to be refact to make it easier to understand.
The goal is to:
make it easier to handle builds and dependencies when there are more repositories, e.g. the Libcheckpoint repo and the nanopb repo will be added soon.