### PR TITLE
fix(vaddr): vaddr_read_safe should not check hlvx instruction

### DIFF
--- a/src/memory/vaddr.c
+++ b/src/memory/vaddr.c
@@ -155,7 +155,9 @@ static void vaddr_mmu_write(struct Decode *s, vaddr_t addr, int len, word_t data
 static inline word_t vaddr_read_internal(void *s, vaddr_t addr, int len, int type, int mmu_mode) {
 
 #ifdef CONFIG_RVH
-  if(type != MEM_TYPE_IFETCH){
+  // check whether here is a hlvx instruction
+  // when inst fetch or vaddr_read_safe (for examine memory), s is NULL
+  if (s != NULL) {
     extern int rvh_hlvx_check(struct Decode *s, int type);
     rvh_hlvx_check((Decode*)s, type);
   }


### PR DESCRIPTION
In previous design, before we do `rvh_hlvx_check`, we will only determine whether it is a instruction fetch request (`MEM_TYPE_IFETCH`). If it is a instruction fetch request, there is no need to determine if it is hlvx. However, for the case of examine memory (using `vaddr_read_safe`), the memory type is `MEM_TYPE_READ`, but there is still no need to determine if it is hlvx.

Since both instruction fetch requests and `vaddr_read_safe` function will pass a NULL pointer `s` here, we will decide whether to execute `rvh_hlvx_check` by determining whether or not `s` is NULL.