### PR TITLE
fix: add static keyword to inline functions in trigger.h

### DIFF
--- a/src/isa/riscv64/local-include/trigger.h
+++ b/src/isa/riscv64/local-include/trigger.h
@@ -192,10 +192,10 @@ void icount_checked_write(trig_icount_t* icount, word_t* wdata);
 bool trigger_reentrancy_check(); 
 void trigger_handler(const trig_type_t type, const trig_action_t action, word_t tval);
 
-inline word_t get_tdata1(TriggerModule* TM) {return TM->triggers[tselect->val].tdata1.val;}
-inline word_t get_tdata2(TriggerModule* TM) {return TM->triggers[tselect->val].tdata2.val;}
+static inline word_t get_tdata1(TriggerModule* TM) {return TM->triggers[tselect->val].tdata1.val;}
+static inline word_t get_tdata2(TriggerModule* TM) {return TM->triggers[tselect->val].tdata2.val;}
 #ifdef CONFIG_SDTRIG_EXTRA
-inline word_t get_tdata3(TriggerModule* TM) {return TM->triggers[tselect->val].tdata3.val;}
+static inline word_t get_tdata3(TriggerModule* TM) {return TM->triggers[tselect->val].tdata3.val;}
 #endif //CONFIG_SDTRIG_EXTRA
 
 // Used to avoid magic number


### PR DESCRIPTION
## Description
This PR fixes linking errors that occur when compiling NEMU with -O0 optimization level. The issue was caused by inline functions in `trigger.h` that were not marked as `static`, leading to multiple definition errors during linking.

## Changes
- Added `static` keyword to the following inline functions in `trigger.h`:
  - `get_tdata1`
  - `get_tdata2`
  - `get_tdata3`

## Technical Details
When compiling with -O0, the compiler does not perform inline optimization, which means it generates actual function calls instead of inlining the function body. Without the `static` keyword, each compilation unit that includes `trigger.h` would generate its own copy of these functions, leading to multiple definition errors during linking.

Adding the `static` keyword ensures that:
1. Each compilation unit gets its own copy of these functions
2. The functions are not visible to other compilation units
3. No multiple definition errors occur during linking