### PR TITLE
fix(hgeie): fix macro generation logic for 'HGEIE_MASK'

### DIFF
--- a/src/isa/riscv64/system/priv.c
+++ b/src/isa/riscv64/system/priv.c
@@ -471,7 +471,7 @@ static inline word_t* csr_decode(uint32_t addr) {
 #define HIP_WMASK     MIP_VSSIP
 #define HIE_RMASK     HSI_MASK
 #define HIE_WMASK     HSI_MASK
-#define HGEIE_MASK    ((1ULL << (1 + MUXDEF(CONFIG_GEILEN, CONFIG_GEILEN, 0))) - 2) // bit 0 is read-only zero
+#define HGEIE_MASK    ((1ULL << (1 + MUXDEF(CONFIG_RV_IMSIC, CONFIG_GEILEN, 0))) - 2) // bit 0 is read-only zero
 #define HGEIP_MASK    HGEIE_MASK
 #define HIDELEG_MASK  (VSI_MASK | MUXDEF(CONFIG_RV_SHLCOFIDELEG, MIP_LCOFIP, 0))
 #define HEDELEG_MASK  ((1 << EX_IAM) | \


### PR DESCRIPTION
We should know that `MUXDEF` can only be used when the condition is `bool`.

The reason for this is as follows:

> #define CHOOSE2nd(a, b, ...) b
> #define MUX_WITH_COMMA(contain_comma, a, b) CHOOSE2nd(contain_comma a, b)
> #define MUX_MACRO_PROPERTY(p, macro, a, b) MUX_WITH_COMMA(concat(p, macro), a, b)
> // define placeholders for some property
> #define __P_DEF_0  X,
> #define __P_DEF_1  X,
> #define __P_ONE_1  X,
> #define __P_ZERO_0 X,
> // define some selection functions based on the properties of BOOLEAN macro
> #define MUXDEF(macro, X, Y)  MUX_MACRO_PROPERTY(__P_DEF_, macro, X, Y)
> #define MUXNDEF(macro, X, Y) MUX_MACRO_PROPERTY(__P_DEF_, macro, Y, X)
> #define MUXONE(macro, X, Y)  MUX_MACRO_PROPERTY(__P_ONE_, macro, X, Y)
> #define MUXZERO(macro, X, Y) MUX_MACRO_PROPERTY(__P_ZERO_,macro, X, Y)

When `macro` is defined as non-0/1, then `Y` will always be selected.