### PR TITLE
fix(cpu-exec): clear stale SYS_STATE_FLUSH_TCACHE for performance

### DIFF
--- a/src/cpu/cpu-exec.c
+++ b/src/cpu/cpu-exec.c
@@ -686,6 +686,10 @@ static void execute(int n) {
 
     if (g_sys_state_flag & SYS_STATE_FLUSH_TCACHE) {
       tcache_handle_flush();
+      // In the non-PERF_OPT path, a tcache flush request is edge-triggered.
+      // Clear only the flush bit after servicing it so we do not re-flush on
+      // every following instruction.
+      g_sys_state_flag &= ~SYS_STATE_FLUSH_TCACHE;
     }
 
     if (cache_s == NULL) {


### PR DESCRIPTION
This change clear SYS_STATE_FLUSH_TCACHE for non-PERF_OPT execute loop, avoiding NEMU to flush tcache on every following instruction for performance.

On linux/coremark-pro with the xs-ref-noshare fragment KPI, this change improved simulation frequency from 152,510 instr/s to 7,372,782 instr/s (+4734.29%).

On Fpga Difftest REF mode, this change improve the overall co-sim speed from 70KHz to 7.9MHz (+11,285.71%).