### PR TITLE
fix(vstopi): remove SEI from Candidate 4

### DIFF
--- a/src/isa/riscv64/local-include/intr.h
+++ b/src/isa/riscv64/local-include/intr.h
@@ -69,6 +69,7 @@ enum {
 #define HSI_MASK   (VSI_MASK | MIP_SGEIP)
 #define SI_MASK    (MIP_SSIP | MIP_STIP | MIP_SEIP)
 #define LCI_MASK   (~0x1FFFULL)
+#define EXCLUDE_SEI_MASK ~(0x1ULL << IRQ_SEIP)
 
 // now NEMU does not support EX_IAM,
 // so it may ok to use EX_IAM to indicate a successful memory access

--- a/src/isa/riscv64/system/priv.c
+++ b/src/isa/riscv64/system/priv.c
@@ -1318,11 +1318,11 @@ inline void update_vstopi() {
   bool candidate1 = read_vsip.seip && read_vsie.seie && (hstatus->vgein != 0) && (cpu.fromaia.vstopei != 0);
   bool candidate2 = read_vsip.seip && read_vsie.seie && (hstatus->vgein == 0) && (hvictl->iid == 9) && (hvictl->iprio != 0);
   bool candidate3 = read_vsip.seip && read_vsie.seie && !candidate1 && !candidate2;
-  bool candidate4 = !hvictl->vti && (read_vsie.val & read_vsip.val & 0xfffffffffffffdff);
+  bool candidate4 = !hvictl->vti && (read_vsie.val & read_vsip.val & EXCLUDE_SEI_MASK);
   bool candidate5 = hvictl->vti && (hvictl->iid != 9);
   bool candidate_no_valid = !candidate1 && !candidate2 && !candidate3 && !candidate4 && !candidate5;
 
-  uint64_t vstopi_gather = get_vsip() & get_vsie();
+  uint64_t vstopi_gather = get_vsip() & get_vsie() & EXCLUDE_SEI_MASK;
   set_viprios_sort(vstopi_gather);
 
   uint8_t vs_iid_idx = high_iprio(cpu.VSIpriosSort, IRQ_VSEIP);


### PR DESCRIPTION
* if hvictl.VTI = 0:
* the highest-priority pending-and-enabled major interrupt indicated
* by vsip and vsie other than a supervisor external interrupt(code 9),
* using the priority numbers assigned by hviprio1 and hviprio2. 
* 
* A hypervisor can choose to employ registers hviprio1 and hviprio2
* when emulating the (virtual) supervisor-level iprio array accessed
* indirectly through siselect and sireg (really vsiselect and vsireg)
* for a virtual hart. For interrupts not in the subset supported by
* hviprio1 and hviprio2, the priority number bytes in the emulated
* iprio array can be read-only zeros.