### PR TITLE
memory/hosttlb: optimize ifetch and data fast paths

### DIFF
--- a/include/memory/host-tlb.h
+++ b/include/memory/host-tlb.h
@@ -19,7 +19,8 @@
 #include <common.h>
 
 struct Decode;
-word_t hosttlb_read(struct Decode *s, vaddr_t vaddr, int len, int type);
+word_t hosttlb_ifetch(vaddr_t vaddr, int len);
+word_t hosttlb_data_read(struct Decode *s, vaddr_t vaddr, int len);
 void hosttlb_write(struct Decode *s, vaddr_t vaddr, int len, word_t data);
 void hosttlb_init();
 void hosttlb_flush(vaddr_t vaddr);

--- a/include/memory/host-tlb.h
+++ b/include/memory/host-tlb.h
@@ -19,10 +19,11 @@
 #include <common.h>
 
 struct Decode;
-word_t hosttlb_read(struct Decode *s, vaddr_t vaddr, int len, int type);
 void hosttlb_read_matrix(struct Decode *s, vaddr_t vbase, vaddr_t stride,
                          int row, int column, int msew, bool transpose,
                          bool isacc, int mreg_id);
+word_t hosttlb_ifetch(vaddr_t vaddr, int len);
+word_t hosttlb_data_read(struct Decode *s, vaddr_t vaddr, int len);
 void hosttlb_write(struct Decode *s, vaddr_t vaddr, int len, word_t data);
 void hosttlb_write_matrix(struct Decode *s, vaddr_t vbase, vaddr_t stride,
                           int row, int column, int msew, bool transpose,

--- a/src/isa/riscv64/system/mmu.c
+++ b/src/isa/riscv64/system/mmu.c
@@ -87,6 +87,12 @@ static inline uint64_t get_mprv() {
 }
 
 #ifdef CONFIG_RVH
+static bool data_hosttlb_fast_enabled = false;
+
+static inline void update_hosttlb_fast_state(void) {
+  data_hosttlb_fast_enabled = !((get_mprv() && mstatus->mpv) || cpu.v);
+}
+
 static inline bool check_permission(PTE *pte, bool ok, vaddr_t vaddr, int type, int virt, int mode) {
 bool ifetch = (type == MEM_TYPE_IFETCH);
 #else
@@ -177,6 +183,10 @@ vaddr_t get_effective_address(vaddr_t vaddr, int type) {
 #ifdef CONFIG_RVH
 bool has_two_stage_translation(){
   return hld_st || (get_mprv() && mstatus->mpv) || cpu.v;
+}
+
+bool hosttlb_data_fast_enabled_for_access(void) {
+  return !hld_st && data_hosttlb_fast_enabled;
 }
 
 void raise_guest_excep(paddr_t gpaddr, vaddr_t vaddr, int type, bool is_support_vs) {
@@ -622,6 +632,9 @@ int update_mmu_state() {
   ifetch_mmu_state = update_mmu_state_internal(true);
   int data_mmu_state_old = data_mmu_state;
   data_mmu_state = update_mmu_state_internal(false);
+#ifdef CONFIG_RVH
+  update_hosttlb_fast_state();
+#endif
 #ifdef CONFIG_RVH
   hyperinst_mmu_state = update_hyperinst_mmu_state_internal();
 #endif

--- a/src/isa/riscv64/system/mmu.c
+++ b/src/isa/riscv64/system/mmu.c
@@ -316,8 +316,10 @@ inline vaddr_t get_effective_address(vaddr_t vaddr, int type) {
 #endif
 
 #ifdef CONFIG_RVH
-bool has_two_stage_translation(){
-  return hld_st || (get_mprv() && mstatus->mpv) || cpu.v;
+extern bool has_two_stage_translation(void);
+bool inline has_two_stage_translation(){
+  bool mprv = mstatus->mprv && MUXDEF(CONFIG_RV_SMRNMI, mnstatus->nmie, true);
+  return hld_st || (mprv && mstatus->mpv) || cpu.v;
 }
 
 void raise_guest_excep(paddr_t gpaddr, vaddr_t vaddr, int type, bool is_support_vs) {

--- a/src/memory/host-tlb.c
+++ b/src/memory/host-tlb.c
@@ -25,6 +25,10 @@
 #define HOSTTLB_SIZE_SHIFT 12
 #define HOSTTLB_SIZE (1 << HOSTTLB_SIZE_SHIFT)
 
+#ifdef CONFIG_RVH
+extern bool hosttlb_data_fast_enabled_for_access(void);
+#endif
+
 typedef struct {
   uint8_t *offset; // offset from the guest virtual address of the data page to the host virtual address
   vaddr_t gvpn; // guest virtual page number
@@ -92,6 +96,14 @@ static word_t hosttlb_read_slowpath(struct Decode *s, vaddr_t vaddr, int len, in
   return data;
 }
 
+static inline word_t hosttlb_fast_read(HostTLBEntry *e, vaddr_t vaddr, int len) {
+#ifdef CONFIG_USE_SPARSEMM
+  return sparse_mem_wread(get_sparsemm(), (vaddr_t)e->offset + vaddr, len);
+#else
+  return host_read(e->offset + vaddr, len);
+#endif
+}
+
 __attribute__((noinline))
 static void hosttlb_write_slowpath(struct Decode *s, vaddr_t vaddr, int len, word_t data) {
   paddr_t paddr = va2pa(s, vaddr, len, MEM_TYPE_WRITE);
@@ -110,36 +122,43 @@ static void hosttlb_write_slowpath(struct Decode *s, vaddr_t vaddr, int len, wor
   }
 }
 
-word_t hosttlb_read(struct Decode *s, vaddr_t vaddr, int len, int type) {
-  Logm("hosttlb_reading " FMT_WORD, vaddr);
+word_t hosttlb_ifetch(vaddr_t vaddr, int len) {
 #ifdef CONFIG_RVH
-  extern bool has_two_stage_translation();
-  if(has_two_stage_translation()){
-    paddr_t paddr = va2pa(s, vaddr, len, type);
-    return paddr_read(paddr, len, type, type, cpu.mode, vaddr);
+  if (unlikely(cpu.v)) {
+    paddr_t paddr = va2pa(NULL, vaddr, len, MEM_TYPE_IFETCH);
+    return paddr_read(paddr, len, MEM_TYPE_IFETCH, MEM_TYPE_IFETCH, cpu.mode, vaddr);
   }
 #endif
   vaddr_t gvpn = hosttlb_vpn(vaddr);
-  HostTLBEntry *e = type == MEM_TYPE_IFETCH ?
-    &hostxtlb[hosttlb_idx(vaddr)] : &hostrtlb[hosttlb_idx(vaddr)];
+  HostTLBEntry *e = &hostxtlb[hosttlb_idx(vaddr)];
+  if (unlikely(e->gvpn != gvpn)) {
+    return hosttlb_read_slowpath(NULL, vaddr, len, MEM_TYPE_IFETCH);
+  }
+  return hosttlb_fast_read(e, vaddr, len);
+}
+
+word_t hosttlb_data_read(struct Decode *s, vaddr_t vaddr, int len) {
+  Logm("hosttlb_reading " FMT_WORD, vaddr);
+#ifdef CONFIG_RVH
+  if (unlikely(!hosttlb_data_fast_enabled_for_access())) {
+    paddr_t paddr = va2pa(s, vaddr, len, MEM_TYPE_READ);
+    return paddr_read(paddr, len, MEM_TYPE_READ, MEM_TYPE_READ, cpu.mode, vaddr);
+  }
+#endif
+  vaddr_t gvpn = hosttlb_vpn(vaddr);
+  HostTLBEntry *e = &hostrtlb[hosttlb_idx(vaddr)];
   if (unlikely(e->gvpn != gvpn)) {
     Logm("Host TLB slow path");
-    return hosttlb_read_slowpath(s, vaddr, len, type);
-  } else {
-    Logm("Host TLB fast path");
-    #ifdef CONFIG_USE_SPARSEMM
-    return sparse_mem_wread(get_sparsemm(), (vaddr_t)e->offset + vaddr, len);
-    #else
-    return host_read(e->offset + vaddr, len);
-    #endif
+    return hosttlb_read_slowpath(s, vaddr, len, MEM_TYPE_READ);
   }
+  Logm("Host TLB fast path");
+  return hosttlb_fast_read(e, vaddr, len);
 }
-extern bool has_two_stage_translation();
 
 #ifdef CONFIG_RVV
 void dummy_hosttlb_translate(struct Decode *s, vaddr_t vaddr, int len, bool is_write) {
 #ifdef CONFIG_RVH
-  if(has_two_stage_translation()){
+  if (unlikely(!hosttlb_data_fast_enabled_for_access())) {
     // Fast path for guest is not implemented yet
     return;
   }
@@ -162,7 +181,7 @@ void dummy_hosttlb_translate(struct Decode *s, vaddr_t vaddr, int len, bool is_w
 
 void hosttlb_write(struct Decode *s, vaddr_t vaddr, int len, word_t data) {
 #ifdef CONFIG_RVH
-  if(has_two_stage_translation()){
+  if (unlikely(!hosttlb_data_fast_enabled_for_access())) {
     paddr_t paddr = va2pa(s, vaddr, len, MEM_TYPE_WRITE);
     return paddr_write(paddr, len, data, cpu.mode, vaddr);
   }

--- a/src/memory/host-tlb.c
+++ b/src/memory/host-tlb.c
@@ -27,6 +27,10 @@
 #define HOSTTLB_SIZE_SHIFT 12
 #define HOSTTLB_SIZE (1 << HOSTTLB_SIZE_SHIFT)
 
+#ifdef CONFIG_RVH
+extern bool has_two_stage_translation(void);
+#endif
+
 typedef struct {
   uint8_t *offset; // offset from the guest virtual address of the data page to the host virtual address
   vaddr_t gvpn; // guest virtual page number
@@ -121,6 +125,14 @@ static void hosttlb_read_matrix_slowpath(struct Decode *s, vaddr_t vbase, vaddr_
 }
 #endif // CONFIG_RV_AME
 
+static inline word_t hosttlb_fast_read(HostTLBEntry *e, vaddr_t vaddr, int len) {
+#ifdef CONFIG_USE_SPARSEMM
+  return sparse_mem_wread(get_sparsemm(), (vaddr_t)e->offset + vaddr, len);
+#else
+  return host_read(e->offset + vaddr, len);
+#endif
+}
+
 __attribute__((noinline))
 static void hosttlb_write_slowpath(struct Decode *s, vaddr_t vaddr, int len, word_t data) {
   paddr_t paddr = va2pa(s, vaddr, len, MEM_TYPE_WRITE);
@@ -161,29 +173,37 @@ static void hosttlb_write_matrix_slowpath(struct Decode *s, vaddr_t vbase, vaddr
 }
 #endif // CONFIG_RV_AME
 
-word_t hosttlb_read(struct Decode *s, vaddr_t vaddr, int len, int type) {
-  Logm("hosttlb_reading " FMT_WORD, vaddr);
+word_t hosttlb_ifetch(vaddr_t vaddr, int len) {
 #ifdef CONFIG_RVH
-  extern bool has_two_stage_translation();
-  if(has_two_stage_translation()){
-    paddr_t paddr = va2pa(s, vaddr, len, type);
-    return paddr_read(paddr, len, type, type, cpu.mode, vaddr);
+  if (unlikely(cpu.v)) {
+    paddr_t paddr = va2pa(NULL, vaddr, len, MEM_TYPE_IFETCH);
+    return paddr_read(paddr, len, MEM_TYPE_IFETCH, MEM_TYPE_IFETCH, cpu.mode, vaddr);
   }
 #endif
   vaddr_t gvpn = hosttlb_vpn(vaddr);
-  HostTLBEntry *e = type == MEM_TYPE_IFETCH ?
-    &hostxtlb[hosttlb_idx(vaddr)] : &hostrtlb[hosttlb_idx(vaddr)];
+  HostTLBEntry *e = &hostxtlb[hosttlb_idx(vaddr)];
+  if (unlikely(e->gvpn != gvpn)) {
+    return hosttlb_read_slowpath(NULL, vaddr, len, MEM_TYPE_IFETCH);
+  }
+  return hosttlb_fast_read(e, vaddr, len);
+}
+
+word_t hosttlb_data_read(struct Decode *s, vaddr_t vaddr, int len) {
+  Logm("hosttlb_reading " FMT_WORD, vaddr);
+#ifdef CONFIG_RVH
+  if (unlikely(has_two_stage_translation())) {
+    paddr_t paddr = va2pa(s, vaddr, len, MEM_TYPE_READ);
+    return paddr_read(paddr, len, MEM_TYPE_READ, MEM_TYPE_READ, cpu.mode, vaddr);
+  }
+#endif
+  vaddr_t gvpn = hosttlb_vpn(vaddr);
+  HostTLBEntry *e = &hostrtlb[hosttlb_idx(vaddr)];
   if (unlikely(e->gvpn != gvpn)) {
     Logm("Host TLB slow path");
-    return hosttlb_read_slowpath(s, vaddr, len, type);
-  } else {
-    Logm("Host TLB fast path");
-    #ifdef CONFIG_USE_SPARSEMM
-    return sparse_mem_wread(get_sparsemm(), (vaddr_t)e->offset + vaddr, len);
-    #else
-    return host_read(e->offset + vaddr, len);
-    #endif
+    return hosttlb_read_slowpath(s, vaddr, len, MEM_TYPE_READ);
   }
+  Logm("Host TLB fast path");
+  return hosttlb_fast_read(e, vaddr, len);
 }
 
 #ifdef CONFIG_RV_AME
@@ -243,12 +263,10 @@ void hosttlb_read_matrix(struct Decode *s, vaddr_t vbase, vaddr_t stride,
 }
 #endif // CONFIG_RV_AME
 
-extern bool has_two_stage_translation();
-
 #ifdef CONFIG_RVV
 void dummy_hosttlb_translate(struct Decode *s, vaddr_t vaddr, int len, bool is_write) {
 #ifdef CONFIG_RVH
-  if(has_two_stage_translation()){
+  if (unlikely(has_two_stage_translation())) {
     // Fast path for guest is not implemented yet
     return;
   }
@@ -271,7 +289,7 @@ void dummy_hosttlb_translate(struct Decode *s, vaddr_t vaddr, int len, bool is_w
 
 void hosttlb_write(struct Decode *s, vaddr_t vaddr, int len, word_t data) {
 #ifdef CONFIG_RVH
-  if(has_two_stage_translation()){
+  if (unlikely(has_two_stage_translation())) {
     paddr_t paddr = va2pa(s, vaddr, len, MEM_TYPE_WRITE);
     return paddr_write(paddr, len, data, cpu.mode, vaddr);
   }

--- a/src/memory/vaddr.c
+++ b/src/memory/vaddr.c
@@ -201,7 +201,10 @@ static inline word_t vaddr_read_internal(void *s, vaddr_t addr, int len, int typ
     Logm("Paddr reading directly");
     return paddr_read(addr, len, type, type, cpu.mode, addr);
   }
-  return MUXDEF(ENABLE_HOSTTLB, hosttlb_read, vaddr_mmu_read) ((struct Decode *)s, addr, len, type);
+  IFDEF(ENABLE_HOSTTLB, return type == MEM_TYPE_IFETCH
+      ? hosttlb_ifetch(addr, len)
+      : hosttlb_data_read((struct Decode *)s, addr, len));
+  IFNDEF(ENABLE_HOSTTLB, return vaddr_mmu_read((struct Decode *)s, addr, len, type));
   return 0;
 
 }

--- a/src/memory/vaddr.c
+++ b/src/memory/vaddr.c
@@ -251,7 +251,10 @@ static inline word_t vaddr_read_internal(void *s, vaddr_t addr, int len, int typ
     Logm("Paddr reading directly");
     return paddr_read(addr, len, type, type, cpu.mode, addr);
   }
-  return MUXDEF(ENABLE_HOSTTLB, hosttlb_read, vaddr_mmu_read) ((struct Decode *)s, addr, len, type);
+  IFDEF(ENABLE_HOSTTLB, return type == MEM_TYPE_IFETCH
+      ? hosttlb_ifetch(addr, len)
+      : hosttlb_data_read((struct Decode *)s, addr, len));
+  IFNDEF(ENABLE_HOSTTLB, return vaddr_mmu_read((struct Decode *)s, addr, len, type));
   return 0;
 
 }


### PR DESCRIPTION
Split HostTLB instruction-fetch and data-read paths so each hot path uses a
fixed TLB table and memory type.

Keep the two-stage translation predicate local and inline. This avoids adding
cached MMU state or CSR invalidation dependencies, making the change
independent from #1011.