### PR TITLE
fix(Makefile): fix menuconfig compile error due to CC and LIBS variable error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,10 +90,12 @@ XSRCS-y += src/memory/store_queue_wrapper.cpp
 
 XSRCS = $(XSRCS-y)
 
-CONFIG_CC ?= gcc
-CONFIG_CXX ?= g++
+ifdef CONFIG_CC
 CC = $(call remove_quote,$(CONFIG_CC))
+endif
+ifdef CONFIG_CXX
 CXX = $(call remove_quote,$(CONFIG_CXX))
+endif
 CFLAGS_BUILD += $(call remove_quote,$(CONFIG_CC_OPT))
 CFLAGS_BUILD += $(if $(CONFIG_CC_LTO),-flto=auto,)
 CFLAGS_BUILD += $(if $(CONFIG_CC_DEBUG),-ggdb3,)

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,8 @@ XSRCS-y += src/memory/store_queue_wrapper.cpp
 
 XSRCS = $(XSRCS-y)
 
+CONFIG_CC ?= gcc
+CONFIG_CXX ?= g++
 CC = $(call remove_quote,$(CONFIG_CC))
 CXX = $(call remove_quote,$(CONFIG_CXX))
 CFLAGS_BUILD += $(call remove_quote,$(CONFIG_CC_OPT))

--- a/tools/kconfig/Makefile
+++ b/tools/kconfig/Makefile
@@ -9,7 +9,7 @@ ifeq ($(NAME),conf)
 SRCS += conf.c
 else ifeq ($(NAME),mconf)
 SRCS += mconf.c $(shell find lxdialog/ -name "*.c")
-LIBS += -lncurses -ltinfo
+LDFLAGS += -lncurses -ltinfo
 else
 $(error bad target=$(NAME))
 endif


### PR DESCRIPTION
* The first compilation `make menuconfig` or `make riscv***defconfig` will fail

* When first clone this repository, CC is initialized with `$(call remove_quote $(CONFIG_CC))`. But `CONFIG_CC` isn't initialized now, so CC will be empty string. So check `CONFIG_CC` and `CONFIG_CXX` before CC is initialized.

* Menuconfig use `LIBS=  -lncurses -ltinfo`, but the target BINARY in build.mk depends on LIBS, which will result in error "No rule to make tartget '-lncurses'". So change LIBS to LDFLAGS