### PR TITLE
fix(vfred): execute vfred inst need mstatus.fs and vsstatus.fs not off

### DIFF
--- a/src/isa/riscv64/instr/rvv/vcompute_impl.c
+++ b/src/isa/riscv64/instr/rvv/vcompute_impl.c
@@ -1506,6 +1506,7 @@ void reduction_instr(int opcode, int is_signed, int wide, Decode *s) {
 
 void float_reduction_instr(int opcode, int widening, Decode *s) {
   isa_fp_rm_check(isa_fp_get_frm());
+  require_float();
 
   vector_reduction_check(s, widening);
   if (widening)
@@ -1675,6 +1676,7 @@ void float_reduction_step1(uint64_t src1, uint64_t src2, Decode *s) {
 
 void float_reduction_computing(Decode *s) {
   isa_fp_rm_check(isa_fp_get_frm());
+  require_float();
   vector_reduction_check(s, false);
   word_t FPCALL_TYPE = FPCALL_W64;
   uint64_t active_num = 0;


### PR DESCRIPTION
* When executing vfred related instructions, we need to check that mstatus.fs and vsstatus.fs are not off. If they are off, an illegal instruction exception will be reported. NEMU missed this check.
* This patch fixes it.