### PR TITLE
riscv64/mmu: cache identity effective-address state

### DIFF
--- a/src/isa/riscv64/init.c
+++ b/src/isa/riscv64/init.c
@@ -36,6 +36,7 @@ void init_pma();
 
 void init_riscv_timer();
 void init_device();
+void update_mmu_state();
 
 #define CSR_ZERO_INIT(name, addr) name->val = 0;
 
@@ -118,6 +119,8 @@ void init_isa() {
   pmpcfg0->val = 0;
   pmpcfg2->val = 0;
 #endif // CONFIG_RV_PMP_ENTRY_16
+
+  update_mmu_state();
 #ifdef CONFIG_RV_PMP_ENTRY_64
   pmpcfg0->val = 0;
   pmpcfg2->val = 0;

--- a/src/isa/riscv64/init.c
+++ b/src/isa/riscv64/init.c
@@ -36,6 +36,7 @@ void init_pma();
 
 void init_riscv_timer();
 void init_device();
+void update_mmu_state();
 
 #define CSR_ZERO_INIT(name, addr) name->val = 0;
 
@@ -120,6 +121,8 @@ void init_isa() {
   pmpcfg0->val = 0;
   pmpcfg2->val = 0;
 #endif // CONFIG_RV_PMP_ENTRY_16
+
+  update_mmu_state();
 #ifdef CONFIG_RV_PMP_ENTRY_64
   pmpcfg0->val = 0;
   pmpcfg2->val = 0;

--- a/src/isa/riscv64/system/mmu.c
+++ b/src/isa/riscv64/system/mmu.c
@@ -86,6 +86,13 @@ static inline uint64_t get_mprv() {
   #endif // CONFIG_RV_SMRNMI
 }
 
+static bool data_effective_address_identity_fast = false;
+
+static inline void update_effective_address_state(void) {
+  data_effective_address_identity_fast =
+    !get_mprv() && cpu.mode == MODE_U && senvcfg->pmm == 0;
+}
+
 #ifdef CONFIG_RVH
 static inline bool check_permission(PTE *pte, bool ok, vaddr_t vaddr, int type, int virt, int mode) {
 bool ifetch = (type == MEM_TYPE_IFETCH);
@@ -212,15 +219,14 @@ vaddr_t get_effective_address(vaddr_t vaddr, int type) {
     return vaddr;
   }
 
+  if (likely(!hld_st && data_effective_address_identity_fast)) {
+    return vaddr;
+  }
+
   bool virt = cpu.v;
   int mode = cpu.mode;
   int pmm = 0;
   int masked_width = 0;
-
-  // Early out fastpath for non-H & non-pmm applications
-  if (likely(!hld_st && !get_mprv() && mode == MODE_U && senvcfg->pmm == 0)) {
-    return vaddr;
-  }
 
   if (hld_st) {
     mode = hstatus->spvp;
@@ -622,6 +628,7 @@ int update_mmu_state() {
   ifetch_mmu_state = update_mmu_state_internal(true);
   int data_mmu_state_old = data_mmu_state;
   data_mmu_state = update_mmu_state_internal(false);
+  update_effective_address_state();
 #ifdef CONFIG_RVH
   hyperinst_mmu_state = update_hyperinst_mmu_state_internal();
 #endif

--- a/src/isa/riscv64/system/mmu.c
+++ b/src/isa/riscv64/system/mmu.c
@@ -227,6 +227,22 @@ void mmu_refresh_pma_cache(void) {
 void mmu_refresh_pma_cache(void) {
 }
 #endif
+
+static bool data_effective_address_identity_fast = false;
+
+static inline void update_effective_address_state(void) {
+#ifdef CONFIG_RVH
+  data_effective_address_identity_fast =
+    !hld_st && !get_mprv() && !cpu.v &&
+    ((cpu.mode == MODE_U && senvcfg->pmm == 0) ||
+     (cpu.mode == MODE_S && (mstatus->mxr || menvcfg->pmm == 0)) ||
+     (cpu.mode == MODE_M && mseccfg->pmm == 0));
+#else
+  data_effective_address_identity_fast =
+    !get_mprv() && cpu.mode == MODE_U && senvcfg->pmm == 0;
+#endif
+}
+
 #ifdef CONFIG_RVH
 static inline bool check_permission(PTE *pte, bool ok, vaddr_t vaddr, int type, int virt, int mode) {
 bool ifetch = (type == MEM_TYPE_IFETCH);
@@ -353,15 +369,14 @@ inline vaddr_t get_effective_address(vaddr_t vaddr, int type) {
     return vaddr;
   }
 
+  if (likely(!hld_st && data_effective_address_identity_fast)) {
+    return vaddr;
+  }
+
   bool virt = cpu.v;
   int mode = cpu.mode;
   int pmm = 0;
   int masked_width = 0;
-
-  // Early out fastpath for non-H & non-pmm applications
-  if (likely(!hld_st && !get_mprv() && mode == MODE_U && senvcfg->pmm == 0)) {
-    return vaddr;
-  }
 
   if (hld_st) {
     mode = hstatus->spvp;
@@ -765,6 +780,7 @@ int update_mmu_state() {
   ifetch_mmu_state = update_mmu_state_internal(true);
   int data_mmu_state_old = data_mmu_state;
   data_mmu_state = update_mmu_state_internal(false);
+  update_effective_address_state();
 #ifdef CONFIG_RVH
   hyperinst_mmu_state = update_hyperinst_mmu_state_internal();
 #endif

--- a/src/isa/riscv64/system/priv.c
+++ b/src/isa/riscv64/system/priv.c
@@ -2649,12 +2649,14 @@ static void csr_write(uint32_t csrid, word_t src) {
 
 #ifdef CONFIG_RVH
   if (is_write(mstatus) || is_write(satp) || is_write(vsatp)
-      || is_write(hgatp) || MUXDEF(CONFIG_RV_SMRNMI, is_write(mnstatus), false)) { update_mmu_state(); }
+      || is_write(hgatp) || is_write(senvcfg)
+      || MUXDEF(CONFIG_RV_SMRNMI, is_write(mnstatus), false)) { update_mmu_state(); }
   if (is_write(hstatus)) {
     set_sys_state_flag(SYS_STATE_FLUSH_TCACHE); // maybe change virtualization mode
   }
 #else
-  if (is_write(mstatus) || is_write(satp) || MUXDEF(CONFIG_RV_SMRNMI, is_write(mnstatus), false)) { update_mmu_state(); }
+  if (is_write(mstatus) || is_write(satp) || is_write(senvcfg)
+      || MUXDEF(CONFIG_RV_SMRNMI, is_write(mnstatus), false)) { update_mmu_state(); }
 #endif
   if (is_write(satp)) { mmu_tlb_flush(0); } // when satp is changed(asid | ppn), flush tlb.
   if (is_write(mstatus) || is_write(sstatus) || is_write(satp) ||

--- a/src/isa/riscv64/system/priv.c
+++ b/src/isa/riscv64/system/priv.c
@@ -2921,12 +2921,15 @@ static void csr_write(uint32_t csrid, word_t src) {
 
 #ifdef CONFIG_RVH
   if (is_write(mstatus) || is_write(satp) || is_write(vsatp)
-      || is_write(hgatp) || MUXDEF(CONFIG_RV_SMRNMI, is_write(mnstatus), false)) { update_mmu_state(); }
+      || is_write(hgatp) || is_write(senvcfg) || is_write(menvcfg)
+      || is_write(mseccfg)
+      || MUXDEF(CONFIG_RV_SMRNMI, is_write(mnstatus), false)) { update_mmu_state(); }
   if (is_write(hstatus)) {
     set_sys_state_flag(SYS_STATE_FLUSH_TCACHE); // maybe change virtualization mode
   }
 #else
-  if (is_write(mstatus) || is_write(satp) || MUXDEF(CONFIG_RV_SMRNMI, is_write(mnstatus), false)) { update_mmu_state(); }
+  if (is_write(mstatus) || is_write(satp) || is_write(senvcfg)
+      || MUXDEF(CONFIG_RV_SMRNMI, is_write(mnstatus), false)) { update_mmu_state(); }
 #endif
   if (is_write(satp)) { mmu_tlb_flush(0); } // when satp is changed(asid | ppn), flush tlb.
   if (is_write(mstatus) || is_write(sstatus) || is_write(satp) ||


### PR DESCRIPTION
Cache whether data effective-address transformation is currently an identity mapping.

The previous hot path repeatedly evaluated privilege, virtualization, MPRV and pointer-masking state for every memory access. This PR computes the result when MMU-related state changes, allowing the common identity case to return the original virtual address directly.

The cached state covers safe U/S/M-mode cases and is refreshed after translation-affecting state changes, including `senvcfg`, `menvcfg` and `mseccfg` updates.

No MMU permission, exception, virtualization or pointer-masking semantics are changed.
