### PR TITLE
feat(perf): add host-side perf profiling workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,12 @@
 !.github/workflows/*.yml
 !scripts/*.sh
 !scripts/*.py
+!tools/perf_profile.py
+!tools/perf_profile/**
 !scripts/checkpoint_example/*
+!docs/perf_profile.md
+__pycache__/
+*.pyc
 include/config
 include/generated
 build

--- a/docs/perf_profile.md
+++ b/docs/perf_profile.md
@@ -1,0 +1,229 @@
+# NEMU Perf Profiling
+
+`tools/perf_profile.py` collects host-side performance data for a NEMU run
+with Linux `perf`. It keeps the raw `perf` outputs, parsed JSON artifacts, a
+manifest, and Markdown reports in one run directory.
+
+The framework answers three practical questions:
+
+- How many host counters did one NEMU run consume?
+- Which functions are hot?
+- Which basic blocks are hot?
+
+## Requirements
+
+- Linux on an x86 host
+- `perf`
+- `addr2line`
+- `nm`
+- Python 3.10+
+- a NEMU binary with symbols; debug info is recommended
+
+## Get Started
+
+Build NEMU first:
+
+```bash
+make riscv64-xs_defconfig
+make -j
+```
+
+Run one quick profile with a fixed guest-instruction budget:
+
+```bash
+python3 tools/perf_profile.py run \
+  --mode quick \
+  --binary ./build/riscv64-nemu-interpreter \
+  --workload ./workloads/linux/coremark-pro/fw_payload.bin \
+  --nemu-args='-b -I 1000000000' \
+  --output-root perf_profile_out
+```
+
+Open the generated summary report:
+
+```text
+perf_profile_out/<run-id>/reports/summary.md
+```
+
+Example summary output:
+
+```text
+# NEMU perf profile summary
+
+## Run Summary
+- mode: quick
+- guest instructions: 1000001488
+- simulation frequency: 185235783 instr/s
+
+## Global Counters
+| event | count | running_pct |
+|---|---:|---:|
+| cycles | 34623153083 | 99.9400 |
+| instructions | 140751835752 | 99.9400 |
+
+## Sample Counts
+- grouped sample groups: 5207
+| event | samples |
+|---|---:|
+| instructions | 5207 |
+| branch-misses | 5207 |
+| cache-misses | 2765 |
+
+## Reports
+- functions_quick: reports/functions_quick.md
+- basic_blocks_quick: reports/basic_blocks_quick.md
+```
+
+`-b` by itself may run for a long time on Linux workloads because NEMU waits for
+the guest workload to finish naturally. Use `-I <guest-instructions>` when you
+want one bounded profiling window that exits quickly.
+
+With the default example above, users should expect one quick profiling run to
+finish in tens of seconds on a typical development machine, not in several
+minutes. If it ends almost immediately, or still runs much longer than you
+expect, adjust `-I` for your host and workload.
+
+## Workload Images
+
+The examples in this document use workload images such as
+`./workloads/linux/coremark-pro/fw_payload.bin`.
+
+NEMU does not include the workload builder as a git submodule. Instead, the
+workload builder is an external example repository that users can fetch and use
+separately:
+
+- repository: <https://github.com/OpenXiangShan/workload-builder>
+
+This profiling framework only consumes the generated workload images. It does
+not depend on the workload builder being checked out inside the NEMU tree.
+
+## Recommended Windows
+
+For Linux workloads, treat the instruction budget as a profiling window. The
+best default is not the shortest run that exits, but the shortest run that
+still gives stable samples on your machine.
+
+Recommended starting points:
+
+- smoke check: `-I 10000000`
+  - use this only to verify that the toolchain and command line work
+- short exploratory window: `-I 100000000`
+  - use this when you want a fast first look
+- default quick profile: `-I 1000000000`
+  - use this as the default first profile for Linux workloads when you want a
+    more stable hotspot ranking
+  - expect the full quick profiling flow to finish in tens of seconds
+- longer comparison window: `-I 4000000000` to `-I 10000000000`
+  - use this when repeated runs still move around too much, or when you want a
+    stronger steady-state signal
+  - expect the full quick profiling flow to take noticeably longer, up to
+    minutes on slower hosts
+
+These timing expectations are only rough guidance. The right window is
+host-dependent, and the real test is whether the resulting sample counts and
+hotspot ordering are stable enough for your task.
+
+If the summary report still shows low-sample warnings or the hotspot order
+changes noticeably across repeated runs, increase `-I` and keep it fixed for
+round-to-round comparisons.
+
+If the environment is not ready yet, run `doctor` first:
+
+```bash
+python3 tools/perf_profile.py doctor \
+  --binary ./build/riscv64-nemu-interpreter \
+  --workload ./workloads/linux/coremark-pro/fw_payload.bin
+```
+
+## Profiling Modes
+
+### Quick Mode
+
+Quick mode is the default starting point. It runs:
+
+- one `perf stat`
+- one grouped `perf record`
+
+The grouped sampling event list is:
+
+```text
+{instructions,cycles,branches,branch-misses,cache-references,cache-misses}:S
+```
+
+`instructions` is the only trigger event in quick mode. The other counters are
+grouped readouts attached to the same samples. Treat them as auxiliary metrics,
+not as independent event-triggered hotspot rankings.
+
+For Linux workloads, prefer a bounded command such as
+`--nemu-args='-b -I 1000000000'` for the first pass. Natural completion with
+bare `-b` can take much longer.
+
+### Precise Mode
+
+Precise mode records each sampled event in a separate NEMU run:
+
+```bash
+python3 tools/perf_profile.py run \
+  --mode precise \
+  --binary ./build/riscv64-nemu-interpreter \
+  --workload ./workloads/linux/coremark-pro/fw_payload.bin \
+  --nemu-args='-b -I 1000000000' \
+  --precise-events instructions,cycles,branch-misses,cache-misses
+```
+
+Use this mode when you need true event-triggered attribution for a specific
+counter and can afford the extra runtime.
+
+## Subcommands
+
+- `doctor`: check the host tools, kernel settings, binary, and workload
+- `stat`: collect only global `perf stat` counters
+- `record`: collect only sampling data
+- `report`: regenerate reports from an existing run directory
+- `run`: execute `doctor -> stat -> record -> report`
+
+## Run Layout
+
+Each `run` directory contains:
+
+```text
+manifest.json
+logs/
+raw/
+parsed/
+reports/
+```
+
+Important outputs:
+
+- `reports/summary.md`: run configuration, throughput, global counters,
+  sample counts, warnings, and report links
+- `reports/functions_quick.md`: function hotspots for quick mode
+- `reports/basic_blocks_quick.md`: basic-block hotspots for quick mode
+- `reports/functions_<event_id>.md`: function hotspots for precise mode
+- `reports/basic_blocks_<event_id>.md`: basic-block hotspots for precise mode
+- `reports/doctor.md`: environment checks
+- `parsed/stat.json`: parsed `perf stat` counters
+- `parsed/quick_samples.json`: parsed grouped samples in quick mode
+- `parsed/quick_functions.json`: aggregated quick-mode function hotspots
+- `parsed/basic_blocks_quick.json`: aggregated quick-mode basic-block hotspots
+- `parsed/samples_<event_id>.json`: parsed samples for precise mode
+- `parsed/functions_<event_id>.json`: aggregated precise-mode function hotspots
+- `parsed/basic_blocks_<event_id>.json`: aggregated precise-mode basic-block
+  hotspots
+
+Here `<event_id>` is the filename-safe identifier derived from the requested
+event string. For plain events such as `instructions` or `cycles`, the filename
+stays readable, for example `reports/functions_instructions.md`. Events with
+modifiers or raw PMU syntax are sanitized for filesystem use, and some forms
+may also gain a short hash suffix to avoid collisions.
+
+## Reading the Reports
+
+- Start with `reports/summary.md` to confirm the command line, throughput, and
+  global counters.
+- Check the sample-count section in `reports/summary.md` before trusting small
+  hotspot differences between runs.
+- Use quick mode to find the dominant instruction-triggered hotspots first.
+- Switch to precise mode only when you need event-specific attribution for
+  `cycles`, `branch-misses`, `cache-misses`, or another sampled counter.

--- a/tools/perf_profile.py
+++ b/tools/perf_profile.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+#***************************************************************************************
+# Copyright (c) 2026 Institute of Computing Technology, Chinese Academy of Sciences
+#
+# NEMU is licensed under Mulan PSL v2.
+# You can use this software according to the terms and conditions of the Mulan PSL v2.
+# You may obtain a copy of Mulan PSL v2 at:
+#          http://license.coscl.org.cn/MulanPSL2
+#
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+# EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+# MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+#
+# See the Mulan PSL v2 for more details.
+#***************************************************************************************/
+
+from perf_profile.cli import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/perf_profile/__init__.py
+++ b/tools/perf_profile/__init__.py
@@ -1,0 +1,20 @@
+#***************************************************************************************
+# Copyright (c) 2026 Institute of Computing Technology, Chinese Academy of Sciences
+#
+# NEMU is licensed under Mulan PSL v2.
+# You can use this software according to the terms and conditions of the Mulan PSL v2.
+# You may obtain a copy of Mulan PSL v2 at:
+#          http://license.coscl.org.cn/MulanPSL2
+#
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+# EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+# MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+#
+# See the Mulan PSL v2 for more details.
+#***************************************************************************************/
+
+"""NEMU perf profiling package."""
+
+from .cli import main
+
+__all__ = ["main"]

--- a/tools/perf_profile/__main__.py
+++ b/tools/perf_profile/__main__.py
@@ -1,0 +1,20 @@
+#***************************************************************************************
+# Copyright (c) 2026 Institute of Computing Technology, Chinese Academy of Sciences
+#
+# NEMU is licensed under Mulan PSL v2.
+# You can use this software according to the terms and conditions of the Mulan PSL v2.
+# You may obtain a copy of Mulan PSL v2 at:
+#          http://license.coscl.org.cn/MulanPSL2
+#
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+# EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+# MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+#
+# See the Mulan PSL v2 for more details.
+#***************************************************************************************/
+
+from .cli import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/perf_profile/catalog.py
+++ b/tools/perf_profile/catalog.py
@@ -1,0 +1,46 @@
+#***************************************************************************************
+# Copyright (c) 2026 Institute of Computing Technology, Chinese Academy of Sciences
+#
+# NEMU is licensed under Mulan PSL v2.
+# You can use this software according to the terms and conditions of the Mulan PSL v2.
+# You may obtain a copy of Mulan PSL v2 at:
+#          http://license.coscl.org.cn/MulanPSL2
+#
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+# EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+# MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+#
+# See the Mulan PSL v2 for more details.
+#***************************************************************************************/
+
+from pathlib import Path
+
+
+DEFAULT_BINARY = Path("build/riscv64-nemu-interpreter")
+DEFAULT_OUTPUT_ROOT = Path("perf_profile_out")
+
+GLOBAL_EVENTS = [
+    "cycles",
+    "instructions",
+    "branches",
+    "branch-misses",
+    "cache-references",
+    "cache-misses",
+]
+
+QUICK_MODE = "quick"
+PRECISE_MODE = "precise"
+MODES = (QUICK_MODE, PRECISE_MODE)
+
+QUICK_LEADER_EVENT = "instructions"
+QUICK_GROUP_EVENTS = [QUICK_LEADER_EVENT] + [
+    event for event in GLOBAL_EVENTS if event != QUICK_LEADER_EVENT
+]
+PRECISE_DEFAULT_SAMPLE_EVENTS = ["instructions", "cycles", "branch-misses", "cache-misses"]
+
+DERIVED_METRICS = ["ipc", "cpi", "bp_mpki", "cache_mpki", "branch_miss_rate"]
+
+DEFAULT_SAMPLE_FREQ = 999
+DEFAULT_CALLGRAPH = "fp"
+DEFAULT_CALLGRAPH_DEPTH = 128
+DEFAULT_ANNOTATE_SYMBOL_LIMIT = 10

