### PR TITLE
fix(csr): fix csr write and read register to pass hyp test

### DIFF
--- a/src/isa/riscv64/include/isa-def.h
+++ b/src/isa/riscv64/include/isa-def.h
@@ -212,6 +212,10 @@ typedef struct {
   uint64_t old_vstopi;
 #endif
 
+#ifdef CONFIG_RVH
+  uint64_t hideleg_reg;
+#endif
+
 } riscv64_CPU_state;
 
 // decode

--- a/src/isa/riscv64/system/priv.c
+++ b/src/isa/riscv64/system/priv.c
@@ -1034,7 +1034,9 @@ static inline void set_tvec(word_t* dest, word_t src) {
 static inline word_t vmode_get_sie() {
   word_t tmp = 0;
 #ifdef CONFIG_RV_AIA
-  word_t originIE = mie->val;
+  word_t originIE = (get_hideleg() & mideleg->val & mie->val) |
+    (get_hideleg() & ~mideleg->val & mvien->val & sie->val) |
+    (~get_hideleg() & hvien->val & vsie->val);
 
   tmp = (originIE & ~0x1fff) | ((originIE & VSI_MASK) >> 1);
   tmp |= vmode_get_ie(13, 63);


### PR DESCRIPTION
* This PR fix csr write/read hideleg and csr read sie in V mode.

* `hideleg->val` is to diff `RTL` and `NEMU` and `hideleg_reg` is register value. The rdata of the `hideleg` register is `reg & mideleg & HIDELEG_MASK |  reg & mvien & LCI` in XiangShan.

* A situation may arise at this point. First, write `1` to bit `13` of `hideleg`. At this point, `hideleg.reg.LCOFIP` = `1` in the RTL. Since bit `13` of `mideleg` or `mvien` is `0`, the RTL's `hideleg.rdata` is `0`. The NEMU's `get_hideleg` is also `0`, and a diff is performed with the RTL. Then, write `1` to bit `13` of `mideleg`. The RTL's `hideleg.rdata` becomes `1`, but the NEMU's `hideleg->val` is the result of `csr_writeback` and `csr_prepare` operations, which is the value of `get_hideleg`, which is `0`. This causes an error in the RTL-NEMU diff.

* Therefore, in order to solve the above problem, a value of the `hideleg` register is temporarily stored in NEMU.