### PR TITLE
feat: support `--store-cpt-in-flash` option to set `serialize_reg_base_addr` to flash address

### DIFF
--- a/src/checkpoint/serializer.cpp
+++ b/src/checkpoint/serializer.cpp
@@ -279,11 +279,8 @@ void Serializer::serialize(uint64_t inst_count) {
   uint8_t* serialize_reg_base_addr = NULL;
 
   if (store_cpt_in_flash) {
-#ifdef CONFIG_HAS_FLASH
-    serialize_reg_base_addr = get_flash_base();
-#else
-    assert(0);
-#endif
+    IFDEF(CONFIG_HAS_FLASH, serialize_reg_base_addr = get_flash_base());
+    IFNDEF(CONFIG_HAS_FLASH, Log("Please enable the flash device to activate the functionality of saving checkpoints to flash."); assert(0));
   } else {
     serialize_reg_base_addr = get_pmem();
   }

--- a/src/checkpoint/serializer.cpp
+++ b/src/checkpoint/serializer.cpp
@@ -278,7 +278,15 @@ void Serializer::serialize(uint64_t inst_count) {
 #ifdef CONFIG_MEM_COMPRESS
   uint8_t* serialize_reg_base_addr = NULL;
 
-  serialize_reg_base_addr = get_pmem();
+  if (store_cpt_in_flash) {
+#ifdef CONFIG_HAS_FLASH
+    serialize_reg_base_addr = get_flash_base();
+#else
+    assert(0);
+#endif
+  } else {
+    serialize_reg_base_addr = get_pmem();
+  }
   assert(serialize_reg_base_addr);
 
   serializeRegs(serialize_reg_base_addr);


### PR DESCRIPTION
Implemented use the `--store-cpt-in-flash` option configure `serialize_reg_base_addr` to point to the flash address.