--- a/tools/perf_profile/cli.py
+++ b/tools/perf_profile/cli.py
@@ -1,0 +1,403 @@
+#***************************************************************************************
+# Copyright (c) 2026 Institute of Computing Technology, Chinese Academy of Sciences
+#
+# NEMU is licensed under Mulan PSL v2.
+# You can use this software according to the terms and conditions of the Mulan PSL v2.
+# You may obtain a copy of Mulan PSL v2 at:
+#          http://license.coscl.org.cn/MulanPSL2
+#
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+# EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+# MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+#
+# See the Mulan PSL v2 for more details.
+#***************************************************************************************/
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+from .catalog import (
+    DEFAULT_BINARY,
+    DEFAULT_CALLGRAPH,
+    DEFAULT_CALLGRAPH_DEPTH,
+    DEFAULT_OUTPUT_ROOT,
+    DEFAULT_SAMPLE_FREQ,
+    MODES,
+    PRECISE_DEFAULT_SAMPLE_EVENTS,
+    QUICK_LEADER_EVENT,
+    QUICK_MODE,
+)
+from .collect.record import collect_precise_records, collect_quick_record
+from .collect.stat import collect_perf_stat
+from .preflight import run_doctor
+from .report import generate_reports
+from .util import ensure_dir, event_id, make_run_id, progress, read_json, write_json, write_text
+
+
+RUN_ID_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def _split_nemu_args(text: str) -> list[str]:
+    import shlex
+
+    return shlex.split(text) if text else []
+
+
+def _validate_run_id(run_id: str) -> str:
+    if not run_id or run_id in {".", ".."} or RUN_ID_RE.fullmatch(run_id) is None:
+        raise ValueError("run-id must match [A-Za-z0-9._-]+")
+    return run_id
+
+
+def _new_run_dir(output_root: Path, run_id: str | None) -> Path:
+    if run_id is None:
+        run_id = make_run_id("perf")
+    else:
+        run_id = _validate_run_id(run_id)
+    run_dir = output_root / run_id
+    if not run_dir.exists():
+        return ensure_dir(run_dir)
+    suffix = 1
+    while True:
+        candidate = output_root / f"{run_id}-{suffix}"
+        if not candidate.exists():
+            return ensure_dir(candidate)
+        suffix += 1
+
+
+def _parse_precise_events(text: str) -> list[str]:
+    events: list[str] = []
+    seen: set[str] = set()
+    for part in text.split(","):
+        event = part.strip()
+        if not event or event in seen:
+            continue
+        seen.add(event)
+        events.append(event)
+    return events
+
+
+def _validate_precise_events(text: str) -> list[str]:
+    events = _parse_precise_events(text)
+    for event in events:
+        event_id(event)
+    return events
+
+
+def _has_error_warnings(report: dict[str, object]) -> bool:
+    warnings = report.get("warnings", [])
+    if not isinstance(warnings, list):
+        return False
+    return any(isinstance(item, dict) and item.get("severity") == "error" for item in warnings)
+
+
+def _finish_doctor_failure(run_dir: Path, manifest: dict[str, object] | None = None) -> int:
+    if manifest is not None:
+        write_json(run_dir / "manifest.json", manifest)
+    print(run_dir / "reports" / "doctor.md")
+    return 1
+
+
+def _record_stat_failure(stat: dict[str, object]) -> int:
+    returncode = int(stat.get("returncode", 0))
+    if returncode == 0:
+        return 0
+    warnings = stat.setdefault("warnings", [])
+    if isinstance(warnings, list):
+        warnings.append(
+            {
+                "code": "perf_stat_failed",
+                "message": f"perf stat failed with return code {returncode}; record/report results were not generated from this run.",
+                "severity": "error",
+            }
+        )
+    return returncode
+
+
+def _base_manifest(args: argparse.Namespace, run_dir: Path) -> dict[str, object]:
+    precise_events = _parse_precise_events(args.precise_events)
+    return {
+        "run_dir": str(run_dir),
+        "config": {
+            "mode": args.mode,
+            "binary": str(Path(args.binary).resolve()),
+            "workload": str(Path(args.workload).resolve()) if getattr(args, "workload", None) else None,
+            "nemu_args": _split_nemu_args(args.nemu_args),
+            "callgraph": args.callgraph,
+            "callgraph_depth": args.callgraph_depth,
+            "include_external": args.include_external,
+            "sample_freq": args.sample_freq,
+            "top": args.top,
+            "bb_top": args.bb_top,
+        },
+        "sampling": {
+            "quick_leader_event": QUICK_LEADER_EVENT,
+            "sampled_events": precise_events if args.mode != QUICK_MODE else [],
+            "record_artifacts": {},
+        },
+        "warnings": [],
+        "reports": {},
+    }
+
+
+def _write_doctor(run_dir: Path, doctor: dict[str, object]) -> None:
+    write_json(run_dir / "parsed" / "doctor.json", doctor)
+    lines = ["# Doctor", ""]
+    for key, value in doctor["checks"].items():
+        lines.append(f"- {key}: {value}")
+    if doctor["warnings"]:
+        lines.append("")
+        lines.append("## Warnings")
+        for warning in doctor["warnings"]:
+            lines.append(f"- [{warning['severity']}] {warning['code']}: {warning['message']}")
+    write_text(run_dir / "reports" / "doctor.md", "\n".join(lines) + "\n")
+
+
+def _copy_nemu_stdout(run_dir: Path, stat: dict[str, object]) -> None:
+    stdout_log = stat.get("stdout_log")
+    if not stdout_log:
+        return
+    stdout_path = Path(str(stdout_log))
+    if not stdout_path.is_absolute():
+        stdout_path = run_dir / stdout_path
+    if stdout_path.exists():
+        write_text(
+            run_dir / "logs" / "nemu.stdout.log",
+            stdout_path.read_text(encoding="utf-8", errors="replace"),
+        )
+
+
+def command_doctor(args: argparse.Namespace) -> int:
+    run_dir = _new_run_dir(Path(args.output_root), args.run_id)
+    report = run_doctor(Path(args.binary), Path(args.workload).resolve() if args.workload else None)
+    _write_doctor(run_dir, report)
+    print(run_dir / "reports" / "doctor.md")
+    return 1 if _has_error_warnings(report) else 0
+
+
+def _record(run_dir: Path, manifest: dict[str, object]) -> None:
+    config = manifest["config"]
+    binary = Path(config["binary"])
+    workload = Path(config["workload"])
+    nemu_args = list(config["nemu_args"])
+    raw_record_dir = ensure_dir(run_dir / "raw" / "record")
+    if config["mode"] == QUICK_MODE:
+        artifact, samples = collect_quick_record(
+            binary=binary,
+            workload=workload,
+            nemu_args=nemu_args,
+            out_dir=raw_record_dir,
+            freq=int(config["sample_freq"]),
+            callgraph=str(config["callgraph"]),
+            callgraph_depth=int(config["callgraph_depth"]),
+            include_external=bool(config["include_external"]),
+        )
+        manifest["sampling"]["sampled_events"] = list(artifact["sampled_events"])
+        manifest["sampling"]["record_artifacts"]["quick"] = artifact
+        write_json(run_dir / "parsed" / "quick_samples.json", samples)
+    else:
+        events = list(manifest["sampling"]["sampled_events"])
+        artifacts, samples_by_event = collect_precise_records(
+            binary=binary,
+            workload=workload,
+            nemu_args=nemu_args,
+            out_dir=raw_record_dir,
+            events=events,
+            freq=int(config["sample_freq"]),
+            callgraph=str(config["callgraph"]),
+            callgraph_depth=int(config["callgraph_depth"]),
+            include_external=bool(config["include_external"]),
+        )
+        manifest["sampling"]["record_artifacts"] = artifacts
+        for event, samples in samples_by_event.items():
+            write_json(run_dir / "parsed" / f"samples_{event_id(event)}.json", samples)
+
+
+def command_stat(args: argparse.Namespace) -> int:
+    run_dir = _new_run_dir(Path(args.output_root), args.run_id)
+    manifest = _base_manifest(args, run_dir)
+    progress(1, 2, "doctor")
+    doctor = run_doctor(Path(manifest["config"]["binary"]), Path(manifest["config"]["workload"]))
+    manifest["warnings"].extend(doctor["warnings"])
+    _write_doctor(run_dir, doctor)
+    if _has_error_warnings(doctor):
+        return _finish_doctor_failure(run_dir, manifest)
+    progress(2, 2, "stat")
+    stat = collect_perf_stat(
+        binary=Path(manifest["config"]["binary"]),
+        workload=Path(manifest["config"]["workload"]),
+        nemu_args=list(manifest["config"]["nemu_args"]),
+        out_dir=ensure_dir(run_dir / "raw" / "stat"),
+    )
+    _copy_nemu_stdout(run_dir, stat)
+    stat_returncode = _record_stat_failure(stat)
+    write_json(run_dir / "parsed" / "stat.json", stat)
+    write_json(run_dir / "manifest.json", manifest)
+    print(run_dir)
+    return stat_returncode
+
+
+def command_record(args: argparse.Namespace) -> int:
+    run_dir = _new_run_dir(Path(args.output_root), args.run_id)
+    manifest = _base_manifest(args, run_dir)
+    progress(1, 2, "doctor")
+    doctor = run_doctor(Path(manifest["config"]["binary"]), Path(manifest["config"]["workload"]))
+    manifest["warnings"].extend(doctor["warnings"])
+    _write_doctor(run_dir, doctor)
+    if _has_error_warnings(doctor):
+        return _finish_doctor_failure(run_dir, manifest)
+    progress(2, 2, "record", manifest["config"]["mode"])
+    _record(run_dir, manifest)
+    write_json(run_dir / "manifest.json", manifest)
+    print(run_dir)
+    return 0
+
+
+def command_report(args: argparse.Namespace) -> int:
+    run_dir = Path(args.from_run).resolve()
+    manifest_path = run_dir / "manifest.json"
+    try:
+        manifest = read_json(manifest_path)
+    except (FileNotFoundError, OSError, json.JSONDecodeError) as exc:
+        print(f"error: failed to read {manifest_path}: {exc}", file=sys.stderr)
+        return 1
+    if not isinstance(manifest, dict):
+        print(f"error: {manifest_path} must contain a JSON object", file=sys.stderr)
+        return 1
+    reports, warnings = generate_reports(run_dir, manifest, top_n=args.top, bb_top_n=args.bb_top)
+    manifest["reports"] = reports
+    manifest["warnings"] = warnings
+    write_json(run_dir / "manifest.json", manifest)
+    print(run_dir / reports["summary"])
+    return 0
+
+
+def command_run(args: argparse.Namespace) -> int:
+    run_dir = _new_run_dir(Path(args.output_root), args.run_id)
+    manifest = _base_manifest(args, run_dir)
+    total_steps = 4
+    progress(1, total_steps, "doctor")
+    doctor = run_doctor(Path(manifest["config"]["binary"]), Path(manifest["config"]["workload"]))
+    manifest["warnings"].extend(doctor["warnings"])
+    _write_doctor(run_dir, doctor)
+    if _has_error_warnings(doctor):
+        return _finish_doctor_failure(run_dir, manifest)
+
+    progress(2, total_steps, "stat")
+    stat = collect_perf_stat(
+        binary=Path(manifest["config"]["binary"]),
+        workload=Path(manifest["config"]["workload"]),
+        nemu_args=list(manifest["config"]["nemu_args"]),
+        out_dir=ensure_dir(run_dir / "raw" / "stat"),
+    )
+    _copy_nemu_stdout(run_dir, stat)
+    stat_returncode = _record_stat_failure(stat)
+    write_json(run_dir / "parsed" / "stat.json", stat)
+    if stat_returncode != 0:
+        write_json(run_dir / "manifest.json", manifest)
+        print(run_dir)
+        return stat_returncode
+
+    progress(3, total_steps, "record", manifest["config"]["mode"])
+    _record(run_dir, manifest)
+
+    progress(4, total_steps, "report")
+    reports, warnings = generate_reports(
+        run_dir,
+        manifest,
+        top_n=int(manifest["config"]["top"]),
+        bb_top_n=int(manifest["config"]["bb_top"]),
+    )
+    manifest["reports"] = reports
+    manifest["warnings"] = warnings
+    write_json(run_dir / "manifest.json", manifest)
+    print(run_dir / reports["summary"])
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="NEMU perf profiling tool")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    def add_common(sub: argparse.ArgumentParser, require_workload: bool = True) -> None:
+        sub.add_argument("--binary", default=str(DEFAULT_BINARY))
+        sub.add_argument("--workload", required=require_workload)
+        sub.add_argument("--output-root", default=str(DEFAULT_OUTPUT_ROOT))
+        sub.add_argument("--run-id")
+        sub.add_argument("--mode", choices=MODES, default=QUICK_MODE)
+        sub.add_argument(
+            "--nemu-args",
+            default="-b",
+            help="arguments passed to NEMU before the workload; for Linux workloads, a practical starting point is '-b -I 1000000000'",
+        )
+        sub.add_argument("--callgraph", choices=["fp", "dwarf"], default=DEFAULT_CALLGRAPH)
+        sub.add_argument(
+            "--callgraph-depth",
+            type=int,
+            default=DEFAULT_CALLGRAPH_DEPTH,
+            help="stack dump size used by perf only when --callgraph=dwarf; ignored for --callgraph=fp",
+        )
+        sub.add_argument("--sample-freq", type=int, default=DEFAULT_SAMPLE_FREQ)
+        sub.add_argument("--top", type=int, default=100)
+        sub.add_argument("--bb-top", type=int, default=100)
+        sub.add_argument("--include-external", action="store_true")
+        sub.add_argument("--precise-events", default=",".join(PRECISE_DEFAULT_SAMPLE_EVENTS))
+
+    doctor = subparsers.add_parser("doctor", help="run environment checks")
+    doctor.add_argument("--binary", default=str(DEFAULT_BINARY))
+    doctor.add_argument("--workload")
+    doctor.add_argument("--output-root", default=str(DEFAULT_OUTPUT_ROOT))
+    doctor.add_argument("--run-id")
+    doctor.set_defaults(func=command_doctor)
+
+    stat = subparsers.add_parser("stat", help="collect perf stat counters")
+    add_common(stat)
+    stat.set_defaults(func=command_stat)
+
+    record = subparsers.add_parser("record", help="collect perf record samples")
+    add_common(record)
+    record.set_defaults(func=command_record)
+
+    report = subparsers.add_parser("report", help="regenerate reports from an existing run")
+    report.add_argument("--from-run", required=True)
+    report.add_argument("--top", type=int, default=100)
+    report.add_argument("--bb-top", type=int, default=100)
+    report.set_defaults(func=command_report)
+
+    run = subparsers.add_parser("run", help="run doctor, stat, record, and report")
+    add_common(run)
+    run.set_defaults(func=command_run)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if getattr(args, "run_id", None) is not None:
+        try:
+            _validate_run_id(args.run_id)
+        except ValueError as exc:
+            parser.error(f"--run-id {exc}")
+    if getattr(args, "command", "") in {"record", "run"}:
+        if int(args.sample_freq) <= 0:
+            parser.error("--sample-freq must be positive")
+        if int(args.callgraph_depth) <= 0:
+            parser.error("--callgraph-depth must be positive")
+    if getattr(args, "command", "") in {"run", "report"}:
+        if int(args.top) <= 0:
+            parser.error("--top must be positive")
+        if int(args.bb_top) <= 0:
+            parser.error("--bb-top must be positive")
+    if getattr(args, "mode", QUICK_MODE) != QUICK_MODE and getattr(args, "command", "") in {"stat", "record", "run"}:
+        try:
+            precise_events = _validate_precise_events(args.precise_events)
+        except ValueError as exc:
+            parser.error(f"--precise-events contains an invalid event: {exc}")
+        if not precise_events:
+            parser.error("--precise-events must specify at least one event in precise mode")
+    return args.func(args)

