### PR TITLE
fix(rv64): avoid unused printf in isa_reg_display

### DIFF
--- a/src/isa/riscv64/reg.c
+++ b/src/isa/riscv64/reg.c
@@ -110,9 +110,9 @@ void isa_reg_display() {
 
   IFDEF(CONFIG_RVH, DISPLAY_CSR("hstatus", cpu.hstatus));
   IFDEF(CONFIG_RV_SMRNMI, DISPLAY_CSR("mnstatus", mnstatus->val));
-#if defined(CONFIG_RVH) || defined(CONFIG_RV_SMRNMI)
-  printf("\n");
-#endif
+  #if defined(CONFIG_RVH) || defined(CONFIG_RV_SMRNMI)
+    printf("\n");
+  #endif
 
   DISPLAY_CSR("mcause", mcause->val);
   DISPLAY_CSR("mepc", mepc->val);


### PR DESCRIPTION
When CONFIG_RVH and CONFIG_RV_SMRNMI are not defined, the `\n` is unnecessary.