### PR TITLE
fix(aia, exception): Add the missing AIA-related permission checks.

### DIFF
--- a/include/isa.h
+++ b/include/isa.h
@@ -93,6 +93,7 @@ void isa_update_mhpmcounter_overflow(uint64_t mhpmeventOverflowVec);
 void isa_update_mtopi();
 void isa_update_stopi();
 void isa_update_vstopi();
+void isa_update_hgeip();
 #endif
 void isa_sync_custom_mflushpwr(bool l2FlushDone);
 

--- a/src/cpu/difftest/ref.c
+++ b/src/cpu/difftest/ref.c
@@ -273,10 +273,11 @@ void difftest_get_store_event_other_info(void *info) {
 
 
 
-void difftest_aia_xtopei(void *xtopei) {
+void difftest_sync_aia(void *src) {
 #ifdef CONFIG_RV_IMSIC
-  memcpy(&cpu.xtopei, xtopei, sizeof(struct Xtopei));
+  memcpy(&cpu.fromaia, src, sizeof(struct FromAIA));
   isa_update_vstopi();
+  isa_update_hgeip();
 #endif
 }
 

--- a/src/isa/riscv64/difftest/ref.c
+++ b/src/isa/riscv64/difftest/ref.c
@@ -441,6 +441,10 @@ void isa_update_stopi() {
 void isa_update_vstopi() {
   update_vstopi();
 }
+
+void isa_update_hgeip() {
+  hgeip->val = cpu.fromaia.hgeip;
+}
 #endif
 
 void isa_sync_custom_mflushpwr(bool l2FlushDone) {

--- a/src/isa/riscv64/include/isa-def.h
+++ b/src/isa/riscv64/include/isa-def.h
@@ -53,10 +53,11 @@ struct NonRegInterruptPending {
   bool lcofi_req;
 };
 
-struct Xtopei {
+struct FromAIA {
   uint64_t mtopei;
   uint64_t stopei;
   uint64_t vstopei;
+  uint64_t hgeip;
 };
 
 struct DebugInfo {
@@ -184,7 +185,7 @@ typedef struct {
   trap_info_t trapInfo;
 
 #ifdef CONFIG_RV_IMSIC
-  struct Xtopei xtopei;
+  struct FromAIA fromaia;
   IpriosModule*  MIprios;
   IpriosModule*  SIprios;
   IpriosModule* VSIprios;

--- a/src/isa/riscv64/system/priv.c
+++ b/src/isa/riscv64/system/priv.c
@@ -1256,7 +1256,7 @@ inline void update_vstopi() {
   vsip_t read_vsip = (vsip_t)get_vsip();
   vsie_t read_vsie = (vsie_t)get_vsie();
 
-  bool candidate1 = read_vsip.seip && read_vsie.seie && (hstatus->vgein != 0) && (cpu.xtopei.vstopei != 0);
+  bool candidate1 = read_vsip.seip && read_vsie.seie && (hstatus->vgein != 0) && (cpu.fromaia.vstopei != 0);
   bool candidate2 = read_vsip.seip && read_vsie.seie && (hstatus->vgein == 0) && (hvictl->iid == 9) && (hvictl->iprio != 0);
   bool candidate3 = read_vsip.seip && read_vsie.seie && !candidate1 && !candidate2;
   bool candidate4 = !hvictl->vti && (read_vsie.val & read_vsip.val & 0xfffffffffffffdff);
@@ -1277,7 +1277,7 @@ inline void update_vstopi() {
   uint16_t iprio_candidate45 = 0;
 
   if (candidate1) {
-    vstopei_t* vstopei_tmp = (vstopei_t*)cpu.xtopei.vstopei;
+    vstopei_t* vstopei_tmp = (vstopei_t*)cpu.fromaia.vstopei;
     iprio_candidate123 = vstopei_tmp->iprio;
   } else if (candidate2) {
     iprio_candidate123 = hvictl->iprio;
@@ -1422,8 +1422,8 @@ static word_t csr_read(uint32_t csrid) {
       if (cpu.v) return vstopi->val;
       return stopi->val;
     case CSR_STOPEI:
-      if (cpu.v) return cpu.xtopei.vstopei;
-      return cpu.xtopei.stopei;
+      if (cpu.v) return cpu.fromaia.vstopei;
+      return cpu.fromaia.stopei;
     case CSR_SIREG:
     {
       bool siselect_is_major_ip = iselect_is_major_ip(siselect->val);
@@ -1466,7 +1466,7 @@ static word_t csr_read(uint32_t csrid) {
     case CSR_HVIP: return hvip->val & HVIP_MASK;
     case CSR_HGEIP: return hgeip->val & HGEIP_MASK;
 #ifdef CONFIG_RV_IMSIC
-    case CSR_VSTOPEI: return cpu.xtopei.vstopei;
+    case CSR_VSTOPEI: return cpu.fromaia.vstopei;
     case CSR_VSIREG:
     {
       bool vsiselect_is_major_ip = iselect_is_major_ip(siselect->val);
@@ -1485,7 +1485,7 @@ static word_t csr_read(uint32_t csrid) {
     case CSR_MVIEN: return mvien->val & MVIEN_MASK;
     case CSR_MVIP: return get_mvip();
 #ifdef CONFIG_RV_IMSIC
-    case CSR_MTOPEI: return cpu.xtopei.mtopei;
+    case CSR_MTOPEI: return cpu.fromaia.mtopei;
     case CSR_MIREG:
     {
       bool miselect_is_major_ip = iselect_is_major_ip(miselect->val);


### PR DESCRIPTION
Along the same lines, when hstatus.VGEIN is not the number of an implemented guest external interrupt, attempts from M-mode or HS-mode to access CSR vstopei raise an illegal instruction exception, and attempts from VS-mode to access stopei raise a virtual instruction exception.