### PR TITLE
fix(clang): guard all tcache functions with macro (#927)

### DIFF
--- a/src/cpu/cpu-exec.c
+++ b/src/cpu/cpu-exec.c
@@ -502,7 +502,7 @@ end_of_loop:
   debug_difftest(this_s, s);
   save_globals(s);
 }
-#else
+#else // CONFIG_PERF_OPT
 #define FILL_EXEC_TABLE(name) [concat(EXEC_ID_, name)] = concat(exec_, name),
 
 #define rtl_priv_next(s)
@@ -731,7 +731,7 @@ static void execute(int n) {
   }
   Loge("total insts: %'lu, execute remain: %'d", get_abs_instr_count(), n_remain);
 }
-#endif
+#endif // CONFIG_PERF_OPT
 
 IFDEF(CONFIG_DEBUG, char log_bytebuf[80] = {};)
 // max size is (strlen(str(instr)) + strlen(suffix_char(id_dest->width)) + sizeof(id_dest->str) + sizeof(id_src2->str) + sizeof(id_src1->str))
@@ -845,7 +845,11 @@ void cpu_exec(uint64_t n) {
 
       // No need to settle instruction counting here, as it is done in longjmp handler.
       // It's necessary to flush tcache for exception: addr space may conflict in different priv/mmu mode.
-      tcache_handle_flush(cpu.pc);
+      #ifdef CONFIG_PERF_OPT
+        tcache_handle_flush(cpu.pc);
+      #else
+        tcache_handle_flush();
+      #endif
 
       // Trigger may raise EX_BP and perform longjmp.
       IFDEF(CONFIG_TDATA1_ETRIGGER, trigger_handler(TRIG_TYPE_ETRIG, action, 0));
@@ -874,7 +878,11 @@ void cpu_exec(uint64_t n) {
         // No need to update_instr_count(). This is not the end of BATCH.
 
         // It's necessary to flush tcache for interrupt: addr space may conflict in different priv/mmu mode.
-        tcache_handle_flush(cpu.pc);
+        #ifdef CONFIG_PERF_OPT
+          tcache_handle_flush(cpu.pc);
+          #else
+          tcache_handle_flush();
+        #endif
 
         IFDEF(CONFIG_TDATA1_ITRIGGER, trigger_handler(TRIG_TYPE_ITRIG, itrigger_action, 0));
         IFDEF(CONFIG_DIFFTEST, ref_difftest_raise_intr(intr));


### PR DESCRIPTION
Resolve compilation errors in clang by ensuring all tcache related function calls in src/cpu/cpu-exec.c are properly guarded by the `CONFIG_PERF_OPT` macro.

Some of these function calls were not guarded with macro. This caused inconsistency between declarations, calls, and actual definitions, resulting in C23 compatibility errors when building with clang.