### PR TITLE
fix(log): add hart-id to nemu logs for REF

### DIFF
--- a/include/cpu/cpu.h
+++ b/include/cpu/cpu.h
@@ -18,6 +18,7 @@
 
 #include <common.h>
 #include <setjmp.h>
+#include <stdarg.h>
 
 #define AHEAD_LENGTH 500
 
@@ -91,4 +92,21 @@ struct lightqs_reg_ss {
   int ifetch_mmu_state;
   int data_mmu_state;
 };
+
+extern unsigned ref_hartid;
+static inline void ref_log_cpu(const char *fmt, ...) {
+#ifdef CONFIG_SHARE
+  if (unlikely(dynamic_config.debug_difftest)) {
+    va_list ap;
+    va_start(ap, fmt);
+
+    fprintf(stderr, "[NEMU][%u] ", ref_hartid);
+    vfprintf(stderr, fmt, ap);
+    fprintf(stderr, "\n");
+
+    va_end(ap);
+  }
+#endif
+}
+
 #endif

--- a/include/memory/paddr.h
+++ b/include/memory/paddr.h
@@ -20,7 +20,6 @@
 #include <common.h>
 
 extern unsigned long MEMORY_SIZE;
-extern unsigned int PMEM_HARTID;
 
 #ifdef CONFIG_MODE_USER
 #define CONFIG_MBASE 0

