### PR TITLE
fix(paddr): move PMEMBASE to avoid conflicts

### DIFF
--- a/src/memory/paddr.c
+++ b/src/memory/paddr.c
@@ -40,7 +40,7 @@ bool need_read_golden_mem = false;
 #ifdef CONFIG_LIGHTQS
 #define PMEMBASE 0x1100000000ul
 #else
-#define PMEMBASE 0x700000000000UL
+#define PMEMBASE 0x70000000000UL
 #endif // CONFIG_LIGHTQS
 
 #ifdef CONFIG_USE_MMAP


### PR DESCRIPTION
This patch moves PMEMBASE to a address(0x70000000000UL, 7TB), which alleviates the conflict.