### PR TITLE
feat: add --store-cpt-in-flash option

### DIFF
--- a/include/checkpoint/serializer.h
+++ b/include/checkpoint/serializer.h
@@ -36,7 +36,7 @@ class Serializer
 
     explicit Serializer();
 
-    void init();
+    void init(bool flash_store_checkpoint);
 
     bool shouldTakeCpt(uint64_t num_insts);
     bool instrsCouldTakeCpt(uint64_t num_insts);
@@ -68,6 +68,7 @@ class Serializer
     const uint32_t MISCDoneFlag;
 
     bool regDumped{false};
+    bool flash_store_checkpoint{false};
 
     std::map<uint64_t, double> simpoint2Weights;
 

--- a/include/checkpoint/serializer.h
+++ b/include/checkpoint/serializer.h
@@ -36,7 +36,7 @@ class Serializer
 
     explicit Serializer();
 
-    void init(bool flash_store_checkpoint);
+    void init(bool store_cpt_in_flash);
 
     bool shouldTakeCpt(uint64_t num_insts);
     bool instrsCouldTakeCpt(uint64_t num_insts);
@@ -68,7 +68,7 @@ class Serializer
     const uint32_t MISCDoneFlag;
 
     bool regDumped{false};
-    bool flash_store_checkpoint{false};
+    bool store_cpt_in_flash{false};
 
     std::map<uint64_t, double> simpoint2Weights;
 

--- a/src/checkpoint/serializer.cpp
+++ b/src/checkpoint/serializer.cpp
@@ -282,8 +282,8 @@ void Serializer::serialize(uint64_t inst_count) {
 #endif
 }
 
