### PR TITLE
chore: fix so generation

### DIFF
--- a/scripts/generate_so_for_difftest.sh
+++ b/scripts/generate_so_for_difftest.sh
@@ -17,27 +17,27 @@ make riscv64-xs-ref_defconfig && \
 
 artifact_dir=$(pwd)/artifact
 mkdir -p $artifact_dir
-make clean
+make clean-all
 make riscv64-xs-ref_defconfig
 make -j
 cp build/riscv64-nemu-interpreter-so ${artifact_dir}/riscv64-nemu-interpreter-so
 
-make clean
+make clean-all
 make riscv64-xs-ref-debug_defconfig
 make -j
 cp build/riscv64-nemu-interpreter-so ${artifact_dir}/riscv64-nemu-interpreter-debug-so
 
-make clean
+make clean-all
 make riscv64-dual-xs-ref_defconfig
 make -j
 cp build/riscv64-nemu-interpreter-so ${artifact_dir}/riscv64-nemu-interpreter-dual-so
 
-make clean
+make clean-all
 make riscv64-dual-xs-ref-debug_defconfig
 make -j
 cp build/riscv64-nemu-interpreter-so ${artifact_dir}/riscv64-nemu-interpreter-dual-debug-so
 
-make clean
+make clean-all
 make riscv64-xs-ref_bitmap_defconfig
 make -j
 cp build/riscv64-nemu-interpreter-so ${artifact_dir}/riscv64-nemu-interpreter-bitmap-so


### PR DESCRIPTION
`riscv64-xs-ref_defconfig` is currently not being generated properly, so here need `make clean-all`.