--- a/src/cpu/cpu-exec.c
+++ b/src/cpu/cpu-exec.c
@@ -699,12 +699,7 @@ static void execute(int n) {
 
     cpu.debug.current_pc = s.pc;
     cpu.pc = s.snpc;
-#ifdef CONFIG_SHARE
-    if (unlikely(dynamic_config.debug_difftest)) {
-      fprintf(stderr, "(%d) [NEMU] pc = 0x%lx inst %x\n", getpid(), s.pc,
-              s.isa.instr.val);
-    }
-#endif
+    ref_log_cpu("pc = 0x%lx inst %x", s.pc, s.isa.instr.val);
     s.EHelper(&s);
 
     IFDEF(CONFIG_INSTR_CNT_BY_INSTR, g_nr_guest_instr += 1);

--- a/src/cpu/difftest/ref.c
+++ b/src/cpu/difftest/ref.c
@@ -22,6 +22,8 @@
 #include <cpu/cpu.h>
 #include <difftest.h>
 
+unsigned ref_hartid = 0;
+
 extern void load_flash_contents(const char *flash_img);
 
 #ifdef CONFIG_LARGE_COPY
@@ -344,7 +346,7 @@ void difftest_runahead_init() {
 void difftest_init() {
 #ifdef CONFIG_SHARE_OUTPUT_LOG_TO_FILE
   char log_file_name[20];
-  sprintf(log_file_name, "nemu-hart-%d.log", PMEM_HARTID);
+  sprintf(log_file_name, "nemu-hart-%d.log", ref_hartid);
   void init_log(const char *log_file, const bool fast_log, const bool small_log);
   init_log(log_file_name, false, false);
 #endif // CONFIG_SHARE_OUTPUT_LOG_TO_FILE
@@ -370,7 +372,7 @@ uint8_t *golden_pmem = NULL;
 
 void difftest_set_mhartid(int n) {
   isa_difftest_set_mhartid(n);
-  PMEM_HARTID = n;
+  ref_hartid = n;
 }
 
 void difftest_put_gmaddr(uint8_t* ptr) {

--- a/src/isa/riscv64/system/priv.c
+++ b/src/isa/riscv64/system/priv.c
@@ -1314,12 +1314,12 @@ static inline void set_hideleg(word_t src) {
   //    reg & mideleg & HIDELEG_MASK |
   //    reg & mvien & LCI
   // in XiangShan.
-  // 
-  // A situation may arise at this point. First, write 1 to bit 13 of hideleg. 
-  // At this point, hideleg.reg.LCOFIP = 1 in the RTL. 
-  // Since bit 13 of mideleg or mvien is 0, the RTL's hideleg.rdata is 0. 
-  // The NEMU's get_hideleg is also 0, and a diff is performed with the RTL. 
-  // Then, write 1 to bit 13 of mideleg. 
+  //
+  // A situation may arise at this point. First, write 1 to bit 13 of hideleg.
+  // At this point, hideleg.reg.LCOFIP = 1 in the RTL.
+  // Since bit 13 of mideleg or mvien is 0, the RTL's hideleg.rdata is 0.
+  // The NEMU's get_hideleg is also 0, and a diff is performed with the RTL.
+  // Then, write 1 to bit 13 of mideleg.
   // The RTL's hideleg.rdata becomes 1, but the NEMU's hideleg->val is the result of csr_writeback and csr_prepare operations,
   // which is the value of get_hideleg, which is 0.
   // This causes an error in the RTL-NEMU diff.
@@ -1836,12 +1836,8 @@ static word_t csr_read(uint32_t csrid) {
       }
 
       uint8_t cfg = pmpcfg_from_index(idx);
-#ifdef CONFIG_SHARE
-      if(dynamic_config.debug_difftest) {
-        fprintf(stderr, "[NEMU] pmp addr read %d : 0x%016lx\n", idx,
+        ref_log_cpu("pmp addr read %d : 0x%016lx", idx,
           (cfg & PMP_A) >= PMP_NAPOT ? *src | (~pmp_tor_mask() >> 1) : *src & pmp_tor_mask());
-      }
-#endif // CONFIG_SHARE
       if ((cfg & PMP_A) >= PMP_NAPOT)
         return *src | (~pmp_tor_mask() >> 1);
       else
@@ -1863,12 +1859,8 @@ static word_t csr_read(uint32_t csrid) {
       }
 
       uint8_t cfg = pmacfg_from_index(idx);
-#ifdef CONFIG_SHARE
-      if (dynamic_config.debug_difftest) {
-        fprintf(stderr, "[NEMU] pma addr read %d : 0x%016lx\n", idx,
+      ref_log_cpu("pma addr read %d : 0x%016lx", idx,
           (cfg & PMA_A) >= PMA_NAPOT ? *src | (~pma_tor_mask() >> 1) : *src & pma_tor_mask());
-      }
-#endif // CONFIG_SHARE
       if ((cfg & PMA_A) >= PMA_NAPOT)
         return *src | (~pma_tor_mask() >> 1);
       else
@@ -2408,12 +2400,8 @@ static void csr_write(uint32_t csrid, word_t src) {
           cfg_data |= (oldCfg << (i*8));
         }
       }
-    #ifdef CONFIG_SHARE
-      if(dynamic_config.debug_difftest) {
-        int idx = dest - &csr_array[CSR_PMPCFG_BASE];
-        Logtr("[NEMU] write pmpcfg%d to %016lx\n", idx, cfg_data);
-      }
-    #endif // CONFIG_SHARE
+      int idx = dest - &csr_array[CSR_PMPCFG_BASE];
+      ref_log_cpu("write pmpcfg%d to %016lx", idx, cfg_data);
 
       *dest = cfg_data;
 
@@ -2439,11 +2427,7 @@ static void csr_write(uint32_t csrid, word_t src) {
       if (idx < CONFIG_RV_PMP_ACTIVE_NUM && !locked && !(next_locked && next_tor)) {
         *dest = src & (((word_t)1 << (CONFIG_PADDRBITS - PMP_SHIFT)) - 1);
       }
-#ifdef CONFIG_SHARE
-      if(dynamic_config.debug_difftest) {
-        fprintf(stderr, "[NEMU] write pmp addr%d to %016lx\n",idx, *dest);
-      }
-#endif // CONFIG_SHARE
+      ref_log_cpu("write pmp addr%d to %016lx",idx, *dest);
       mmu_tlb_flush(0);
       break;
     }
@@ -2473,12 +2457,8 @@ static void csr_write(uint32_t csrid, word_t src) {
           cfg_data |= (oldCfg << (i*8));
         }
       }
-#ifdef CONFIG_SHARE
-      if (dynamic_config.debug_difftest) {
-        int idx = dest - &csr_array[CSR_PMACFG_BASE];
-        Logtr("[NEMU] write pmacfg%d to %016lx\n", idx, cfg_data);
-      }
-#endif // CONFIG_SHARE
+      int idx = dest - &csr_array[CSR_PMACFG_BASE];
+      ref_log_cpu("write pmacfg%d to %016lx", idx, cfg_data);
 
       *dest = cfg_data;
 
@@ -2503,11 +2483,7 @@ static void csr_write(uint32_t csrid, word_t src) {
       if (idx < CONFIG_RV_PMA_ACTIVE_NUM && !locked && !(next_locked && next_tor)) {
         *dest = src & (((word_t)1 << (CONFIG_PADDRBITS - PMA_SHIFT)) - 1);
       }
-#ifdef CONFIG_SHARE
-      if (dynamic_config.debug_difftest) {
-        fprintf(stderr, "[NEMU] write pma addr%d to %016lx\n", idx, *dest);
-      }
-#endif // CONFIG_SHARE
+      ref_log_cpu("write pma addr%d to %016lx", idx, *dest);
       mmu_tlb_flush(0);
       break;
     }

--- a/src/memory/paddr.c
+++ b/src/memory/paddr.c
@@ -27,7 +27,6 @@
 #include "../local-include/intr.h"
 
 unsigned long MEMORY_SIZE = CONFIG_MSIZE;
-unsigned int PMEM_HARTID = 0;
 
 extern Decode *prev_s;
 
@@ -287,10 +286,8 @@ word_t paddr_read(paddr_t addr, int len, int type, int trap_type, int mode, vadd
 #else
   if (likely(in_pmem(addr))) {
     uint64_t rdata = pmem_read(addr, len);
-    if (dynamic_config.debug_difftest) {
-      fprintf(stderr, "[NEMU] paddr read addr:" FMT_PADDR ", data: %016lx, len:%d, type:%d, mode:%d\n",
+    ref_log_cpu("paddr read addr:" FMT_PADDR ", data: %016lx, len:%d, type:%d, mode:%d",
         addr, rdata, len, type, mode);
-    }
     return rdata;
   }
   else {
@@ -437,10 +434,8 @@ void paddr_write(paddr_t addr, int len, word_t data, int mode, vaddr_t vaddr) {
 #ifdef CONFIG_STORE_LOG
     pmem_record_store(addr);
 #endif // CONFIG_STORE_LOG
-    if(dynamic_config.debug_difftest) {
-      fprintf(stderr, "[NEMU] paddr write addr:" FMT_PADDR ", data:%016lx, len:%d, mode:%d\n",
+    ref_log_cpu("paddr write addr:" FMT_PADDR ", data:%016lx, len:%d, mode:%d",
         addr, data, len, mode);
-    }
     return pmem_write(addr, len, data, cross_page_store);
   } else {
     if (likely(is_in_mmio(addr))) {

--- a/src/memory/vaddr.c
+++ b/src/memory/vaddr.c
@@ -147,12 +147,8 @@ static word_t vaddr_mmu_read(struct Decode *s, vaddr_t addr, int len, int type) 
 #else
     word_t rdata = paddr_read(addr, len, type, type, cpu.mode, vaddr);
 #endif // CONFIG_MULTICORE_DIFF
-#ifdef CONFIG_SHARE
-    if (unlikely(dynamic_config.debug_difftest)) {
-      fprintf(stderr, "[NEMU] mmu_read: vaddr 0x%lx, paddr 0x%lx, rdata 0x%lx\n",
+    ref_log_cpu("mmu_read: vaddr 0x%lx, paddr 0x%lx, rdata 0x%lx",
         vaddr, addr, rdata);
-    }
-#endif // CONFIG_SHARE
     return rdata;
   }
   return 0;
@@ -165,12 +161,8 @@ static void vaddr_mmu_write(struct Decode *s, vaddr_t addr, int len, word_t data
   int ret = pg_base & PAGE_MASK;
   if (ret == MEM_RET_OK) {
     addr = pg_base | (addr & PAGE_MASK);
-#ifdef CONFIG_SHARE
-    if (unlikely(dynamic_config.debug_difftest)) {
-      fprintf(stderr, "[NEMU] mmu_write: vaddr 0x%lx, paddr 0x%lx, len %d, data 0x%lx\n",
+    ref_log_cpu("mmu_write: vaddr 0x%lx, paddr 0x%lx, len %d, data 0x%lx",
         vaddr, addr, len, data);
-    }
-#endif // CONFIG_SHARE
     paddr_write(addr, len, data, cpu.mode, vaddr);
   }
 }


### PR DESCRIPTION
NEMU implements a lot of REF logs for debugging. However, in multicore, these logs are hard to distinguish because we don't know the hartid, and logs from different cores are mixed.

This commit adds a hartid to the printf and wraps it in a function.

We also remove the unused PMEM_HARTID.