### PR TITLE
fix(ci): pass PR number using artifact file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -456,11 +456,21 @@ jobs:
           python3 -c "print('| linux-hello | {:.3e} | {:.3e} | {:.3e} |'.format($host_instr_count, $est_throughput, $actual_throughput))" >> performance_results.md
           echo -e "\n\n* Host throughput is estimated based on 4GHz CPU frequency and IPC=2.5. \n* Actual throughput may vary based on the host CPU performance." >> performance_results.md
       
+      - name: Record PR number
+        if: github.event_name == 'pull_request'
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          echo -n $PR_NUMBER > PR_NUMBER.txt
+      
       - name: Save performance results artifact
         uses: actions/upload-artifact@v6
         with:
           name: performance-results
-          path: performance_results.md
+          if-no-files-found: ignore
+          path: |
+            performance_results.md
+            PR_NUMBER.txt
 
   build-so:
     name: Build NEMU Difftest Shared Objects

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -15,8 +15,6 @@ jobs:
   comment:
     if: github.event.workflow_run.event == 'pull_request' &&
         github.event.workflow_run.conclusion == 'success'
-    env:
-      PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
     runs-on: ubuntu-latest
     steps:
       - name: Download performance results artifact
@@ -55,11 +53,13 @@ jobs:
           script: |
             const fs = require('fs');
             const path = require('path');
-            const filePath = path.join('${{ runner.temp }}/artifacts/', 'performance_results.md');
-            const performanceResults = fs.readFileSync(filePath, 'utf8');
+            const resultPath = path.join('${{ runner.temp }}/artifacts/', 'performance_results.md');
+            const performanceResults = fs.readFileSync(resultPath, 'utf8');
+            const prNumberPath = path.join('${{ runner.temp }}/artifacts/', 'PR_NUMBER.txt');
+            const prNumber = fs.readFileSync(prNumberPath, 'utf8').trim();
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: process.env.PR_NUMBER,
+              issue_number: prNumber,
               body: performanceResults,
             });


### PR DESCRIPTION
Our method to get PR number in pr-comment.yml is not reliable, so we store the PR number in an artifact file during the CI workflow and read it in the pr-comment workflow.