--- a/tools/perf_profile/collect/__init__.py
+++ b/tools/perf_profile/collect/__init__.py
@@ -1,0 +1,16 @@
+#***************************************************************************************
+# Copyright (c) 2026 Institute of Computing Technology, Chinese Academy of Sciences
+#
+# NEMU is licensed under Mulan PSL v2.
+# You can use this software according to the terms and conditions of the Mulan PSL v2.
+# You may obtain a copy of Mulan PSL v2 at:
+#          http://license.coscl.org.cn/MulanPSL2
+#
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+# EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+# MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+#
+# See the Mulan PSL v2 for more details.
+#***************************************************************************************/
+
+"""Collectors for perf profiling."""

--- a/tools/perf_profile/collect/record.py
+++ b/tools/perf_profile/collect/record.py
@@ -1,0 +1,140 @@
+#***************************************************************************************
+# Copyright (c) 2026 Institute of Computing Technology, Chinese Academy of Sciences
+#
+# NEMU is licensed under Mulan PSL v2.
+# You can use this software according to the terms and conditions of the Mulan PSL v2.
+# You may obtain a copy of Mulan PSL v2 at:
+#          http://license.coscl.org.cn/MulanPSL2
+#
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+# EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+# MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+#
+# See the Mulan PSL v2 for more details.
+#***************************************************************************************/
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..catalog import QUICK_GROUP_EVENTS, QUICK_LEADER_EVENT
+from ..parse import parse_script_samples
+from ..util import event_id, run_cmd
+
+
+SCRIPT_FIELDS = "comm,pid,tid,time,event,ip,sym,dso,period"
+
+
+def _callgraph_arg(mode: str, depth: int) -> str:
+    normalized_mode = mode.strip().lower()
+    if normalized_mode == "dwarf":
+        return f"{normalized_mode},{depth}"
+    return normalized_mode
+
+
+def _record_one(
+    *,
+    binary: Path,
+    workload: Path,
+    nemu_args: list[str],
+    out_dir: Path,
+    run_dir: Path,
+    name: str,
+    event_expr: str,
+    freq: int,
+    callgraph: str,
+    callgraph_depth: int,
+    include_external: bool,
+) -> tuple[dict[str, object], list[dict[str, object]]]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    perf_data = out_dir / f"{name}.data"
+    script_txt = out_dir / f"{name}.script.txt"
+    stderr_path = out_dir / f"{name}.record.stderr.log"
+    stdout_path = out_dir / f"{name}.record.stdout.log"
+    cmd = [
+        "perf", "record", "--all-user",
+        "--call-graph", _callgraph_arg(callgraph, callgraph_depth),
+        "-F", str(freq), "-e", event_expr, "-o", str(perf_data),
+        "--", str(binary), *nemu_args, str(workload),
+    ]
+    proc = run_cmd(cmd, check=False, stdout_path=stdout_path, stderr_path=stderr_path)
+    if proc.returncode != 0:
+        raise RuntimeError(f"perf record failed for {name}, see {stderr_path}")
+
+    run_cmd(["perf", "script", "-i", str(perf_data), "-F", SCRIPT_FIELDS], stdout_path=script_txt)
+    with script_txt.open("r", encoding="utf-8") as script_fp:
+        samples = parse_script_samples(script_fp, binary.name, include_external=include_external)
+    artifact = {
+        "freq": freq,
+        "perf_data": str(perf_data.relative_to(run_dir)),
+        "script_txt": str(script_txt.relative_to(run_dir)),
+        "stderr_log": str(stderr_path.relative_to(run_dir)),
+        "stdout_log": str(stdout_path.relative_to(run_dir)),
+        "command": cmd,
+    }
+    return artifact, [sample.__dict__ for sample in samples]
+
+
+def collect_quick_record(
+    binary: Path,
+    workload: Path,
+    nemu_args: list[str],
+    out_dir: Path,
+    freq: int,
+    callgraph: str,
+    callgraph_depth: int,
+    include_external: bool,
+) -> tuple[dict[str, object], list[dict[str, object]]]:
+    event_expr = "{" + ",".join(QUICK_GROUP_EVENTS) + "}:S"
+    run_dir = out_dir.parent.parent
+    artifact, samples = _record_one(
+        binary=binary,
+        workload=workload,
+        nemu_args=nemu_args,
+        out_dir=out_dir,
+        run_dir=run_dir,
+        name="quick",
+        event_expr=event_expr,
+        freq=freq,
+        callgraph=callgraph,
+        callgraph_depth=callgraph_depth,
+        include_external=include_external,
+    )
+    artifact.update({"mode": "quick", "leader_event": QUICK_LEADER_EVENT, "sampled_events": QUICK_GROUP_EVENTS})
+    return artifact, samples
+
+
+def collect_precise_records(
+    binary: Path,
+    workload: Path,
+    nemu_args: list[str],
+    out_dir: Path,
+    events: list[str],
+    freq: int,
+    callgraph: str,
+    callgraph_depth: int,
+    include_external: bool,
+) -> tuple[dict[str, dict[str, object]], dict[str, list[dict[str, object]]]]:
+    artifacts: dict[str, dict[str, object]] = {}
+    samples_by_event: dict[str, list[dict[str, object]]] = {}
+    run_dir = out_dir.parent.parent
+    for event in events:
+        event_slug = event_id(event)
+        event_dir = out_dir / event_slug
+        artifact, samples = _record_one(
+            binary=binary,
+            workload=workload,
+            nemu_args=nemu_args,
+            out_dir=event_dir,
+            run_dir=run_dir,
+            name=event_slug,
+            event_expr=event,
+            freq=freq,
+            callgraph=callgraph,
+            callgraph_depth=callgraph_depth,
+            include_external=include_external,
+        )
+        artifact.update({"mode": "precise", "event": event})
+        artifacts[event] = artifact
+        samples_by_event[event] = samples
+    return artifacts, samples_by_event

