### PR TITLE
fix(xtopi): fix xtopi generation conditions

### DIFF
--- a/src/isa/riscv64/local-include/aia.h
+++ b/src/isa/riscv64/local-include/aia.h
@@ -34,7 +34,6 @@ typedef struct {
   uint8_t hviprios[24];
 } Hviprios;
 
-bool iprio_is_zero(IpriosModule* iprios);
 void set_iprios_sort(uint64_t topi_gather, IpriosSort* iprios_sort, IpriosModule* iprios, uint8_t xei, mtopei_t* xtopei);
 void set_viprios_sort(uint64_t topi_gather);
 uint8_t high_iprio(IpriosSort* ipriosSort, uint8_t xei);

--- a/src/isa/riscv64/system/aia.c
+++ b/src/isa/riscv64/system/aia.c
@@ -35,14 +35,6 @@ int interrupt_default_prio[IPRIO_ENABLE_NUM] = {
   49, 24, 48
 };
 
-bool iprio_is_zero(IpriosModule* iprios) {
-  bool is_zero = true;
-  for (int i = 0; i < IPRIO_NUM; i++) {
-    is_zero &= iprios->iprios[i].val == 0;
-  }
-  return is_zero;
-}
-
 uint8_t get_prio_idx_in_group(uint8_t irq) {
   uint8_t idx = 0;
   for (int i = 0; i < IPRIO_ENABLE_NUM; i++) {

--- a/src/isa/riscv64/system/priv.c
+++ b/src/isa/riscv64/system/priv.c
@@ -1332,7 +1332,6 @@ static inline void update_siprios() {
 inline void update_mtopi() {
   update_miprios();
 
-  bool miprios_is_zero = iprio_is_zero(cpu.MIprios_rdata);
   uint64_t mtopi_gather = get_mip() & mie->val & (~(mideleg->val));
   bool mtopi_is_not_zero = mtopi_gather != 0;
 
@@ -1349,16 +1348,12 @@ inline void update_mtopi() {
 
   if (mtopi_is_not_zero) {
     mtopi->iid = m_iid_num;
-    if (miprios_is_zero) {
-      mtopi->iprio = 1;
-    } else {
-      if (m_prio_greater_255 || (m_prio_is_zero && m_iid_default_prio_low_MEI)) {
-        mtopi->iprio = 255;
-      } else if (m_prio_is_zero && m_iid_default_prio_high_MEI) {
-        mtopi->iprio = 0;
-      } else if ((m_prio_num >= 1) && (m_prio_num <= 255)) {
-        mtopi->iprio = m_prio_num;
-      }
+    if (m_prio_greater_255 || (m_prio_is_zero && m_iid_default_prio_low_MEI)) {
+      mtopi->iprio = 255;
+    } else if (m_prio_is_zero && m_iid_default_prio_high_MEI) {
+      mtopi->iprio = 0;
+    } else if ((m_prio_num >= 1) && (m_prio_num <= 255)) {
+      mtopi->iprio = m_prio_num;
     }
   } else {
     mtopi->val = 0;
@@ -1370,7 +1365,6 @@ inline void update_mtopi() {
 inline void update_stopi() {
   update_siprios();
 
-  bool siprios_is_zero = iprio_is_zero(cpu.SIprios_rdata);
   hip_t read_hip = (hip_t)get_hip();
   sip_t read_sip = (sip_t)non_vmode_get_sip();
   hie_t read_hie = (hie_t)get_hie();
@@ -1392,16 +1386,12 @@ inline void update_stopi() {
 
   if (stopi_is_not_zero) {
     stopi->iid = s_iid_num;
-    if (siprios_is_zero) {
-      stopi->iprio = 1;
-    } else {
-      if (s_prio_greater_255 || (s_prio_is_zero && s_iid_default_prio_low_SEI)) {
-        stopi->iprio = 255;
-      } else if (s_prio_is_zero && s_iid_default_prio_high_SEI) {
-        stopi->iprio = 0;
-      } else if ((s_prio_num >= 1) && (s_prio_num <= 255)) {
-        stopi->iprio = s_prio_num;
-      }
+    if (s_prio_greater_255 || (s_prio_is_zero && s_iid_default_prio_low_SEI)) {
+      stopi->iprio = 255;
+    } else if (s_prio_is_zero && s_iid_default_prio_high_SEI) {
+      stopi->iprio = 0;
+    } else if ((s_prio_num >= 1) && (s_prio_num <= 255)) {
+      stopi->iprio = s_prio_num;
     }
   } else {
     stopi->val = 0;


### PR DESCRIPTION
* For `mtopi` / `stopi` :
> AIA Spec:

> If all bytes of the supervisor-level iprio array are read-only zeros, a simplified implementation of field `IPRIO` is allowed in which its value is always `1` whenever `stopi` is not zero.

* We are configurable and `do not need` to simplify the implementation.

* For `vstopi`: 
> AIA Spec:

> Ties in nominal priority are broken as usual by the default priority order from `Table 8`, unless `hvictl` fields `VTI = 1` and `IID ≠ 9` (last item in the candidate list above), in which case default priority order is determined solely by `hvictl.DPR`.

> If bit `IPRIOM` (IPRIO Mode) of `hvictl` is zero, `IPRIO` in `vstopi` is 1; else, if the priority number for the highest-priority candidate is within the range `1` to `255`, `IPRIO` is that value; else, `IPRIO` is set to either `0` or `255` in the manner documented for `stopi` in `Section 5.4.2`.