### PR TITLE
fix(paddr): move PMEMBASE to higher address to avoid conflicts

### DIFF
--- a/src/memory/paddr.c
+++ b/src/memory/paddr.c
@@ -40,7 +40,7 @@ bool need_read_golden_mem = false;
 #ifdef CONFIG_LIGHTQS
 #define PMEMBASE 0x1100000000ul
 #else
-#define PMEMBASE 0x100000000ul
+#define PMEMBASE 0x700000000000UL
 #endif // CONFIG_LIGHTQS
 
 #ifdef CONFIG_USE_MMAP


### PR DESCRIPTION
In NEMU, mmap is used with MAP_FIXED to allocate guest memory starting at PMEMBASE. This is intended to avoid memory leaks when NEMU is initialized multiple times to run multiple workloads in a single execution. However, since MAP_FIXED unconditionally overwrites existing mappings, it can conflict with host allocations.

When running an 8-core PLDM, the PLDM process uses more memory than with 4-core or smaller configurations. In this case, some PLDM allocations overlapped with the previous PMEMBASE (0x100000000UL, 4 GB), causing malloc() errors such as:

    malloc(): invalid size (unsorted)

This patch moves PMEMBASE to a much higher address (0x700000000000UL, 112 TB), which alleviates the conflict.

In the long term, NEMU should implement a proper memory recycling mechanism to remove the reliance on MAP_FIXED. This improvement is left for future work.