--- a/tools/perf_profile/collect/stat.py
+++ b/tools/perf_profile/collect/stat.py
@@ -1,0 +1,40 @@
+#***************************************************************************************
+# Copyright (c) 2026 Institute of Computing Technology, Chinese Academy of Sciences
+#
+# NEMU is licensed under Mulan PSL v2.
+# You can use this software according to the terms and conditions of the Mulan PSL v2.
+# You may obtain a copy of Mulan PSL v2 at:
+#          http://license.coscl.org.cn/MulanPSL2
+#
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+# EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+# MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+#
+# See the Mulan PSL v2 for more details.
+#***************************************************************************************/
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..catalog import GLOBAL_EVENTS
+from ..parse import parse_perf_stat
+from ..util import run_cmd
+
+
+def collect_perf_stat(binary: Path, workload: Path, nemu_args: list[str], out_dir: Path) -> dict[str, object]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    run_dir = out_dir.parent.parent
+    stdout_path = out_dir / "perf.stat.stdout.log"
+    stderr_path = out_dir / "perf.stat.stderr.log"
+    cmd = ["perf", "stat", "--all-user"]
+    for event in GLOBAL_EVENTS:
+        cmd += ["-e", event]
+    cmd += ["--", str(binary), *nemu_args, str(workload)]
+    proc = run_cmd(cmd, check=False, stdout_path=stdout_path, stderr_path=stderr_path)
+    parsed = parse_perf_stat(stderr_path.read_text(encoding="utf-8", errors="replace"))
+    parsed["returncode"] = proc.returncode
+    parsed["command"] = cmd
+    parsed["stdout_log"] = str(stdout_path.relative_to(run_dir))
+    parsed["stderr_log"] = str(stderr_path.relative_to(run_dir))
+    return parsed

