### PR TITLE
fix(aia, difftest): fix AIA sync between XiangShan and NEMU

### DIFF
--- a/src/cpu/difftest/ref.c
+++ b/src/cpu/difftest/ref.c
@@ -309,6 +309,8 @@ void difftest_update_vec_load_pmem() {
 void difftest_sync_aia(void *src) {
 #ifdef CONFIG_RV_IMSIC
   memcpy(&cpu.fromaia, src, sizeof(struct FromAIA));
+  isa_update_mtopi();
+  isa_update_stopi();
   isa_update_vstopi();
   isa_update_hgeip();
 #endif

--- a/src/isa/riscv64/include/isa-def.h
+++ b/src/isa/riscv64/include/isa-def.h
@@ -206,6 +206,9 @@ typedef struct {
   uint64_t old_mtopei;
   uint64_t old_stopei;
   uint64_t old_vstopei;
+  uint64_t old_mtopi;
+  uint64_t old_stopi;
+  uint64_t old_vstopi;
 #endif
 
 } riscv64_CPU_state;

--- a/src/isa/riscv64/include/isa-def.h
+++ b/src/isa/riscv64/include/isa-def.h
@@ -203,6 +203,9 @@ typedef struct {
   IpriosSort*    SIpriosSort;
   IpriosSort*   VSIpriosSort;
   bool external_interrupt_select;
+  uint64_t old_mtopei;
+  uint64_t old_stopei;
+  uint64_t old_vstopei;
 #endif
 
 } riscv64_CPU_state;

--- a/src/isa/riscv64/init.c
+++ b/src/isa/riscv64/init.c
@@ -166,6 +166,9 @@ void init_isa() {
   mtopei->val = 0;
   stopei->val = 0;
   vstopei->val = 0;
+  cpu.old_mtopei = 0;
+  cpu.old_stopei = 0;
+  cpu.old_vstopei = 0;
 #endif // CONFIG_RV_IMSIC
 
   misa->mxl = 2; // XLEN = 64

--- a/src/isa/riscv64/init.c
+++ b/src/isa/riscv64/init.c
@@ -169,6 +169,9 @@ void init_isa() {
   cpu.old_mtopei = 0;
   cpu.old_stopei = 0;
   cpu.old_vstopei = 0;
+  cpu.old_mtopi = 0;
+  cpu.old_stopi = 0;
+  cpu.old_vstopi = 0;
 #endif // CONFIG_RV_IMSIC
 
   misa->mxl = 2; // XLEN = 64

--- a/src/isa/riscv64/system/priv.c
+++ b/src/isa/riscv64/system/priv.c
@@ -1682,8 +1682,8 @@ static word_t csr_read(uint32_t csrid) {
       IFDEF(CONFIG_RVH, if (cpu.v) return vsiselect->val);
       return siselect->val;
     case CSR_STOPI:
-      if (cpu.v) return vstopi->val;
-      return stopi->val;
+      if (cpu.v) return cpu.old_vstopi;
+      return cpu.old_stopi;
     case CSR_STOPEI:
       if (cpu.v) return cpu.old_vstopei;
       return cpu.old_stopei;
@@ -1729,6 +1729,7 @@ static word_t csr_read(uint32_t csrid) {
     case CSR_HVIP: return hvip->val & HVIP_MASK;
     case CSR_HGEIP: return hgeip->val & HGEIP_MASK;
 #ifdef CONFIG_RV_IMSIC
+    case CSR_VSTOPI: return cpu.old_vstopi;
     case CSR_VSTOPEI: return cpu.old_vstopei;
     case CSR_VSIREG:
     {
@@ -1748,6 +1749,7 @@ static word_t csr_read(uint32_t csrid) {
     case CSR_MVIEN: return mvien->val & MVIEN_MASK;
     case CSR_MVIP: return get_mvip();
 #ifdef CONFIG_RV_IMSIC
+    case CSR_MTOPI: return cpu.old_mtopi;
     case CSR_MTOPEI: return cpu.old_mtopei;
     case CSR_MIREG:
     {
@@ -2956,6 +2958,12 @@ static void sync_old_xtopei() {
   cpu.old_stopei = cpu.fromaia.stopei;
   cpu.old_vstopei = cpu.fromaia.vstopei;
 }
+
+static void sync_old_xtopi() {
+  cpu.old_mtopi = mtopi->val;
+  cpu.old_stopi = stopi->val;
+  cpu.old_vstopi = vstopi->val;
+}
 #endif // CONFIG_RV_IMSIC
 
 void riscv64_priv_csrrw(rtlreg_t *dest, word_t val, word_t csrid, word_t rd) {
@@ -2966,6 +2974,7 @@ void riscv64_priv_csrrw(rtlreg_t *dest, word_t val, word_t csrid, word_t rd) {
   csr_write(csrid, val);
 #ifdef CONFIG_RV_IMSIC
   sync_old_xtopei();
+  sync_old_xtopi();
 #endif // CONFIG_RV_IMSIC
 }
 
@@ -2977,6 +2986,7 @@ void riscv64_priv_csrrs(rtlreg_t *dest, word_t val, word_t csrid, word_t rs1) {
   }
 #ifdef CONFIG_RV_IMSIC
   sync_old_xtopei();
+  sync_old_xtopi();
 #endif // CONFIG_RV_IMSIC
 }
 
@@ -2988,6 +2998,7 @@ void riscv64_priv_csrrc(rtlreg_t *dest, word_t val, word_t csrid, word_t rs1) {
   }
 #ifdef CONFIG_RV_IMSIC
   sync_old_xtopei();
+  sync_old_xtopi();
 #endif // CONFIG_RV_IMSIC
 }
 

--- a/src/isa/riscv64/system/priv.c
+++ b/src/isa/riscv64/system/priv.c
@@ -1685,8 +1685,8 @@ static word_t csr_read(uint32_t csrid) {
       if (cpu.v) return vstopi->val;
       return stopi->val;
     case CSR_STOPEI:
-      if (cpu.v) return cpu.fromaia.vstopei;
-      return cpu.fromaia.stopei;
+      if (cpu.v) return cpu.old_vstopei;
+      return cpu.old_stopei;
     case CSR_SIREG:
     {
       bool siselect_is_major_ip = iselect_is_major_ip(siselect->val);
@@ -1729,7 +1729,7 @@ static word_t csr_read(uint32_t csrid) {
     case CSR_HVIP: return hvip->val & HVIP_MASK;
     case CSR_HGEIP: return hgeip->val & HGEIP_MASK;
 #ifdef CONFIG_RV_IMSIC
-    case CSR_VSTOPEI: return cpu.fromaia.vstopei;
+    case CSR_VSTOPEI: return cpu.old_vstopei;
     case CSR_VSIREG:
     {
       bool vsiselect_is_major_ip = iselect_is_major_ip(siselect->val);
@@ -1748,7 +1748,7 @@ static word_t csr_read(uint32_t csrid) {
     case CSR_MVIEN: return mvien->val & MVIEN_MASK;
     case CSR_MVIP: return get_mvip();
 #ifdef CONFIG_RV_IMSIC
-    case CSR_MTOPEI: return cpu.fromaia.mtopei;
+    case CSR_MTOPEI: return cpu.old_mtopei;
     case CSR_MIREG:
     {
       bool miselect_is_major_ip = iselect_is_major_ip(miselect->val);
@@ -2950,12 +2950,23 @@ static inline void csr_permit_check(uint32_t addr, bool is_write) {
   if (has_vi) longjmp_exception(EX_VI);
 }
 
+#ifdef CONFIG_RV_IMSIC
+static void sync_old_xtopei() {
+  cpu.old_mtopei = cpu.fromaia.mtopei;
+  cpu.old_stopei = cpu.fromaia.stopei;
+  cpu.old_vstopei = cpu.fromaia.vstopei;
+}
+#endif // CONFIG_RV_IMSIC
+
 void riscv64_priv_csrrw(rtlreg_t *dest, word_t val, word_t csrid, word_t rd) {
   csr_permit_check(csrid, true);
   if (rd) {
     *dest = csr_read(csrid);
   }
   csr_write(csrid, val);
+#ifdef CONFIG_RV_IMSIC
+  sync_old_xtopei();
+#endif // CONFIG_RV_IMSIC
 }
 
 void riscv64_priv_csrrs(rtlreg_t *dest, word_t val, word_t csrid, word_t rs1) {
@@ -2964,6 +2975,9 @@ void riscv64_priv_csrrs(rtlreg_t *dest, word_t val, word_t csrid, word_t rs1) {
   if (rs1) {
     csr_write(csrid, val | *dest);
   }
+#ifdef CONFIG_RV_IMSIC
+  sync_old_xtopei();
+#endif // CONFIG_RV_IMSIC
 }
 
 void riscv64_priv_csrrc(rtlreg_t *dest, word_t val, word_t csrid, word_t rs1) {
@@ -2972,6 +2986,9 @@ void riscv64_priv_csrrc(rtlreg_t *dest, word_t val, word_t csrid, word_t rs1) {
   if (rs1) {
     csr_write(csrid, (~val) & *dest);
   }
+#ifdef CONFIG_RV_IMSIC
+  sync_old_xtopei();
+#endif // CONFIG_RV_IMSIC
 }
 
 static bool execIn (cpu_mode_t mode) {

--- a/src/isa/riscv64/system/priv.c
+++ b/src/isa/riscv64/system/priv.c
@@ -1326,7 +1326,8 @@ static inline void update_miprios() {
   // For a given interrupt number, if the corresponding bit in mie is read-only zero,
   // then the interrupt’s priority number in the iprio array must be read-only zero as well.
   // The priority number for a machine-level external interrupt (bits 31:24 of register iprio2) must also be read-only zero.
-  cpu.MIprios->iprios[1].val = cpu.MIprios->iprios[1].val & 0xffffffff00ffffff;
+  cpu.MIprios->iprios[0].val = cpu.MIprios->iprios[0].val & 0xffffff00ffffff00;
+  cpu.MIprios->iprios[1].val = cpu.MIprios->iprios[1].val & 0xffffffff00ffff00;
   for (int i = 0; i < IPRIO_NUM; i++) {
     uint64_t mask = 0;
     for (int j = 0; j < 8; j++) {
@@ -1343,7 +1344,8 @@ static inline void update_siprios() {
   // For a given interrupt number, if the corresponding bit in sie is read-only zero,
   // then the interrupt’s priority number in the supervisor-level iprio array must be read-only zero as well.
   // The priority number for a supervisor-level external interrupt (bits 15:8 of iprio2) must also be read-only zero.
-  cpu.SIprios->iprios[1].val = cpu.SIprios->iprios[1].val & 0xffffffffffff00ff;
+  cpu.SIprios->iprios[0].val = cpu.SIprios->iprios[0].val & 0xffffff00ffffff00;
+  cpu.SIprios->iprios[1].val = cpu.SIprios->iprios[1].val & 0xffffffffffff0000;
   for (int i = 0; i < IPRIO_NUM; i++) {
     uint64_t mask = 0;
     for (int j = 0; j < 8; j++) {


### PR DESCRIPTION
> AIA spec:

> A write to a *topei CSR claims the reported interrupt identity by clearing its pending bit in the interrupt file. The value written is ignored; rather, the current readable value of the register determines which interrupt-pending bit is cleared. Specifically, when a *topei CSR is written, if the register value has interrupt identity in bits 26:16, then the interrupt file’s pending bit for interrupt is cleared. When a *topei CSR’s value is zero, a write to the register has no effect.

> If a read and write of a *topei CSR are done together by a single CSR instruction (CSRRW, CSRRS, or CSRRC), the value returned by the read indicates the pending bit that is cleared.

* There is a situation where the instruction is csrrw a5, 0x15c, 0, where 0x15c is the stopei register.

* The CSRRW instruction writes the old value of the stopei register into the general register a5. When the CSRRW instruction writes a value into xtopei, CSR will issue a claim to IMSIC, the write value will be ignored, and IMSIC will return a new value of xtopei to update the xtopei register.

* However, NEMU does not have AIA. When xtopei changes, the value of xtopei in NEMU is passed to NEMU by RTL through the difftest framework, so the value of xtopei obtained by NEMU is the new value.

* NEMU writes the new value into the general register a5, resulting in an error when RTL and NEMU perform diff.

* To solve this problem, I store a set of old values of xtopei in NEMU, use the old value of xtopei when reading xtopei, and synchronize the new and old values of xtopei after executing a single CSR instruction (CSRRW, CSRRS or CSRRC).