-void Serializer::init(bool flash_store_checkpoint) {
-  this->flash_store_checkpoint = flash_store_checkpoint;
+void Serializer::init(bool store_cpt_in_flash) {
+  this->store_cpt_in_flash = store_cpt_in_flash;
 
   if  (checkpoint_state == SimpointCheckpointing) {
     assert(checkpoint_interval);
@@ -384,8 +384,8 @@ uint64_t Serializer::next_index(){
 
 extern "C" {
 
-void init_serializer(bool flash_store_checkpoint) {
-  serializer.init(flash_store_checkpoint);
+void init_serializer(bool store_cpt_in_flash) {
+  serializer.init(store_cpt_in_flash);
 }
 
 bool try_take_cpt(uint64_t icount) {

--- a/src/checkpoint/serializer.cpp
+++ b/src/checkpoint/serializer.cpp
@@ -282,7 +282,9 @@ void Serializer::serialize(uint64_t inst_count) {
 #endif
 }
 
-void Serializer::init() {
+void Serializer::init(bool flash_store_checkpoint) {
+  this->flash_store_checkpoint = flash_store_checkpoint;
+
   if  (checkpoint_state == SimpointCheckpointing) {
     assert(checkpoint_interval);
     intervalSize = checkpoint_interval;
@@ -382,8 +384,8 @@ uint64_t Serializer::next_index(){
 
 extern "C" {
 
-void init_serializer() {
-  serializer.init();
+void init_serializer(bool flash_store_checkpoint) {
+  serializer.init(flash_store_checkpoint);
 }
 
 bool try_take_cpt(uint64_t icount) {

--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -44,7 +44,7 @@ static char *flash_image = NULL;
 static int batch_mode = false;
 static int difftest_port = 1234;
 char *max_instr = NULL;
-static bool flash_store_checkpoint = false;
+static bool store_cpt_in_flash = false;
 char compress_file_format = 0; // default is gz
 
 extern char *mapped_cpt_file;  // defined in paddr.c
@@ -116,7 +116,7 @@ static inline int parse_args(int argc, char *argv[]) {
     {"cpt-mmode"          , no_argument      , NULL, 7},
     {"map-cpt"            , required_argument, NULL, 10},
     {"checkpoint-format"  , required_argument, NULL, 12},
-    {"using-flash-store-checkpoint", no_argument, NULL, 17},
+    {"store-cpt-in-flash", no_argument, NULL, 17},
 
     // profiling
     {"simpoint-profile"   , no_argument      , NULL, 3},
@@ -158,7 +158,7 @@ static inline int parse_args(int argc, char *argv[]) {
 
       case 17:
       #ifdef CONFIG_HAS_FLASH
-        flash_store_checkpoint = true;
+        store_cpt_in_flash = true;
       #else
         assert(0);
       #endif
@@ -281,7 +281,7 @@ static inline int parse_args(int argc, char *argv[]) {
         printf("\t--manual-oneshot-cpt    Manually take one-shot cpt by send signal.\n");
         printf("\t--manual-uniform-cpt    Manually take uniform cpt by send signal.\n");
         printf("\t--checkpoint-format=FORMAT            Specify the checkpoint format('gz' or 'zstd'), default: 'gz'.\n");
-        printf("\t--using-flash-store-checkpoint        Use this option to save the checkpoint to flash storage.\n");
+        printf("\t--store-cpt-in-flash    Use this option to save the checkpoint to flash storage.\n");
 //        printf("\t--map-cpt               map to this file as pmem, which can be treated as a checkpoint.\n"); //comming back soon
 
         printf("\t--flash-image=FLASH_IMAGE             image path of flash\n");
@@ -326,14 +326,14 @@ void init_monitor(int argc, char *argv[]) {
 
   extern void init_path_manager();
   extern void simpoint_init();
-  extern void init_serializer(bool flash_store_checkpoint);
+  extern void init_serializer(bool store_cpt_in_flash);
 
   //checkpoint and profiling set output
   bool output_features_enabled = checkpoint_state != NoCheckpoint || profiling_state == SimpointProfiling;
   if (output_features_enabled) {
     init_path_manager();
     simpoint_init();
-    init_serializer(flash_store_checkpoint);
+    init_serializer(store_cpt_in_flash);
   }
 
   /* Initialize memory. */

--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -44,6 +44,7 @@ static char *flash_image = NULL;
 static int batch_mode = false;
 static int difftest_port = 1234;
 char *max_instr = NULL;
+static bool flash_store_checkpoint = false;
 char compress_file_format = 0; // default is gz
 
 extern char *mapped_cpt_file;  // defined in paddr.c
@@ -115,6 +116,7 @@ static inline int parse_args(int argc, char *argv[]) {
     {"cpt-mmode"          , no_argument      , NULL, 7},
     {"map-cpt"            , required_argument, NULL, 10},
     {"checkpoint-format"  , required_argument, NULL, 12},
+    {"using-flash-store-checkpoint", no_argument, NULL, 17},
 
     // profiling
     {"simpoint-profile"   , no_argument      , NULL, 3},
@@ -152,6 +154,14 @@ static inline int parse_args(int argc, char *argv[]) {
 
       case 16:
         flash_image = optarg;
+        break;
+
+      case 17:
+      #ifdef CONFIG_HAS_FLASH
+        flash_store_checkpoint = true;
+      #else
+        assert(0);
+      #endif
         break;
 
       case 'r':
@@ -271,6 +281,7 @@ static inline int parse_args(int argc, char *argv[]) {
         printf("\t--manual-oneshot-cpt    Manually take one-shot cpt by send signal.\n");
         printf("\t--manual-uniform-cpt    Manually take uniform cpt by send signal.\n");
         printf("\t--checkpoint-format=FORMAT            Specify the checkpoint format('gz' or 'zstd'), default: 'gz'.\n");
+        printf("\t--using-flash-store-checkpoint        Use this option to save the checkpoint to flash storage.\n");
 //        printf("\t--map-cpt               map to this file as pmem, which can be treated as a checkpoint.\n"); //comming back soon
 
         printf("\t--flash-image=FLASH_IMAGE             image path of flash\n");
@@ -315,14 +326,14 @@ void init_monitor(int argc, char *argv[]) {
 
   extern void init_path_manager();
   extern void simpoint_init();
-  extern void init_serializer();
+  extern void init_serializer(bool flash_store_checkpoint);
 
   //checkpoint and profiling set output
   bool output_features_enabled = checkpoint_state != NoCheckpoint || profiling_state == SimpointProfiling;
   if (output_features_enabled) {
     init_path_manager();
     simpoint_init();
-    init_serializer();
+    init_serializer(flash_store_checkpoint);
   }
 
   /* Initialize memory. */


### PR DESCRIPTION
This commit introduces the `--using-flash-store-checkpoint` option, which is intended to enable saving checkpoints directly to flash storage.

Currently, this option is not yet implemented in the workflow. Future updates will integrate this feature into the relevant checkpoint handling logic.