--- a/tools/perf_profile/models.py
+++ b/tools/perf_profile/models.py
@@ -1,0 +1,53 @@
+#***************************************************************************************
+# Copyright (c) 2026 Institute of Computing Technology, Chinese Academy of Sciences
+#
+# NEMU is licensed under Mulan PSL v2.
+# You can use this software according to the terms and conditions of the Mulan PSL v2.
+# You may obtain a copy of Mulan PSL v2 at:
+#          http://license.coscl.org.cn/MulanPSL2
+#
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+# EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+# MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+#
+# See the Mulan PSL v2 for more details.
+#***************************************************************************************/
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, is_dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class WarningEntry:
+    code: str
+    message: str
+    severity: str = "warning"
+
+
+@dataclass
+class SampleRecord:
+    event: str
+    period: float
+    leaf: str
+    leaf_dso: str
+    ip: int | None
+    chain: list[str]
+    group_id: str
+    time: str
+    command: str
+    pid_tid: str
+
+
+def to_data(value: Any) -> Any:
+    if is_dataclass(value):
+        return {k: to_data(v) for k, v in asdict(value).items()}
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, dict):
+        return {str(k): to_data(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [to_data(v) for v in value]
+    return value

--- a/tools/perf_profile/parse.py
+++ b/tools/perf_profile/parse.py
@@ -1,0 +1,535 @@
+#***************************************************************************************
+# Copyright (c) 2026 Institute of Computing Technology, Chinese Academy of Sciences
+#
+# NEMU is licensed under Mulan PSL v2.
+# You can use this software according to the terms and conditions of the Mulan PSL v2.
+# You may obtain a copy of Mulan PSL v2 at:
+#          http://license.coscl.org.cn/MulanPSL2
+#
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+# EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+# MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+#
+# See the Mulan PSL v2 for more details.
+#***************************************************************************************/
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from bisect import bisect_right
+from collections import defaultdict
+from pathlib import Path
+
+from .catalog import DEFAULT_ANNOTATE_SYMBOL_LIMIT
+from .models import SampleRecord
+from .util import canonical_event, run_cmd
+
+
+SAMPLE_RE = re.compile(
+    r"^\s*(?P<comm>\S+)\s+"
+    r"(?:(?P<pidtid>\d+/\d+)|(?P<pid>\d+)\s+(?P<tid>\d+))\s+"
+    r"(?P<time>[0-9.]+):\s+"
+    r"(?P<period>\d+)\s+"
+    r"(?P<event>[^:]+):"
+    r"(?:\s+(?P<ip>[0-9a-fA-Fx]+)\s+(?P<sym>\S+)\s+\((?P<dso>[^)]*)\))?\s*$"
+)
+CC_ADDR_RE = re.compile(r"^\s*(?P<addr>[0-9a-fA-Fx]+)\s+(?P<sym>\S+)\s+\((?P<dso>[^)]*)\)\s*$")
+STAT_LINE_RE = re.compile(
+    r"^\s*(?P<count>[0-9,]+)\s+(?P<event>\S+)(?P<rest>.*)$"
+)
+RUNNING_RE = re.compile(r"\((?P<pct>[0-9.]+)%\)")
+ELAPSED_RE = re.compile(r"([0-9]+(?:\.[0-9]+)?)\s+seconds\s+time\s+elapsed")
+ANN_INSN_RE = re.compile(r"^\s*(?P<pct>[0-9]+(?:\.[0-9]+)?)\s*:\s*(?P<addr>[0-9a-fA-F]+):\s*(?P<asm>.+)$")
+ANN_EVENT_HDR_RE = re.compile(r"Disassembly of .* for (?P<pmu>[^\s]+) \((?P<samples>\d+) samples")
+ANN_GROUP_HDR_RE = re.compile(r"anon group\s*\{(?P<events>[^}]*)\}")
+ANN_GROUP_INSN_RE = re.compile(
+    r"^\s*(?P<pcts>(?:[0-9]+(?:\.[0-9]+)?\s+){2,}):\s*(?P<addr>[0-9a-fA-F]+):\s*(?P<asm>.+)$"
+)
+NM_LINE_RE = re.compile(r"^(?P<addr>[0-9a-fA-F]+)\s+\S\s+(?P<sym>\S+)$")
+TARGET_ADDR_RE = re.compile(r"\b(?:0x)?(?P<addr>[0-9a-fA-F]{4,})\b")
+
+_SYMBOL_CACHE: dict[str, tuple[list[int], list[str]]] = {}
+_ANNOTATE_CACHE: dict[tuple[str, str], str] = {}
+CONTROL_TRANSFER_PREFIXES = (
+    "j",
+    "call",
+    "ret",
+    "syscall",
+    "sysenter",
+    "int",
+    "iret",
+)
+
+
+def parse_perf_stat(stderr_text: str) -> dict[str, object]:
+    counts: dict[str, int] = defaultdict(int)
+    running_pct: dict[str, float] = {}
+    unsupported: list[str] = []
+    warnings: list[dict[str, str]] = []
+
+    for line in stderr_text.splitlines():
+        if "<not supported>" in line:
+            unsupported.append(line.strip())
+            continue
+        match = STAT_LINE_RE.match(line)
+        if not match:
+            continue
+        event = canonical_event(match.group("event"))
+        try:
+            count = int(match.group("count").replace(",", ""))
+        except ValueError:
+            continue
+        counts[event] += count
+        pct_match = RUNNING_RE.search(match.group("rest"))
+        if pct_match:
+            pct = float(pct_match.group("pct"))
+            running_pct[event] = max(running_pct.get(event, 0.0), pct)
+
+    elapsed = None
+    elapsed_match = ELAPSED_RE.search(stderr_text)
+    if elapsed_match:
+        elapsed = float(elapsed_match.group(1))
+
+    for event, pct in running_pct.items():
+        if pct < 99.0:
+            warnings.append(
+                {
+                    "code": "stat_multiplexed",
+                    "message": f"{event} ran for {pct:.2f}% of the measurement window; perf stat scaling is in effect.",
+                    "severity": "warning",
+                }
+            )
+
+    return {
+        "counts": dict(counts),
+        "running_pct": running_pct,
+        "elapsed_seconds": elapsed,
+        "unsupported_lines": unsupported,
+        "warnings": warnings,
+    }
+
+
+def parse_script_samples(
+    script_lines: Iterable[str] | str,
+    binary_name: str,
+    include_external: bool = False,
+) -> list[SampleRecord]:
+    records: list[SampleRecord] = []
+    line_iter = iter(script_lines.splitlines() if isinstance(script_lines, str) else script_lines)
+    pending_line: str | None = None
+    while True:
+        line = pending_line
+        pending_line = None
+        if line is None:
+            try:
+                line = next(line_iter)
+            except StopIteration:
+                break
+
+        match = SAMPLE_RE.match(line)
+        if not match:
+            continue
+
+        event = canonical_event(match.group("event"))
+        period = float(match.group("period"))
+        command = match.group("comm")
+        pid_tid = match.group("pidtid") or f"{match.group('pid')}/{match.group('tid')}"
+        time = match.group("time")
+        group_id = f"{command}|{pid_tid}|{time}"
+
+        leaf = ""
+        leaf_dso = ""
+        leaf_ip = None
+        chain: list[str] = []
+
+        if match.group("sym"):
+            leaf = match.group("sym").split("+0x", 1)[0].strip()
+            leaf_dso = match.group("dso") or ""
+            try:
+                leaf_ip = int(match.group("ip"), 16) if match.group("ip") else None
+            except ValueError:
+                leaf_ip = None
+            in_target_binary = binary_name in leaf_dso
+            if leaf and leaf != "[unknown]" and (include_external or in_target_binary):
+                chain.append(leaf)
+
+        while True:
+            try:
+                callchain_line = next(line_iter)
+            except StopIteration:
+                callchain_line = None
+            if callchain_line is None:
+                break
+
+            addr_match = CC_ADDR_RE.match(callchain_line)
+            if not addr_match:
+                pending_line = callchain_line
+                break
+            sym = addr_match.group("sym").split("+0x", 1)[0].strip()
+            dso = addr_match.group("dso")
+            if not leaf:
+                leaf = sym
+                leaf_dso = dso
+                try:
+                    leaf_ip = int(addr_match.group("addr"), 16)
+                except ValueError:
+                    leaf_ip = None
+            in_target_binary = binary_name in (dso or "")
+            if sym and sym != "[unknown]" and sym not in chain and (include_external or in_target_binary):
+                chain.append(sym)
+
+        if not leaf or leaf == "[unknown]":
+            continue
+        if not include_external and binary_name not in (leaf_dso or ""):
+            continue
+
+        records.append(
+            SampleRecord(
+                event=event,
+                period=period,
+                leaf=leaf,
+                leaf_dso=leaf_dso,
+                ip=leaf_ip,
+                chain=chain or [leaf],
+                group_id=group_id,
+                time=time,
+                command=command,
+                pid_tid=pid_tid,
+            )
+        )
+    return records
+
+
+def _load_symbol_table(binary: Path) -> tuple[list[int], list[str]]:
+    key = str(binary.resolve())
+    cached = _SYMBOL_CACHE.get(key)
+    if cached is not None:
+        return cached
+
+    proc = run_cmd(["nm", "-n", "--defined-only", str(binary)], check=False)
+    addrs: list[int] = []
+    symbols: list[str] = []
+    for line in proc.stdout.splitlines():
+        match = NM_LINE_RE.match(line.strip())
+        if not match:
+            continue
+        addrs.append(int(match.group("addr"), 16))
+        symbols.append(match.group("sym"))
+
+    cached = (addrs, symbols)
+    _SYMBOL_CACHE[key] = cached
+    return cached
+
+
+def _fallback_symbol(binary: Path, addr: int) -> str | None:
+    addrs, symbols = _load_symbol_table(binary)
+    if not addrs:
+        return None
+    idx = bisect_right(addrs, addr) - 1
+    if idx < 0:
+        return None
+    return symbols[idx]
+
+
+def _is_control_transfer(op: str) -> bool:
+    return op.startswith(CONTROL_TRANSFER_PREFIXES)
+
+
+def _branch_target_addr(operand: object) -> int | None:
+    match = TARGET_ADDR_RE.search(str(operand))
+    if match is None:
+        return None
+    return int(match.group("addr"), 16)
+
+
+def _annotate_output(perf_data: Path, symbol: str) -> str:
+    key = (str(perf_data.resolve()), symbol)
+    cached = _ANNOTATE_CACHE.get(key)
+    if cached is not None:
+        return cached
+    output = run_cmd(["perf", "annotate", "--stdio", "-i", str(perf_data), "--symbol", symbol]).stdout
+    _ANNOTATE_CACHE[key] = output
+    return output
+
+
+def run_addr2line(binary: Path, addrs: list[int]) -> dict[int, tuple[str, str]]:
+    if not addrs:
+        return {}
+
+    cmd = ["addr2line", "-a", "-i", "-f", "-C", "-e", str(binary)] + [f"0x{addr:x}" for addr in addrs]
+    output = run_cmd(cmd).stdout.splitlines()
+    mapping: dict[int, tuple[str, str]] = {}
+
+    current_addr: int | None = None
+    current_pairs: list[tuple[str, str]] = []
+
+    def flush() -> None:
+        nonlocal current_addr, current_pairs
+        if current_addr is None:
+            return
+        fn = "??"
+        loc = "??:0"
+        for cand_fn, cand_loc in current_pairs:
+            if cand_loc and cand_loc != "??:0":
+                loc = cand_loc
+            if cand_fn and cand_fn != "??":
+                fn = cand_fn
+                if cand_loc and cand_loc != "??:0":
+                    loc = cand_loc
+                break
+        if fn == "??":
+            fallback = _fallback_symbol(binary, current_addr)
+            if fallback:
+                fn = fallback
+        mapping[current_addr] = (fn, loc)
+        current_addr = None
+        current_pairs = []
+
+    idx = 0
+    while idx < len(output):
+        line = output[idx].strip()
+        if line.startswith("0x"):
+            flush()
+            try:
+                current_addr = int(line, 16)
+            except ValueError:
+                current_addr = None
+            idx += 1
+            continue
+        if current_addr is not None and idx + 1 < len(output):
+            current_pairs.append((line or "??", output[idx + 1].strip() or "??:0"))
+            idx += 2
+            continue
+        idx += 1
+
+    flush()
+    for addr in addrs:
+        mapping.setdefault(addr, (_fallback_symbol(binary, addr) or "??", "??:0"))
+    return mapping
+
+
+def annotate_basic_blocks(
+    perf_data: Path,
+    binary: Path,
+    event: str,
+    symbol_periods: dict[str, float],
+    global_total_count: float | None,
+    top_n: int,
+    max_annotated_symbols: int = DEFAULT_ANNOTATE_SYMBOL_LIMIT,
+) -> dict[str, object] | None:
+    if not symbol_periods:
+        return None
+
+    normalized_event = canonical_event(event)
+    annotate_limit = min(max(1, top_n), max(1, max_annotated_symbols))
+    hot_symbols = [
+        symbol
+        for symbol, _ in sorted(symbol_periods.items(), key=lambda kv: kv[1], reverse=True)[:annotate_limit]
+    ]
+    merged_blocks: dict[tuple[str, int, int], dict[str, object]] = {}
+    total_est = 0.0
+
+    for symbol in hot_symbols:
+        try:
+            ann = _annotate_output(perf_data, symbol)
+        except RuntimeError:
+            continue
+
+        lines = ann.splitlines()
+        group_order: list[str] = []
+        for line in lines:
+            header = ANN_GROUP_HDR_RE.search(line)
+            if header:
+                raw_events = [part.strip() for part in header.group("events").split(",") if part.strip()]
+                group_order = [canonical_event(item.strip("/ ")) for item in raw_events]
+                break
+
+        if group_order and normalized_event in group_order:
+            event_idx = group_order.index(normalized_event)
+            insns: list[dict[str, object]] = []
+            for line in lines:
+                insn_match = ANN_GROUP_INSN_RE.match(line)
+                if not insn_match:
+                    continue
+                pcts = [float(token) for token in insn_match.group("pcts").split()]
+                if event_idx >= len(pcts):
+                    continue
+                asm = insn_match.group("asm").strip()
+                parts = asm.split(None, 1)
+                insns.append(
+                    {
+                        "addr": int(insn_match.group("addr"), 16),
+                        "pct": pcts[event_idx],
+                        "op": parts[0] if parts else "",
+                        "operand": parts[1] if len(parts) > 1 else "",
+                        "asm": asm,
+                    }
+                )
+            if not insns:
+                continue
+
+            leaders = {insns[0]["addr"]}
+            for idx, insn in enumerate(insns):
+                op = str(insn["op"]).lower()
+                if _is_control_transfer(op):
+                    if idx + 1 < len(insns):
+                        leaders.add(insns[idx + 1]["addr"])
+                    target_addr = _branch_target_addr(insn["operand"])
+                    if target_addr is not None:
+                        leaders.add(target_addr)
+
+            blocks: list[list[dict[str, object]]] = []
+            current: list[dict[str, object]] = []
+            for insn in insns:
+                if current and insn["addr"] in leaders:
+                    blocks.append(current)
+                    current = []
+                current.append(insn)
+            if current:
+                blocks.append(current)
+
+            total_est += symbol_periods.get(symbol, 0.0)
+            for block in blocks:
+                key = (symbol, int(block[0]["addr"]), int(block[-1]["addr"]))
+                entry = merged_blocks.setdefault(
+                    key,
+                    {
+                        "symbol": symbol,
+                        "start": block[0]["addr"],
+                        "end": block[-1]["addr"],
+                        "insn_count": len(block),
+                        "event_count_est": 0.0,
+                        "preview": [str(ins["asm"]) for ins in block[:4]],
+                    },
+                )
+                entry["event_count_est"] += symbol_periods.get(symbol, 0.0) * sum(float(ins["pct"]) for ins in block) / 100.0
+            continue
+
+        sections: list[tuple[int, list[dict[str, object]]]] = []
+        section_insns: list[dict[str, object]] = []
+        section_samples = 0
+        in_target = False
+
+        for line in lines:
+            header_match = ANN_EVENT_HDR_RE.search(line)
+            if header_match:
+                if in_target and section_insns:
+                    sections.append((section_samples, section_insns))
+                section_insns = []
+                pmu_event = canonical_event(header_match.group("pmu").strip())
+                section_samples = int(header_match.group("samples"))
+                in_target = pmu_event == normalized_event
+                continue
+            if not in_target:
+                continue
+            insn_match = ANN_INSN_RE.match(line)
+            if not insn_match:
+                continue
+            asm = insn_match.group("asm").strip()
+            parts = asm.split(None, 1)
+            section_insns.append(
+                {
+                    "addr": int(insn_match.group("addr"), 16),
+                    "pct": float(insn_match.group("pct")),
+                    "op": parts[0] if parts else "",
+                    "operand": parts[1] if len(parts) > 1 else "",
+                    "asm": asm,
+                }
+            )
+        if in_target and section_insns:
+            sections.append((section_samples, section_insns))
+        if not sections:
+            continue
+
+        symbol_weight = 0.0
+        local_blocks: list[dict[str, object]] = []
+        for section_samples, insns in sections:
+            leaders = {insns[0]["addr"]}
+            for idx, insn in enumerate(insns):
+                op = str(insn["op"]).lower()
+                if _is_control_transfer(op):
+                    if idx + 1 < len(insns):
+                        leaders.add(insns[idx + 1]["addr"])
+                    target_addr = _branch_target_addr(insn["operand"])
+                    if target_addr is not None:
+                        leaders.add(target_addr)
+
+            blocks: list[list[dict[str, object]]] = []
+            current: list[dict[str, object]] = []
+            for insn in insns:
+                if current and insn["addr"] in leaders:
+                    blocks.append(current)
+                    current = []
+                current.append(insn)
+            if current:
+                blocks.append(current)
+
+            for block in blocks:
+                block_weight = section_samples * sum(float(ins["pct"]) for ins in block) / 100.0
+                symbol_weight += block_weight
+                local_blocks.append(
+                    {
+                        "symbol": symbol,
+                        "start": block[0]["addr"],
+                        "end": block[-1]["addr"],
+                        "insn_count": len(block),
+                        "preview": [str(ins["asm"]) for ins in block[:4]],
+                        "weight": block_weight,
+                    }
+                )
+
+        if symbol_weight <= 0:
+            continue
+
+        scale = symbol_periods.get(symbol, 0.0) / symbol_weight
+        total_est += symbol_periods.get(symbol, 0.0)
+        for block in local_blocks:
+            key = (symbol, int(block["start"]), int(block["end"]))
+            est = float(block["weight"]) * scale
+            entry = merged_blocks.setdefault(
+                key,
+                {
+                    "symbol": symbol,
+                    "start": block["start"],
+                    "end": block["end"],
+                    "insn_count": block["insn_count"],
+                    "event_count_est": 0.0,
+                    "preview": block["preview"],
+                },
+            )
+            entry["event_count_est"] += est
+
+    if not merged_blocks:
+        return None
+
+    scored = list(merged_blocks.values())
+    addr_map: dict[int, tuple[str, str]] = {}
+    if binary.exists():
+        try:
+            addr_map = run_addr2line(binary, [int(row["start"]) for row in scored])
+        except RuntimeError:
+            addr_map = {}
+    for row in scored:
+        fn, loc = addr_map.get(int(row["start"]), ("??", "??:0"))
+        row["function"] = fn
+        row["location"] = loc
+        row["coverage_pct"] = 100.0 * float(row["event_count_est"]) / total_est if total_est > 0 else 0.0
+        row["global_coverage_pct"] = (
+            100.0 * float(row["event_count_est"]) / global_total_count
+            if global_total_count is not None and global_total_count > 0
+            else None
+        )
+
+    scored.sort(key=lambda row: float(row["event_count_est"]), reverse=True)
+    block_index = {
+        (str(row["symbol"]), int(row["start"]), int(row["end"])): row
+        for row in scored
+    }
+    return {
+        "event": event,
+        "rows": scored[:top_n],
+        "index": block_index,
+        "sampled_total_est": total_est,
+        "global_total_count": global_total_count,
+    }

--- a/tools/perf_profile/preflight.py
+++ b/tools/perf_profile/preflight.py
@@ -1,0 +1,133 @@
+#***************************************************************************************
+# Copyright (c) 2026 Institute of Computing Technology, Chinese Academy of Sciences
+#
+# NEMU is licensed under Mulan PSL v2.
+# You can use this software according to the terms and conditions of the Mulan PSL v2.
+# You may obtain a copy of Mulan PSL v2 at:
+#          http://license.coscl.org.cn/MulanPSL2
+#
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+# EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+# MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+#
+# See the Mulan PSL v2 for more details.
+#***************************************************************************************/
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+from .models import WarningEntry, to_data
+from .util import get_host_summary, read_proc_int, run_cmd
+
+
+def _version_line(cmd: list[str]) -> str | None:
+    try:
+        proc = run_cmd(cmd, check=False)
+    except RuntimeError:
+        return None
+    text = proc.stdout.strip() or proc.stderr.strip()
+    if not text:
+        return None
+    return text.splitlines()[0]
+
+
+def _probe_symbolization(binary: Path) -> bool | None:
+    try:
+        proc = subprocess.Popen(
+            ["nm", "-n", "--defined-only", str(binary)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+    except OSError:
+        return None
+
+    probe_addr: str | None = None
+    assert proc.stdout is not None
+    try:
+        for line in proc.stdout:
+            match = re.match(r"^(?P<addr>[0-9a-fA-F]+)\s+\S\s+\S+$", line.strip())
+            if match is None:
+                continue
+            probe_addr = match.group("addr")
+            if int(probe_addr, 16) != 0:
+                proc.terminate()
+                break
+    finally:
+        proc.stdout.close()
+        try:
+            proc.wait(timeout=1)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+    if probe_addr is None:
+        return False
+
+    try:
+        probe = run_cmd(["addr2line", "-f", "-C", "-e", str(binary), f"0x{probe_addr}"], check=False)
+    except RuntimeError:
+        return False
+    if probe.returncode != 0:
+        return False
+
+    lines = [line.strip() for line in probe.stdout.splitlines() if line.strip()]
+    if len(lines) < 2:
+        return False
+    function, location = lines[0], lines[1]
+    return function != "??" and location not in {"??:0", "??:?"}
+
+
+def run_doctor(binary: Path, workload: Path | None) -> dict[str, object]:
+    warnings: list[WarningEntry] = []
+    checks = {
+        "python_version": _version_line(["python3", "--version"]),
+        "perf_version": _version_line(["perf", "--version"]),
+        "addr2line_version": _version_line(["addr2line", "--version"]),
+        "nm_version": _version_line(["nm", "--version"]),
+        "perf_event_paranoid": read_proc_int(Path("/proc/sys/kernel/perf_event_paranoid")),
+        "perf_event_max_sample_rate": read_proc_int(Path("/proc/sys/kernel/perf_event_max_sample_rate")),
+        "binary_exists": binary.exists(),
+        "workload_exists": workload.exists() if workload is not None else None,
+    }
+
+    if not binary.exists():
+        warnings.append(WarningEntry("binary_missing", f"binary not found: {binary}", "error"))
+    if workload is not None and not workload.exists():
+        warnings.append(WarningEntry("workload_missing", f"workload not found: {workload}", "error"))
+    if checks["perf_version"] is None:
+        warnings.append(WarningEntry("perf_missing", "perf not found in PATH.", "error"))
+    if checks["addr2line_version"] is None:
+        warnings.append(WarningEntry("addr2line_missing", "addr2line not found in PATH.", "error"))
+    if checks["nm_version"] is None:
+        warnings.append(WarningEntry("nm_missing", "nm not found in PATH.", "error"))
+
+    if checks["perf_event_paranoid"] is not None and checks["perf_event_paranoid"] > 1:
+        warnings.append(
+            WarningEntry(
+                "perf_permissions",
+                "perf_event_paranoid is high; user-space sampling may be restricted or incomplete.",
+            )
+        )
+
+    symbolization = None
+    if binary.exists() and checks["addr2line_version"] is not None and checks["nm_version"] is not None:
+        symbolization = _probe_symbolization(binary)
+        if symbolization is False:
+            warnings.append(
+                WarningEntry(
+                    "symbolization_probe_failed",
+                    "addr2line did not resolve source locations from the binary; reports may show ??:0.",
+                )
+            )
+
+    report = {
+        "host": get_host_summary(),
+        "checks": {**checks, "symbolization_probe_ok": symbolization},
+        "warnings": [to_data(w) for w in warnings],
+    }
+    return report

--- a/tools/perf_profile/report.py
+++ b/tools/perf_profile/report.py
@@ -1,0 +1,574 @@
+#***************************************************************************************
+# Copyright (c) 2026 Institute of Computing Technology, Chinese Academy of Sciences
+#
+# NEMU is licensed under Mulan PSL v2.
+# You can use this software according to the terms and conditions of the Mulan PSL v2.
+# You may obtain a copy of Mulan PSL v2 at:
+#          http://license.coscl.org.cn/MulanPSL2
+#
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+# EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+# MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+#
+# See the Mulan PSL v2 for more details.
+#***************************************************************************************/
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from collections import defaultdict
+from pathlib import Path
+
+from .catalog import GLOBAL_EVENTS, QUICK_GROUP_EVENTS, QUICK_LEADER_EVENT, QUICK_MODE
+from .parse import annotate_basic_blocks
+from .util import canonical_event, derive_metrics, event_id, fmt_count, fmt_num, parse_nemu_summary, write_json, write_text
+
+
+def _iter_sample_records(records: list[object]) -> Iterator[tuple[dict[str, object], str, str, float]]:
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        event = record.get("event")
+        leaf = record.get("leaf")
+        period = record.get("period")
+        if event is None or leaf is None or period is None:
+            continue
+        try:
+            yield record, str(event), str(leaf), float(period)
+        except (TypeError, ValueError):
+            continue
+
+
+def _aggregate_precise_functions(records: list[dict[str, object]], event: str) -> list[dict[str, object]]:
+    normalized_event = canonical_event(event)
+    agg: dict[str, dict[str, object]] = defaultdict(lambda: {"function": "", "counters": {event: 0.0}, "samples": {event: 0}})
+    for _, sample_event, leaf, period in _iter_sample_records(records):
+        if canonical_event(sample_event) != normalized_event:
+            continue
+        entry = agg[leaf]
+        entry["function"] = leaf
+        entry["counters"][event] = entry["counters"].get(event, 0.0) + period
+        entry["samples"][event] = entry["samples"].get(event, 0) + 1
+    rows = list(agg.values())
+    rows.sort(key=lambda row: float(row["counters"].get(event, 0.0)), reverse=True)
+    return rows
+
+
+def aggregate_quick_functions(records: list[dict[str, object]]) -> list[dict[str, object]]:
+    by_group: dict[str, dict[str, dict[str, object]]] = defaultdict(dict)
+    for record, event, leaf, period in _iter_sample_records(records):
+        group_id = record.get("group_id")
+        if group_id is None:
+            continue
+        by_group[str(group_id)][event] = {"leaf": leaf, "period": period}
+
+    agg: dict[str, dict[str, object]] = defaultdict(
+        lambda: {"function": "", "counters": defaultdict(float), "samples": defaultdict(int)}
+    )
+    for group in by_group.values():
+        leader = group.get(QUICK_LEADER_EVENT)
+        if not leader:
+            continue
+        fn = str(leader["leaf"])
+        entry = agg[fn]
+        entry["function"] = fn
+        for event, sample in group.items():
+            entry["counters"][event] += float(sample["period"])
+            entry["samples"][event] += 1
+
+    rows = list(agg.values())
+    rows.sort(key=lambda row: float(row["counters"].get(QUICK_LEADER_EVENT, 0.0)), reverse=True)
+    for row in rows:
+        row["counters"] = dict(row["counters"])
+        row["samples"] = dict(row["samples"])
+        row["derived"] = derive_metrics(row["counters"])
+    return rows
+
+
+def _render_warning_section(lines: list[str], warnings: list[dict[str, object]]) -> None:
+    if not warnings:
+        return
+    lines.append("")
+    lines.append("## Warnings")
+    for warning in warnings:
+        lines.append(f"- [{warning.get('severity', 'warning')}] {warning.get('code')}: {warning.get('message')}")
+
+
+def summarize_sample_counts(parsed_dir: Path, manifest: dict[str, object]) -> dict[str, object]:
+    mode = str(manifest["config"]["mode"])
+    sampled_events = [str(event) for event in manifest["sampling"].get("sampled_events", [])]
+
+    if mode == QUICK_MODE:
+        quick_samples_path = parsed_dir / "quick_samples.json"
+        samples = _read_json_list(quick_samples_path)
+        if samples is None:
+            return {"mode": mode, "group_count": 0, "event_counts": {}}
+        event_counts: dict[str, int] = defaultdict(int)
+        group_ids: set[str] = set()
+        for sample in samples:
+            if not isinstance(sample, dict):
+                continue
+            event = str(sample.get("event", ""))
+            group_id = str(sample.get("group_id", ""))
+            if not event:
+                continue
+            event_counts[event] += 1
+            if group_id:
+                group_ids.add(group_id)
+        return {
+            "mode": mode,
+            "group_count": len(group_ids),
+            "event_counts": dict(event_counts),
+        }
+
+    event_counts: dict[str, int] = {}
+    for event in sampled_events:
+        sample_path = parsed_dir / f"samples_{event_id(event)}.json"
+        samples = _read_json_list(sample_path)
+        if samples is None:
+            continue
+        event_counts[event] = sum(1 for sample in samples if isinstance(sample, dict))
+    return {"mode": mode, "event_counts": event_counts}
+
+
+def _read_json_list(path: Path) -> list[object] | None:
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, list):
+        return None
+    return data
+
+
+def _read_json_dict(path: Path) -> dict[str, object] | None:
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    return data
+
+
+def write_precise_function_report(path: Path, event: str, rows: list[dict[str, object]], global_total: float | None, top_n: int) -> None:
+    top_rows = rows[:top_n]
+    sampled_total = sum(float(row["counters"].get(event, 0.0)) for row in rows)
+    lines = [
+        f"# Functions for {event}",
+        "",
+        "- mode: precise",
+        "- attribution: event-triggered sampled self period",
+        f"- sampled total {event}: {sampled_total:.0f}",
+    ]
+    if global_total is None:
+        lines.append(f"- global total {event}: unavailable")
+        lines.append("- note: precise mode samples each event in a separate NEMU run, so summary-wide global totals are not reused here")
+    else:
+        lines.append(f"- global total {event}: {global_total:.0f}")
+    lines.extend([
+        "",
+        "| rank | function | event_count_est | pct_of_sampled_event | samples |",
+        "|---|---|---:|---:|---:|",
+    ])
+    for idx, row in enumerate(top_rows, 1):
+        count = float(row["counters"].get(event, 0.0))
+        pct = 100.0 * count / sampled_total if sampled_total > 0 else 0.0
+        lines.append(f"| {idx} | {row['function']} | {count:.0f} | {pct:.2f}% | {row['samples'].get(event, 0)} |")
+    write_text(path, "\n".join(lines) + "\n")
+
+
+def write_quick_function_report(path: Path, rows: list[dict[str, object]], top_n: int) -> None:
+    top_rows = rows[:top_n]
+    leader_total = sum(float(row["counters"].get(QUICK_LEADER_EVENT, 0.0)) for row in rows)
+    lines = [
+        "# Quick Mode Function Hotspots",
+        "",
+        "- mode: quick",
+        f"- leader event: {QUICK_LEADER_EVENT}",
+        "- note: only instructions is the trigger event; other counters are grouped readouts from the same samples",
+        "",
+        "| rank | function | instructions | cycles | branches | branch-misses | cache-references | cache-misses | cpi | bp_mpki | cache_mpki |",
+        "|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for idx, row in enumerate(top_rows, 1):
+        ctrs = row["counters"]
+        derived = row["derived"]
+        lines.append(
+            "| {idx} | {fn} | {ins} | {cyc} | {br} | {bm} | {cr} | {cm} | {cpi} | {bp} | {cache} |".format(
+                idx=idx,
+                fn=row["function"],
+                ins=fmt_count(ctrs.get("instructions")),
+                cyc=fmt_count(ctrs.get("cycles")),
+                br=fmt_count(ctrs.get("branches")),
+                bm=fmt_count(ctrs.get("branch-misses")),
+                cr=fmt_count(ctrs.get("cache-references")),
+                cm=fmt_count(ctrs.get("cache-misses")),
+                cpi=fmt_num(derived["cpi"]),
+                bp=fmt_num(derived["bp_mpki"]),
+                cache=fmt_num(derived["cache_mpki"]),
+            )
+        )
+    lines.append("")
+    lines.append(f"- sampled total instructions: {leader_total:.0f}")
+    write_text(path, "\n".join(lines) + "\n")
+
+
+def write_precise_block_report(path: Path, result: dict[str, object], top_n: int) -> None:
+    rows = list(result["rows"])[:top_n]
+    event = str(result["event"])
+    global_total = result["global_total_count"]
+    lines = [
+        f"# Basic Blocks for {event}",
+        "",
+        "- mode: precise",
+        "- attribution: event-triggered sampled attribution projected to basic blocks via perf annotate",
+        f"- sampled total {event}: {float(result['sampled_total_est']):.0f}",
+    ]
+    if global_total is None:
+        lines.append(f"- global total {event}: unavailable")
+        lines.append("- note: precise mode samples each event in a separate NEMU run, so global coverage is omitted")
+    else:
+        lines.append(f"- global total {event}: {float(global_total):.0f}")
+    lines.append("")
+    if global_total is None:
+        lines.extend([
+            "| rank | block_start | block_end | event_count_est | sampled_coverage | insns | function | source |",
+            "|---|---:|---:|---:|---:|---:|---|---|",
+        ])
+    else:
+        lines.extend([
+            "| rank | block_start | block_end | event_count_est | sampled_coverage | global_coverage | insns | function | source |",
+            "|---|---:|---:|---:|---:|---:|---:|---|---|",
+        ])
+    for idx, row in enumerate(rows, 1):
+        if global_total is None:
+            lines.append(
+                f"| {idx} | 0x{int(row['start']):x} | 0x{int(row['end']):x} | {float(row['event_count_est']):.0f} | {float(row['coverage_pct']):.2f}% | {row['insn_count']} | {row['function']} | {row['location']} |"
+            )
+        else:
+            lines.append(
+                f"| {idx} | 0x{int(row['start']):x} | 0x{int(row['end']):x} | {float(row['event_count_est']):.0f} | {float(row['coverage_pct']):.2f}% | {float(row['global_coverage_pct']):.2f}% | {row['insn_count']} | {row['function']} | {row['location']} |"
+            )
+    write_text(path, "\n".join(lines) + "\n")
+
+
+def merge_quick_blocks(per_event_results: dict[str, dict[str, object]], top_n: int) -> list[dict[str, object]]:
+    leader_rows = list(per_event_results[QUICK_LEADER_EVENT]["rows"])[:top_n]
+    indices = {event: result["index"] for event, result in per_event_results.items()}
+    merged: list[dict[str, object]] = []
+    for row in leader_rows:
+        key = (str(row["symbol"]), int(row["start"]), int(row["end"]))
+        counters = {}
+        for event, index in indices.items():
+            counters[event] = float(index.get(key, {}).get("event_count_est", 0.0))
+        merged_row = dict(row)
+        merged_row["counters"] = counters
+        merged_row["derived"] = derive_metrics(counters)
+        merged.append(merged_row)
+    return merged
+
+
+def _serialize_block_result(result: dict[str, object]) -> dict[str, object]:
+    return {
+        key: value
+        for key, value in result.items()
+        if key != "index"
+    }
+
+
+def write_quick_block_report(path: Path, rows: list[dict[str, object]]) -> None:
+    lines = [
+        "# Quick Mode Basic Block Hotspots",
+        "",
+        "- mode: quick",
+        f"- leader event: {QUICK_LEADER_EVENT}",
+        "- note: ranked by instruction-triggered samples; other counters are grouped readouts projected onto the same blocks",
+        "",
+        "| rank | block_start | block_end | instructions | cycles | branch-misses | cache-misses | cpi | bp_mpki | cache_mpki | function | source |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---|",
+    ]
+    for idx, row in enumerate(rows, 1):
+        ctrs = row["counters"]
+        derived = row["derived"]
+        lines.append(
+            f"| {idx} | 0x{int(row['start']):x} | 0x{int(row['end']):x} | {fmt_count(ctrs.get('instructions'))} | {fmt_count(ctrs.get('cycles'))} | {fmt_count(ctrs.get('branch-misses'))} | {fmt_count(ctrs.get('cache-misses'))} | {fmt_num(derived['cpi'])} | {fmt_num(derived['bp_mpki'])} | {fmt_num(derived['cache_mpki'])} | {row['function']} | {row['location']} |"
+        )
+    write_text(path, "\n".join(lines) + "\n")
+
+
+def write_summary_report(
+    path: Path,
+    manifest: dict[str, object],
+    stat: dict[str, object] | None,
+    sample_summary: dict[str, object],
+    warnings: list[dict[str, object]],
+    reports: dict[str, str],
+    logs_dir: Path,
+) -> None:
+    config = manifest["config"]
+    stdout_path = logs_dir / "nemu.stdout.log"
+    stdout_text = stdout_path.read_text(encoding="utf-8", errors="replace") if stdout_path.exists() else ""
+    guest_instr, sim_freq = parse_nemu_summary(stdout_text)
+
+    lines = [
+        "# NEMU perf profile summary",
+        "",
+        "## Goal",
+        "- quantify end-to-end host-side counter cost",
+        "- localize hot functions and basic blocks",
+        "- support quick overview and precise diagnosis modes",
+        "",
+        "## Run Summary",
+        f"- mode: {config['mode']}",
+        f"- binary: {config['binary']}",
+        f"- workload: {config.get('workload')}",
+        f"- quick leader event: {manifest['sampling'].get('quick_leader_event')}",
+        f"- sampled events: {', '.join(manifest['sampling'].get('sampled_events', []))}",
+    ]
+    if guest_instr is not None:
+        lines.append(f"- guest instructions: {guest_instr}")
+    if sim_freq is not None:
+        lines.append(f"- simulation frequency: {sim_freq} instr/s")
+
+    if stat:
+        lines.extend(["", "## Global Counters", "| event | count | running_pct |", "|---|---:|---:|"])
+        counts = stat.get("counts", {})
+        running_pct = stat.get("running_pct", {})
+        for event in GLOBAL_EVENTS:
+            lines.append(
+                f"| {event} | {fmt_count(counts.get(event))} | {fmt_num(running_pct.get(event))} |"
+            )
+
+    event_counts = sample_summary.get("event_counts", {})
+    if event_counts:
+        lines.extend(["", "## Sample Counts"])
+        if sample_summary.get("mode") == QUICK_MODE:
+            lines.append(f"- grouped sample groups: {sample_summary.get('group_count', 0)}")
+        lines.extend(["| event | samples |", "|---|---:|"])
+        for event in manifest["sampling"].get("sampled_events", []):
+            lines.append(f"| {event} | {event_counts.get(event, 0)} |")
+
+    lines.extend(["", "## Reports"])
+    for name, rel_path in reports.items():
+        lines.append(f"- {name}: {rel_path}")
+
+    _render_warning_section(lines, warnings)
+    write_text(path, "\n".join(lines) + "\n")
+
+
+def generate_reports(run_dir: Path, manifest: dict[str, object], top_n: int = 100, bb_top_n: int = 100) -> tuple[dict[str, str], list[dict[str, object]]]:
+    parsed_dir = run_dir / "parsed"
+    reports_dir = run_dir / "reports"
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    config = manifest["config"]
+    binary = Path(config["binary"])
+    mode = str(config["mode"])
+    stat = None
+    warnings: list[dict[str, object]] = []
+    doctor_path = parsed_dir / "doctor.json"
+    doctor = _read_json_dict(doctor_path)
+    if doctor is None:
+        if doctor_path.exists():
+            warnings.append(
+                {
+                    "code": "invalid_doctor_json",
+                    "message": "doctor.json is invalid; doctor warnings could not be loaded.",
+                    "severity": "warning",
+                }
+            )
+    else:
+        doctor_warnings = doctor.get("warnings", [])
+        if isinstance(doctor_warnings, list):
+            warnings.extend(doctor_warnings)
+    stat_path = parsed_dir / "stat.json"
+    stat = _read_json_dict(stat_path)
+    if stat is None:
+        if stat_path.exists():
+            warnings.append(
+                {
+                    "code": "invalid_stat_json",
+                    "message": "stat.json is invalid; global counters could not be loaded.",
+                    "severity": "warning",
+                }
+            )
+    else:
+        stat_warnings = stat.get("warnings", [])
+        if isinstance(stat_warnings, list):
+            warnings.extend(stat_warnings)
+
+    reports: dict[str, str] = {}
+    raw_records = manifest["sampling"].get("record_artifacts", {})
+    sample_summary = summarize_sample_counts(parsed_dir, manifest)
+
+    doctor_report_path = reports_dir / "doctor.md"
+    if doctor_report_path.exists():
+        reports["doctor"] = str(doctor_report_path.relative_to(run_dir))
+
+    if mode == QUICK_MODE:
+        warnings.append(
+            {
+                "code": "quick_mode_semantics",
+                "message": "quick mode ranks hotspots by instruction-triggered samples; grouped counters are auxiliary readouts, not standalone event-triggered hotspots.",
+                "severity": "info",
+            }
+        )
+        quick_artifact = raw_records.get("quick")
+        quick_samples_path = parsed_dir / "quick_samples.json"
+        samples = _read_json_list(quick_samples_path)
+        if samples is None:
+            warnings.append(
+                {
+                    "code": "missing_quick_samples",
+                    "message": "quick-mode parsed samples are missing or invalid; skipping quick sample reports.",
+                    "severity": "warning",
+                }
+            )
+            samples = []
+
+        if samples:
+            function_rows = aggregate_quick_functions(samples)
+            quick_func_path = reports_dir / "functions_quick.md"
+            write_quick_function_report(quick_func_path, function_rows, top_n)
+            reports["functions_quick"] = str(quick_func_path.relative_to(run_dir))
+            write_json(parsed_dir / "quick_functions.json", function_rows)
+
+        if quick_artifact is None:
+            warnings.append(
+                {
+                    "code": "missing_quick_artifact",
+                    "message": "quick-mode record artifacts are missing; skipping quick basic-block reports.",
+                    "severity": "warning",
+                }
+            )
+        elif "perf_data" not in quick_artifact:
+            warnings.append(
+                {
+                    "code": "invalid_quick_artifact",
+                    "message": "quick-mode record artifacts are incomplete; skipping quick basic-block reports.",
+                    "severity": "warning",
+                }
+            )
+
+        per_event_results: dict[str, dict[str, object]] = {}
+        if samples and quick_artifact is not None and "perf_data" in quick_artifact:
+            for event in QUICK_GROUP_EVENTS:
+                event_symbol_periods: dict[str, float] = defaultdict(float)
+                event_sample_count = 0
+                for _, sample_event, leaf, period in _iter_sample_records(samples):
+                    if sample_event != event:
+                        continue
+                    event_symbol_periods[leaf] += period
+                    event_sample_count += 1
+                if event_sample_count < 20:
+                    warnings.append(
+                        {
+                            "code": "low_sample_count",
+                            "message": f"{event} collected fewer than 20 grouped samples; quick-mode auxiliary metrics may be noisy.",
+                            "severity": "warning",
+                        }
+                    )
+                result = annotate_basic_blocks(
+                    perf_data=run_dir / str(quick_artifact["perf_data"]),
+                    binary=binary,
+                    event=event,
+                    symbol_periods=dict(event_symbol_periods),
+                    global_total_count=None,
+                    top_n=bb_top_n,
+                )
+                if result is None:
+                    warnings.append(
+                        {
+                            "code": "annotate_failed",
+                            "message": f"perf annotate did not yield blocks for {event} in quick mode.",
+                            "severity": "warning",
+                        }
+                    )
+                    continue
+                per_event_results[event] = result
+        if QUICK_LEADER_EVENT in per_event_results:
+            quick_block_rows = merge_quick_blocks(per_event_results, bb_top_n)
+            quick_bb_path = reports_dir / "basic_blocks_quick.md"
+            write_quick_block_report(quick_bb_path, quick_block_rows)
+            reports["basic_blocks_quick"] = str(quick_bb_path.relative_to(run_dir))
+            write_json(parsed_dir / "basic_blocks_quick.json", quick_block_rows)
+    else:
+        for event in manifest["sampling"].get("sampled_events", []):
+            sample_path = parsed_dir / f"samples_{event_id(event)}.json"
+            samples = _read_json_list(sample_path)
+            if samples is None:
+                warnings.append(
+                    {
+                        "code": "missing_precise_samples",
+                        "message": f"{event} parsed samples are missing or invalid; skipping precise reports for this event.",
+                        "severity": "warning",
+                    }
+                )
+                continue
+
+            valid_samples = 0
+            normalized_event = canonical_event(event)
+            event_symbol_periods: dict[str, float] = defaultdict(float)
+            for _, sample_event, leaf, period in _iter_sample_records(samples):
+                if canonical_event(sample_event) != normalized_event:
+                    continue
+                event_symbol_periods[leaf] += period
+                valid_samples += 1
+            if valid_samples < 20:
+                warnings.append(
+                    {
+                        "code": "low_sample_count",
+                        "message": f"{event} collected fewer than 20 samples; event-triggered attribution may be low confidence.",
+                        "severity": "warning",
+                    }
+                )
+
+            function_rows = _aggregate_precise_functions(samples, event)
+            event_slug = event_id(event)
+            func_path = reports_dir / f"functions_{event_slug}.md"
+            write_precise_function_report(func_path, event, function_rows, None, top_n)
+            reports[f"functions_{event_slug}"] = str(func_path.relative_to(run_dir))
+            write_json(parsed_dir / f"functions_{event_slug}.json", function_rows)
+
+            artifact = raw_records.get(event)
+            if artifact is None or "perf_data" not in artifact:
+                warnings.append(
+                    {
+                        "code": "missing_precise_artifact",
+                        "message": f"{event} record artifacts are missing; skipping precise basic-block reports for this event.",
+                        "severity": "warning",
+                    }
+                )
+                continue
+
+            block_result = annotate_basic_blocks(
+                perf_data=run_dir / str(artifact["perf_data"]),
+                binary=binary,
+                event=event,
+                symbol_periods=dict(event_symbol_periods),
+                global_total_count=None,
+                top_n=bb_top_n,
+            )
+            if block_result is None:
+                warnings.append(
+                    {
+                        "code": "annotate_failed",
+                        "message": f"perf annotate did not yield blocks for {event}.",
+                        "severity": "warning",
+                    }
+                )
+                continue
+            bb_path = reports_dir / f"basic_blocks_{event_slug}.md"
+            write_precise_block_report(bb_path, block_result, bb_top_n)
+            reports[f"basic_blocks_{event_slug}"] = str(bb_path.relative_to(run_dir))
+            write_json(parsed_dir / f"basic_blocks_{event_slug}.json", _serialize_block_result(block_result))
+
+    summary_path = reports_dir / "summary.md"
+    write_summary_report(summary_path, manifest, stat, sample_summary, warnings, reports, run_dir / "logs")
+    reports["summary"] = str(summary_path.relative_to(run_dir))
+    return reports, warnings

--- a/tools/perf_profile/util.py
+++ b/tools/perf_profile/util.py
@@ -1,0 +1,218 @@
+#***************************************************************************************
+# Copyright (c) 2026 Institute of Computing Technology, Chinese Academy of Sciences
+#
+# NEMU is licensed under Mulan PSL v2.
+# You can use this software according to the terms and conditions of the Mulan PSL v2.
+# You may obtain a copy of Mulan PSL v2 at:
+#          http://license.coscl.org.cn/MulanPSL2
+#
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+# EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+# MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+#
+# See the Mulan PSL v2 for more details.
+#***************************************************************************************/
+
+from __future__ import annotations
+
+import hashlib
+import json
+import platform
+import re
+import shlex
+import subprocess
+import sys
+from contextlib import ExitStack
+from datetime import datetime
+from pathlib import Path
+
+
+_EVENT_ID_HASH_LEN = 8
+_EVENT_ID_MAX_SLUG_LEN = 64
+
+
+def _read_file_tail(path: Path, max_bytes: int = 8192) -> str:
+    if not path.exists():
+        return ""
+    with path.open("rb") as fp:
+        fp.seek(0, 2)
+        size = fp.tell()
+        fp.seek(max(0, size - max_bytes))
+        data = fp.read()
+    return data.decode("utf-8", errors="replace").strip()
+
+
+def run_cmd(
+    args: list[str],
+    check: bool = True,
+    cwd: Path | None = None,
+    stdout_path: Path | None = None,
+    stderr_path: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    with ExitStack() as stack:
+        stdout_target: int | object = subprocess.PIPE
+        stderr_target: int | object = subprocess.PIPE
+        if stdout_path is not None:
+            ensure_dir(stdout_path.parent)
+            stdout_target = stack.enter_context(stdout_path.open("w", encoding="utf-8"))
+        if stderr_path is not None:
+            ensure_dir(stderr_path.parent)
+            stderr_target = stack.enter_context(stderr_path.open("w", encoding="utf-8"))
+        try:
+            proc = subprocess.run(
+                args,
+                stdout=stdout_target,
+                stderr=stderr_target,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                cwd=cwd,
+            )
+        except FileNotFoundError as exc:
+            tool = args[0] if args else "<unknown>"
+            raise RuntimeError(f"Command not found: {tool}") from exc
+    if check and proc.returncode != 0:
+        cmd = " ".join(shlex.quote(a) for a in args)
+        err = proc.stderr if proc.stderr is not None else ""
+        if not err and stderr_path is not None:
+            err = _read_file_tail(stderr_path)
+            if err:
+                err = f"{err}\nstderr log: {stderr_path}"
+            else:
+                err = f"stderr log: {stderr_path}"
+        raise RuntimeError(f"Command failed ({proc.returncode}): {cmd}\n{err}")
+    return proc
+
+
+def ensure_dir(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def write_text(path: Path, text: str) -> None:
+    ensure_dir(path.parent)
+    path.write_text(text, encoding="utf-8")
+
+
+def write_json(path: Path, data: object) -> None:
+    ensure_dir(path.parent)
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def read_json(path: Path) -> object:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def canonical_event(event: str) -> str:
+    e = event.lower().strip()
+    if "branch-misses" in e:
+        return "branch-misses"
+    if "cache-misses" in e:
+        return "cache-misses"
+    if "cache-references" in e:
+        return "cache-references"
+    if "branch-instructions" in e or "branch_instructions" in e:
+        return "branches"
+    if "branches" in e:
+        return "branches"
+    if "instructions" in e:
+        return "instructions"
+    if "cycles" in e and "ref-cycles" not in e:
+        return "cycles"
+    return event.strip()
+
+
+def event_id(event: str) -> str:
+    text = event.strip().lower()
+    slug = re.sub(r"[^0-9A-Za-z._-]+", "_", text).strip("._-")
+    if not slug or slug in {".", ".."}:
+        raise ValueError(f"Unsafe event name: {event}")
+    if slug == text and len(slug) <= _EVENT_ID_MAX_SLUG_LEN:
+        return slug
+    slug = slug[:_EVENT_ID_MAX_SLUG_LEN].rstrip("._-")
+    if not slug or slug in {".", ".."}:
+        raise ValueError(f"Unsafe event name: {event}")
+    digest = hashlib.sha1(text.encode("utf-8")).hexdigest()[:_EVENT_ID_HASH_LEN]
+    return f"{slug}-{digest}"
+
+
+def fmt_num(value: float | int | None) -> str:
+    if value is None:
+        return "-"
+    if isinstance(value, float):
+        return f"{value:.4f}"
+    return str(value)
+
+
+def fmt_count(value: float | int | None) -> str:
+    if value is None:
+        return "-"
+    return f"{value:.0f}"
+
+
+def derive_metrics(counters: dict[str, float]) -> dict[str, float | None]:
+    ins = counters.get("instructions", 0.0)
+    cyc = counters.get("cycles", 0.0)
+    bm = counters.get("branch-misses", 0.0)
+    br = counters.get("branches", 0.0)
+    cm = counters.get("cache-misses", 0.0)
+    return {
+        "ipc": ins / cyc if cyc > 0 else None,
+        "cpi": cyc / ins if ins > 0 else None,
+        "bp_mpki": 1000.0 * bm / ins if ins > 0 else None,
+        "cache_mpki": 1000.0 * cm / ins if ins > 0 else None,
+        "branch_miss_rate": bm / br if br > 0 else None,
+    }
+
+
+def parse_nemu_summary(stdout_text: str) -> tuple[int | None, int | None]:
+    guest = None
+    sim_freq = None
+    mg = re.search(r"total guest instructions\s*=\s*([^\n]+)", stdout_text)
+    if mg:
+        digits = re.sub(r"\D", "", mg.group(1))
+        if digits:
+            guest = int(digits)
+    mf = re.search(r"simulation frequency\s*=\s*([^\n]*?)\s*instr/s", stdout_text)
+    if mf:
+        digits = re.sub(r"\D", "", mf.group(1))
+        if digits:
+            sim_freq = int(digits)
+    return guest, sim_freq
+
+
+def progress(step: int, total: int, label: str, detail: str = "") -> None:
+    suffix = f" {detail}" if detail else ""
+    print(f"[{step}/{total} {label}]{suffix}", file=sys.stderr)
+
+
+def make_run_id(prefix: str = "run") -> str:
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S-%f")
+    return f"{prefix}-{stamp}"
+
+
+def read_proc_int(path: Path, default: int | None = None) -> int | None:
+    try:
+        return int(path.read_text(encoding="utf-8").strip())
+    except Exception:
+        return default
+
+
+def get_cpu_model() -> str | None:
+    cpuinfo = Path("/proc/cpuinfo")
+    if not cpuinfo.exists():
+        return None
+    for line in cpuinfo.read_text(encoding="utf-8", errors="ignore").splitlines():
+        if line.lower().startswith("model name"):
+            return line.split(":", 1)[1].strip()
+    return None
+
+
+def get_host_summary() -> dict[str, str | None]:
+    uname = platform.uname()
+    return {
+        "system": uname.system,
+        "release": uname.release,
+        "machine": uname.machine,
+        "cpu_model": get_cpu_model(),
+    }


### PR DESCRIPTION
Add a Linux perf profiling framework for NEMU host-side performance analysis. The tool provides doctor, stat, record, report, and run subcommands, and stores raw perf artifacts, parsed JSON data, and Markdown hotspot reports in one run directory.

Add user documentation for the profiling flow, output layout, and quick versus precise sampling modes. This keeps the default path easy to start and preserves per-event diagnosis when more precise attribution is needed.