### PR TITLE
feat: replace fixed get_pmem with serialize_base_addr for checkpoint storage

### DIFF
--- a/include/checkpoint/serializer.h
+++ b/include/checkpoint/serializer.h
@@ -32,7 +32,7 @@ class Serializer
 
     void serializePMem(uint64_t inst_count);
 
-    void serializeRegs();
+    void serializeRegs(uint8_t* serialize_base_addr);
 
     explicit Serializer();
 


### PR DESCRIPTION
Replaced the hardcoded `get_pmem` with `serialize_base_addr` to enable specifying the checkpoint storage location via the `--using-flash-store-checkpoint` option. While this change lays the groundwork for saving checkpoints to flash, the functionality is not yet fully implemented and will be completed in future updates.