### PR TITLE
feat(ref): add trace output required for SimFrontend

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -192,6 +192,14 @@ config SHARE_OUTPUT_LOG_TO_FILE
     Note: This option is only effective in SHARE mode. For standalone mode, 
     use the corresponding command option.
 
+config SET_OUTPUT_LOG_FILE_NAME
+  bool "Set log file name"
+  depends on SHARE_OUTPUT_LOG_TO_FILE
+  default n
+  help
+    If y, the DUT will pass a filename via the API to be used as the log file name.
+    Typically used for generating the instr trace file for SimFrontend.
+
 config DIFFTEST
   depends on !SHARE
   bool "Enable differential testing"
@@ -242,6 +250,11 @@ config DIFFTEST_REF_NAME
   default "kvm" if DIFFTEST_REF_KVM
   default "nemu-interpreter" if DIFFTEST_REF_NEMU
   default "none"
+
+config SIMFRONTEND_TRACE
+  depends on !PERF_OPT
+  bool "Output the 'pc:instr' trace log required by the sim frontend"
+  default n
 
 config IQUEUE
   bool "Record the last instrucitons executed"

--- a/include/cpu/ifetch.h
+++ b/include/cpu/ifetch.h
@@ -36,4 +36,11 @@ static inline uint32_t instr_fetch(vaddr_t *pc, int len) {
   return instr;
 }
 
+# ifdef CONFIG_SIMFRONTEND_TRACE
+static inline uint32_t trace_instr_fetch(vaddr_t pc, int len) {
+  uint32_t instr = vaddr_ifetch(pc, len);
+  return instr;
+}
+#endif // CONFIG_SIMFRONTEND_TRACE
+
 #endif

--- a/include/debug.h
+++ b/include/debug.h
@@ -31,6 +31,9 @@
         __FILE__, __LINE__, __func__, ## __VA_ARGS__)
 #endif // CONFIG_SIMPLE_LOG
 
+#define Log_Trace(format, ...) \
+  _Log(format "\n", ## __VA_ARGS__)
+
 #define Logf(flag, ...) \
   do { \
     if (flag == dflag_mem && ISDEF(CONFIG_MEMLOG)) Log(__VA_ARGS__); \

--- a/src/cpu/cpu-exec.c
+++ b/src/cpu/cpu-exec.c
@@ -742,6 +742,7 @@ void fetch_decode(Decode *s, vaddr_t pc) {
   s->snpc = pc;
   IFDEF(CONFIG_DEBUG, log_bytebuf[0] = '\0');
   int idx = isa_fetch_decode(s);
+  IFDEF(CONFIG_SIMFRONTEND_TRACE, Log_Trace("%lx:%x", s->pc, s->isa.instr.val));
   Logtid(
     "(%s) " FMT_WORD ":   %s%*.s%s",
     isa_get_privilege_mode_str(),


### PR DESCRIPTION
Add two API to improve trace generation when using NEMU for ref.
1. Allow the dut to pass in log names, primarily for batch-generating instr traces.
2. Print skip instructions as well.