### PR TITLE
fix(LCOFI): fix writable of LCOFI bit(13) of mvip/mvien/hvip/hvien

### DIFF
--- a/src/isa/riscv64/local-include/intr.h
+++ b/src/isa/riscv64/local-include/intr.h
@@ -69,6 +69,7 @@ enum {
 #define HSI_MASK   (VSI_MASK | MIP_SGEIP)
 #define SI_MASK    (MIP_SSIP | MIP_STIP | MIP_SEIP)
 #define LCI_MASK   (~0x1FFFULL)
+#define LCI_EXCLUDE_LCOFI_MASK (~0x3FFFULL)
 #define EXCLUDE_SEI_MASK ~(0x1ULL << IRQ_SEIP)
 
 // now NEMU does not support EX_IAM,

--- a/src/isa/riscv64/system/priv.c
+++ b/src/isa/riscv64/system/priv.c
@@ -553,9 +553,10 @@ static inline word_t* csr_decode(uint32_t addr) {
 
 #define LCOFI MUXDEF(CONFIG_RV_SSCOFPMF, (1 << 13), 0)
 #define LCI MUXDEF(CONFIG_RV_AIA, LCI_MASK, 0)
+#define LCI_NO_LCOFI MUXDEF(CONFIG_RV_AIA, LCI_EXCLUDE_LCOFI_MASK, 0)
 
 #ifdef CONFIG_RVH
-#define HVIP_MASK     (VSI_MASK | LCOFI | LCI)
+#define HVIP_MASK     (VSI_MASK | LCI_NO_LCOFI)
 #define HIP_RMASK     (MIP_VSTIP | MIP_VSEIP | MIP_SGEIP)
 #define HIP_WMASK     MIP_VSSIP
 #define HIE_RMASK     HSI_MASK
@@ -647,12 +648,12 @@ static inline word_t* csr_decode(uint32_t addr) {
 #define SIE_LCOFI_MASK_MIE (mideleg->val & LCOFI)
 
 // mvien
-#define MVIEN_MASK (LCI | LCOFI | (1 << 9) | (1 << 1))
+#define MVIEN_MASK (LCI_NO_LCOFI | (1 << 9) | (1 << 1))
 // hvien
-#define HVIEN_MSAK (LCI | LCOFI)
+#define HVIEN_MSAK LCI_NO_LCOFI
 
 // mvip
-#define MVIP_MASK MUXDEF(CONFIG_RV_AIA, (LCOFI | LCI), 0)
+#define MVIP_MASK MUXDEF(CONFIG_RV_AIA, LCI_NO_LCOFI, 0)
 
 #define FFLAGS_MASK 0x1f
 #define FRM_MASK 0x07


### PR DESCRIPTION
For implementations that support Smcdeleg, Sscofpmf, and Smaia, the local counter overflow interrupt (LCOFI) bit (bit 13) in each of CSRs mvip and mvien is implemented and writable.

For implementations that support Smcdeleg/Ssccfg, Sscofpmf, Smaia/Ssaia, and the H extension, the LCOFI bit (bit 13) in each of hvip and hvien is implemented and writable.