### PR TITLE
fix(mmu): adjusting the timing of non-virt PBMT assignments

### DIFF
--- a/src/isa/riscv64/system/mmu.c
+++ b/src/isa/riscv64/system/mmu.c
@@ -523,7 +523,11 @@ static paddr_t ptw(vaddr_t vaddr, int type) {
   if(virt){
     pg_base = gpa_stage(pg_base | (vaddr & PAGE_MASK), vaddr, type, type, hlvx, false) & ~PAGE_MASK;
     if(pg_base == MEM_RET_FAIL) return MEM_RET_FAIL;
+  } else {
+    cpu.pbmt = pte.pbmt;
   }
+  #else
+  cpu.pbmt = pte.pbmt;
   #endif //CONFIG_RVH
 #ifndef CONFIG_SHARE
   // update a/d by hardware
@@ -548,8 +552,6 @@ static paddr_t ptw(vaddr_t vaddr, int type) {
     }
   }
 #endif // CONFIG_SHARE
-
-  cpu.pbmt = pte.pbmt;
   return pg_base | MEM_RET_OK;
 
 bad:


### PR DESCRIPTION
We have already assigned a value to cpu.pbmt at the end of gpa_stage. It should not be reassigned, as this will cause it to be overwritten incorrectly:
https://github.com/OpenXiangShan/NEMU/blob/112f2fd1e68d1c8978f964f6a2846104dcd928e8/src/isa/riscv64/system/mmu.c#L371-L382