### PR TITLE
fix(aia): external interrupt priority from CLINT or IMSIC

### DIFF
--- a/include/isa.h
+++ b/include/isa.h
@@ -94,6 +94,7 @@ void isa_update_mtopi();
 void isa_update_stopi();
 void isa_update_vstopi();
 void isa_update_hgeip();
+void isa_update_external_interrupt_select();
 #endif
 void isa_sync_custom_mflushpwr(bool l2FlushDone);
 

--- a/src/cpu/difftest/ref.c
+++ b/src/cpu/difftest/ref.c
@@ -259,6 +259,10 @@ void difftest_non_reg_interrupt_pending(void *nonRegInterruptPending) {
   memcpy(&cpu.non_reg_interrupt_pending, nonRegInterruptPending, sizeof(struct NonRegInterruptPending));
   isa_update_mip(cpu.non_reg_interrupt_pending.lcofi_req);
 #ifdef CONFIG_RV_IMSIC
+  if (cpu.non_reg_interrupt_pending.platform_irp_meip || cpu.non_reg_interrupt_pending.from_aia_meip ||
+      cpu.non_reg_interrupt_pending.platform_irp_seip || cpu.non_reg_interrupt_pending.from_aia_seip) {
+    isa_update_external_interrupt_select();
+  }
   isa_update_mtopi();
   isa_update_stopi();
   isa_update_vstopi();

--- a/src/isa/riscv64/difftest/ref.c
+++ b/src/isa/riscv64/difftest/ref.c
@@ -430,6 +430,14 @@ void isa_update_mhpmcounter_overflow(uint64_t mhpmeventOverflowVec) {
 }
 
 #ifdef CONFIG_RV_IMSIC
+void isa_update_external_interrupt_select() {
+  if (cpu.non_reg_interrupt_pending.from_aia_meip || cpu.non_reg_interrupt_pending.from_aia_seip) {
+    cpu.external_interrupt_select = true;
+  } else {
+    cpu.external_interrupt_select = false;
+  }
+}
+
 void isa_update_mtopi() {
   update_mtopi();
 }

--- a/src/isa/riscv64/include/isa-def.h
+++ b/src/isa/riscv64/include/isa-def.h
@@ -50,6 +50,8 @@ struct NonRegInterruptPending {
   bool platform_irp_stip;
   bool platform_irp_vseip;
   bool platform_irp_vstip;
+  bool from_aia_meip;
+  bool from_aia_seip;
   bool lcofi_req;
 };
 
@@ -82,7 +84,6 @@ struct MemEventQueryResult {
 typedef struct TriggerModule TriggerModule;
 typedef struct IpriosModule IpriosModule;
 typedef struct IpriosSort IpriosSort;
-typedef struct HighestPrioIntr HighestPrioIntr;
 
 typedef struct {
   // Below will be synced by regcpy when run difftest, DO NOT TOUCH
@@ -187,12 +188,14 @@ typedef struct {
 #ifdef CONFIG_RV_IMSIC
   struct FromAIA fromaia;
   IpriosModule*  MIprios;
+  IpriosModule*  MIprios_rdata;
   IpriosModule*  SIprios;
+  IpriosModule*  SIprios_rdata;
   IpriosModule* VSIprios;
   IpriosSort*    MIpriosSort;
   IpriosSort*    SIpriosSort;
   IpriosSort*   VSIpriosSort;
-  HighestPrioIntr* HighestPrioIntr;
+  bool external_interrupt_select;
 #endif
 
 } riscv64_CPU_state;

--- a/src/isa/riscv64/local-include/aia.h
+++ b/src/isa/riscv64/local-include/aia.h
@@ -21,13 +21,10 @@ typedef struct IpriosModule {
 
 typedef struct {
   bool enable;
+  bool isZero;
+  bool greaterThan255;
   uint8_t priority;
 } IpriosEnable;
-
-typedef struct HighestPrioIntr {
-  uint8_t idx;
-  uint8_t priority;
-} HighestPrioIntr;
 
 typedef struct IpriosSort {
   IpriosEnable ipriosEnable[IPRIO_ENABLE_NUM];
@@ -38,7 +35,7 @@ typedef struct {
 } Hviprios;
 
 bool iprio_is_zero(IpriosModule* iprios);
-void set_iprios_sort(uint64_t topi_gather, IpriosSort* iprios_sort, IpriosModule* iprios);
+void set_iprios_sort(uint64_t topi_gather, IpriosSort* iprios_sort, IpriosModule* iprios, uint8_t xei, mtopei_t* xtopei);
 void set_viprios_sort(uint64_t topi_gather);
 uint8_t high_iprio(IpriosSort* ipriosSort, uint8_t xei);
 uint8_t get_prio_idx_in_group(uint8_t irq);


### PR DESCRIPTION
* The current external interrupts come from two sources, `CLINT` and `IMSIC`.
  The external interrupt priority number of CLINT is `0`, and the external interrupt priority number of IMSIC is `1~2047`.
  We use the global variable `external_interrupt_select` to determine the source of the external interrupt.
  If the external interrupt comes from CLINT, `external_interrupt_select` = false;
  if the external interrupt comes from IMSIC, `external_interrupt_select` = true.

* The case where the priority number is greater than `255` is added to the interrupt priority comparison method.

* The priority number of each interrupt in the `iprios array` occupies `8` bits, and its read data is masked by the corresponding bit of the `xie` register, so when writing the `xie` register, the `read data` of the `iprios array` needs to be updated.