### PR TITLE
fix(ci): Separate PR comment workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -426,6 +426,7 @@ jobs:
             am/misc-tests/bin/softprefetchtest-riscv64-xs.bin
             am/misc-tests/bin/zacas-riscv64-xs.bin
         run: |
+          echo -e "### NEMU Performance Results\n\n| Test | Instructions Executed | Estimated Host Throughput (instr/s) | Actual NEMU Throughput (instr/s) |\n|------|-----------------------|-------------------------------------|-------------------------------|" > performance_results.md
           for test_bin in $tests; do
             echo ::group::$test_bin
             result=$(./DynamoRIO-Linux-11.3.0-1/bin64/drrun -c ./DynamoRIO-Linux-11.3.0-1/samples/bin64/libinscount.so -- \
@@ -453,21 +454,13 @@ jobs:
           # Calculate host throughput per second with 4GHz and IPC=2.5
           est_throughput=$(python3 -c "print(4e9 * $estimate_host_ipc / $host_instr_count * $guest_instr_count)")
           python3 -c "print('| linux-hello | {:.3e} | {:.3e} | {:.3e} |'.format($host_instr_count, $est_throughput, $actual_throughput))" >> performance_results.md
+          echo -e "\n\n* Host throughput is estimated based on 4GHz CPU frequency and IPC=2.5. \n* Actual throughput may vary based on the host CPU performance." >> performance_results.md
       
-      - name: Report to PR comment
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+      - name: Save performance results artifact
+        uses: actions/upload-artifact@v6
         with:
-          script: |
-            const fs = require('fs');
-            const performanceResults = fs.readFileSync('performance_results.md', 'utf8');
-            const commentBody = `### NEMU Performance Results\n\n| Test | Instructions Executed | Estimated Host Throughput (instr/s) | Actual NEMU Throughput (instr/s) |\n|------|-----------------------|-------------------------------------|-------------------------------|\n${performanceResults}\n\n* Host throughput is estimated based on 4GHz CPU frequency and IPC=2.5. Actual throughput may vary based on the host CPU performance.`;
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: commentBody
-            });
+          name: performance-results
+          path: performance_results.md
 
   build-so:
     name: Build NEMU Difftest Shared Objects

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,0 +1,65 @@
+name: PR Comment with Performance Results
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+permissions:
+  artifact-metadata: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  comment:
+    if: github.event.workflow_run.event == 'pull_request' &&
+        github.event.workflow_run.conclusion == 'success'
+    env:
+      PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download performance results artifact
+        uses: actions/github-script@v8
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == 'performance-results';
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: 'zip',
+            });
+            const fs = require('fs');
+            const path = require('path');
+            const temp = '${{ runner.temp }}/artifacts';
+            if (!fs.existsSync(temp)){
+              fs.mkdirSync(temp);
+            }
+            fs.writeFileSync(path.join(temp, 'artifacts.zip'), Buffer.from(download.data));
+
+      - name: Extract and read performance results
+        run: |
+          unzip ${{ runner.temp }}/artifacts/artifacts.zip -d ${{ runner.temp }}/artifacts/
+      
+      - name: Post comment on PR
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const filePath = path.join('${{ runner.temp }}/artifacts/', 'performance_results.md');
+            const performanceResults = fs.readFileSync(filePath, 'utf8');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: process.env.PR_NUMBER,
+              body: performanceResults,
+            });


### PR DESCRIPTION
When a PR is created from a forked repository, the CI workflow does not have permission to post comments back to the PR due to GitHub security restrictions. To address this, we separate the PR comment workflow from the main CI workflow. The main CI workflow runs with limited permissions, while the PR comment workflow runs with elevated permissions to post comments.