### PR TITLE
fix(README): Delete unnecessary config related tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,7 @@ make -j
 
 Specifically, xxx-ref_defconfig varies for different ISA extensions.
 
-| rv64gcb | rv64gcbh | rv64gcbv |
-| :-----: | :------: | :-------: |
-|  riscv64-xs-ref_defconfig | riscv64-rvh-ref_defconfig | riscv64-rvv-ref_defconfig |
+Vector and Hypervisor extensions were merged into XiangShan master, riscv64-xs_defconfig (and other riscv64-xs defconfigs) has enabled RVH and RVV. 
 
 
 #### Cosimulation

--- a/README.md
+++ b/README.md
@@ -159,10 +159,7 @@ make -j
 ```
 `./build/riscv64-nemu-interpreter-so` is the reference design.
 
-Specifically, xxx-ref_defconfig varies for different ISA extensions.
-
-riscv64-xs_defconfig (and other riscv64-xs defconfigs) has already enabled RVH and RVV. 
-
+riscv64-xs_defconfig is the base configuration targeting XiangShan processor, which has already enabled RVH and RVV. There are also a series of other configurations based on this base configuration.
 
 #### Cosimulation
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ make -j
 
 Specifically, xxx-ref_defconfig varies for different ISA extensions.
 
-Vector and Hypervisor extensions were merged into XiangShan master, riscv64-xs_defconfig (and other riscv64-xs defconfigs) has enabled RVH and RVV. 
+riscv64-xs_defconfig (and other riscv64-xs defconfigs) has already enabled RVH and RVV. 
 
 
 #### Cosimulation


### PR DESCRIPTION
I am Yang Guolin from the RACE team,I'm testing RVV for fp16 to int8 conversion,I have noticed that Vector and Hypervisor extensions were merged into XiangShan master, riscv64-xs_defconfig (and other riscv64-xs defconfigs) has enabled RVH and RVV,therefore, keeping riscv64-rvv-ref_defconfig in README will cause misunderstanding to users.