### PR TITLE
ci: add standalone ref-mode performance tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,196 +425,86 @@ jobs:
         run: |
           echo "NEMU_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV
 
-      - name: Build NEMU interpreter for XS in interpreter mode
-        run: |
-          make riscv64-xs_defconfig
-          sed -i 's/CONFIG_CC_NATIVE_ARCH=y/# CONFIG_CC_NATIVE_ARCH is not set/g' .config
-          sed -i 's/CONFIG_CC_OPT_FLAGS=""/CONFIG_CC_OPT_FLAGS="-march=x86-64-v3 -mtune=generic -ftree-vectorize"/g' .config
-          make -j `nproc`
-
-      - name: Build master baseline interpreter
-        if: github.event_name == 'pull_request'
+      - name: Run performance tests
         env:
           PERF_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PERF_BASE_REF: ${{ github.base_ref }}
         run: |
-          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
-          git config --global --add safe.directory "${GITHUB_WORKSPACE}/perf-baseline"
-          echo "Building perf baseline from PR base commit ${PERF_BASE_SHA} (${PERF_BASE_REF})"
-          git fetch --depth=1 origin "${PERF_BASE_REF}"
-          rm -rf perf-baseline
-          mkdir -p perf-baseline/resource
-          git archive "${PERF_BASE_SHA}" | tar -xf - -C perf-baseline
-          for resource_dir in LibCheckpoint bbl debian gcpt_restore mips-elf nanopb sdcard simpoint softfloat; do
-            if [ -e "resource/${resource_dir}" ]; then
-              rm -rf "perf-baseline/resource/${resource_dir}"
-              ln -s "${GITHUB_WORKSPACE}/resource/${resource_dir}" "perf-baseline/resource/${resource_dir}"
+          workloads_dir=$(realpath "${CI_WORKLOADS}")
+          dynamorio_dir=$(realpath DynamoRIO-Linux-11.3.0-1)
+          ref_config_generator=$(realpath tools/ref-so-runner/gen-xs-ref-perf-defconfig.sh)
+
+          tools/perf-benchmark.sh \
+            --defconfig riscv64-xs_defconfig \
+            --title "NEMU Performance Results - XS Interpreter" \
+            --workloads "$workloads_dir" \
+            --dynamorio-dir "$dynamorio_dir" \
+            --output performance_xs.md \
+            --metrics-output performance_xs.tsv
+          tools/perf-benchmark.sh \
+            --defconfig riscv64-xs-ref-perf_defconfig \
+            --title "NEMU Performance Results - XS Ref Shared Object" \
+            --workloads "$workloads_dir" \
+            --dynamorio-dir "$dynamorio_dir" \
+            --output performance_ref_so.md \
+            --metrics-output performance_ref_so.tsv \
+            --defconfig-gen-script "$ref_config_generator" \
+            --binary "${GITHUB_WORKSPACE}/tools/ref-so-runner/runner"
+
+          if [ -n "${PERF_BASE_SHA:-}" ] && [ -n "${PERF_BASE_REF:-}" ]; then
+            git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+            git config --global --add safe.directory "${GITHUB_WORKSPACE}/perf-baseline"
+            echo "Building perf baseline from PR base commit ${PERF_BASE_SHA} (${PERF_BASE_REF})"
+            git fetch --depth=1 origin "${PERF_BASE_REF}"
+            git worktree prune
+            rm -rf perf-baseline
+            git worktree add --detach perf-baseline "${PERF_BASE_SHA}"
+            git -C perf-baseline submodule update --init --recursive --depth=1
+
+            if [ -f perf-baseline/configs/riscv64-xs_defconfig ]; then
+              tools/perf-benchmark.sh \
+                --repo-dir perf-baseline \
+                --defconfig riscv64-xs_defconfig \
+                --title "Baseline - XS Interpreter" \
+                --workloads "$workloads_dir" \
+                --dynamorio-dir "$dynamorio_dir" \
+                --output baseline_xs.md \
+                --metrics-output baseline_xs.tsv
             fi
-          done
-          make -C perf-baseline NEMU_HOME=$GITHUB_WORKSPACE/perf-baseline riscv64-xs_defconfig
-          sed -i 's/CONFIG_CC_NATIVE_ARCH=y/# CONFIG_CC_NATIVE_ARCH is not set/g' perf-baseline/.config
-          sed -i 's/CONFIG_CC_OPT_FLAGS=""/CONFIG_CC_OPT_FLAGS="-march=x86-64-v3 -mtune=generic -ftree-vectorize"/g' perf-baseline/.config
-          make -C perf-baseline NEMU_HOME=$GITHUB_WORKSPACE/perf-baseline -j `nproc`
 
-      - name: Basic - misc-tests
-        env:
-          tests: |
-            am/misc-tests/bin/bitmanip.bin
-            am/coremark/bin/coremark-riscv64-xs-rv64gc-o2.bin
-            am/coremark/bin/coremark-riscv64-xs-rv64gc-o3.bin
-            am/coremark/bin/coremark-riscv64-xs-rv64gcb-o3.bin
-            am/misc-tests/bin/amtest-riscv64-xs.bin
-            am/misc-tests/bin/aliastest-riscv64-xs.bin
-            am/misc-tests/bin/softprefetchtest-riscv64-xs.bin
-            am/misc-tests/bin/zacas-riscv64-xs.bin
-        run: |
-          get_sim_freq() {
-            printf '%s\n' "$1" | grep "simulation frequency" | tail -n 1 | cut -d '=' -f2 | cut -d ' ' -f2 | tr -d ', '
-          }
-
-          get_host_instr_count() {
-            printf '%s\n' "$1" | grep "Instrumentation results:" | tail -n 1 | cut -d ' ' -f3
-          }
-
-          run_native_freq() {
-            local binary="$1"
-            local image="$2"
-            local output
-            output=$("$binary" -b "$image" | strings)
-            get_sim_freq "$output"
-          }
-
-          benchmark_current_only_once() {
-            local binary="$1"
-            local image="$2"
-            run_native_freq "$binary" "$image"
-          }
-
-          benchmark_paired_once() {
-            local current_bin="$1"
-            local baseline_bin="$2"
-            local image="$3"
-            printf '%s\t%s\n' "$(run_native_freq "$current_bin" "$image")" "$(run_native_freq "$baseline_bin" "$image")"
-          }
-
-          format_change_pct() {
-            python3 -c 'import sys; curr, base = sys.argv[1:3]; print("N/A" if curr in ("", "N/A") or base in ("", "N/A") else f"{(float(curr) - float(base)) * 100.0 / float(base):+.2f}%")' "$1" "$2"
-          }
-
-          format_instr_change_pct() {
-            python3 -c 'import sys; curr, base = sys.argv[1:3]; print("N/A" if curr in ("", "N/A") or base in ("", "N/A") else f"{(float(base) - float(curr)) * 100.0 / float(base):+.2f}%")' "$1" "$2"
-          }
-
-          append_result_row() {
-            python3 -c 'import sys; sci = lambda value: value if value == "N/A" else f"{float(value):.3e}"; test_name, host_instr_count, est_throughput, actual_throughput, baseline_host_instr_count, baseline_actual_throughput, instr_change, throughput_change = sys.argv[1:]; print(f"| {test_name} | {sci(host_instr_count)} | {sci(est_throughput)} | {sci(actual_throughput)} | {sci(baseline_host_instr_count)} | {sci(baseline_actual_throughput)} | {instr_change} | {throughput_change} |")' "$@"
-          }
-
-          echo -e "### NEMU Performance Results\n\n| Test | Instructions Executed | Estimated Host Throughput (instr/s) | Actual NEMU Throughput (instr/s) | Master Instructions Executed | Master Actual NEMU Throughput (instr/s) | Change vs Master (Instructions) | Change vs Master (Throughput) |\n|------|-----------------------|-------------------------------------|----------------------------------|------------------------------|-----------------------------------------|---------------------------------|-------------------------------|" > performance_results.md
-          for test_bin in $tests; do
-            echo ::group::$test_bin
-            result=$(./DynamoRIO-Linux-11.3.0-1/bin64/drrun -c ./DynamoRIO-Linux-11.3.0-1/samples/bin64/libinscount.so -- \
-            ./build/riscv64-nemu-interpreter -b ${CI_WORKLOADS}/${test_bin} | strings)
-            guest_instr_count=$(echo "$result" | grep "total guest instructions" | tail -n 1 | cut -d '=' -f2 | tr -d ', ')
-            host_instr_count=$(get_host_instr_count "$result")
-            estimate_host_ipc=2.5
-            # Calculate host throughput per second with 4GHz and IPC=2.5
-            est_throughput=$(python3 -c "print(4e9 * $estimate_host_ipc / $host_instr_count * $guest_instr_count)")
-            baseline_host_instr_count="N/A"
-            baseline_actual_throughput="N/A"
-            if [ -x ./perf-baseline/build/riscv64-nemu-interpreter ]; then
-              baseline_result=$(./DynamoRIO-Linux-11.3.0-1/bin64/drrun -c ./DynamoRIO-Linux-11.3.0-1/samples/bin64/libinscount.so -- \
-              ./perf-baseline/build/riscv64-nemu-interpreter -b ${CI_WORKLOADS}/${test_bin} | strings)
-              baseline_host_instr_count=$(get_host_instr_count "$baseline_result")
-              IFS=$'\t' read -r actual_throughput baseline_actual_throughput < <(
-                benchmark_paired_once \
-                  ./build/riscv64-nemu-interpreter \
-                  ./perf-baseline/build/riscv64-nemu-interpreter \
-                  ${CI_WORKLOADS}/${test_bin}
-              )
-            else
-              actual_throughput=$(
-                benchmark_current_only_once \
-                  ./build/riscv64-nemu-interpreter \
-                  ${CI_WORKLOADS}/${test_bin}
-              )
+            if [ -f perf-baseline/configs/riscv64-xs-ref_defconfig ]; then
+              tools/perf-benchmark.sh \
+                --repo-dir perf-baseline \
+                --defconfig riscv64-xs-ref-perf_defconfig \
+                --title "Baseline - XS Ref Shared Object" \
+                --workloads "$workloads_dir" \
+                --dynamorio-dir "$dynamorio_dir" \
+                --output baseline_ref_so.md \
+                --metrics-output baseline_ref_so.tsv \
+                --defconfig-gen-script "$ref_config_generator" \
+                --binary "${GITHUB_WORKSPACE}/tools/ref-so-runner/runner"
             fi
-            instr_change=$(format_instr_change_pct "$host_instr_count" "$baseline_host_instr_count")
-            throughput_change=$(format_change_pct "$actual_throughput" "$baseline_actual_throughput")
-            append_result_row \
-              "$(basename "$test_bin")" \
-              "$host_instr_count" \
-              "$est_throughput" \
-              "$actual_throughput" \
-              "$baseline_host_instr_count" \
-              "$baseline_actual_throughput" \
-              "$instr_change" \
-              "$throughput_change" \
-              >> performance_results.md
-            echo "::endgroup::"
-          done
-
-      - name: System - linux
-        run: |
-          get_sim_freq() {
-            printf '%s\n' "$1" | grep "simulation frequency" | tail -n 1 | cut -d '=' -f2 | cut -d ' ' -f2 | tr -d ', '
-          }
-
-          get_host_instr_count() {
-            printf '%s\n' "$1" | grep "Instrumentation results:" | tail -n 1 | cut -d ' ' -f3
-          }
-
-          format_instr_change_pct() {
-            python3 -c 'import sys; curr, base = sys.argv[1:3]; print("N/A" if curr in ("", "N/A") or base in ("", "N/A") else f"{(float(base) - float(curr)) * 100.0 / float(base):+.2f}%")' "$1" "$2"
-          }
-
-          format_change_pct() {
-            python3 -c 'import sys; curr, base = sys.argv[1:3]; print("N/A" if curr in ("", "N/A") or base in ("", "N/A") else f"{(float(curr) - float(base)) * 100.0 / float(base):+.2f}%")' "$1" "$2"
-          }
-
-          append_result_row() {
-            python3 -c 'import sys; sci = lambda value: value if value == "N/A" else f"{float(value):.3e}"; test_name, host_instr_count, est_throughput, actual_throughput, baseline_host_instr_count, baseline_actual_throughput, instr_change, throughput_change = sys.argv[1:]; print(f"| {test_name} | {sci(host_instr_count)} | {sci(est_throughput)} | {sci(actual_throughput)} | {sci(baseline_host_instr_count)} | {sci(baseline_actual_throughput)} | {instr_change} | {throughput_change} |")' "$@"
-          }
-
-          result=$(./DynamoRIO-Linux-11.3.0-1/bin64/drrun -c ./DynamoRIO-Linux-11.3.0-1/samples/bin64/libinscount.so -- \
-          ./build/riscv64-nemu-interpreter -b ${CI_WORKLOADS}/linux/hello/fw_payload.bin | strings)
-          result_native=$(./build/riscv64-nemu-interpreter -b ${CI_WORKLOADS}/linux/hello/fw_payload.bin | strings)
-          actual_throughput=$(get_sim_freq "$result_native")
-          guest_instr_count=$(echo "$result" | grep "total guest instructions" | tail -n 1 | cut -d '=' -f2 | tr -d ', ')
-          host_instr_count=$(get_host_instr_count "$result")
-          estimate_host_ipc=2.5
-          # Calculate host throughput per second with 4GHz and IPC=2.5
-          est_throughput=$(python3 -c "print(4e9 * $estimate_host_ipc / $host_instr_count * $guest_instr_count)")
-          baseline_host_instr_count="N/A"
-          baseline_actual_throughput="N/A"
-          if [ -x ./perf-baseline/build/riscv64-nemu-interpreter ]; then
-            baseline_instr_result=$(./DynamoRIO-Linux-11.3.0-1/bin64/drrun -c ./DynamoRIO-Linux-11.3.0-1/samples/bin64/libinscount.so -- \
-            ./perf-baseline/build/riscv64-nemu-interpreter -b ${CI_WORKLOADS}/linux/hello/fw_payload.bin | strings)
-            baseline_host_instr_count=$(get_host_instr_count "$baseline_instr_result")
-            baseline_result_native=$(./perf-baseline/build/riscv64-nemu-interpreter -b ${CI_WORKLOADS}/linux/hello/fw_payload.bin | strings)
-            baseline_actual_throughput=$(get_sim_freq "$baseline_result_native")
           fi
-          instr_change=$(format_instr_change_pct "$host_instr_count" "$baseline_host_instr_count")
-          throughput_change=$(format_change_pct "$actual_throughput" "$baseline_actual_throughput")
-          append_result_row \
-            "linux-hello" \
-            "$host_instr_count" \
-            "$est_throughput" \
-            "$actual_throughput" \
-            "$baseline_host_instr_count" \
-            "$baseline_actual_throughput" \
-            "$instr_change" \
-            "$throughput_change" \
+
+          tools/perf-compare.sh \
+            --title "NEMU Performance Results - XS Interpreter" \
+            --current performance_xs.tsv \
+            --baseline baseline_xs.tsv \
+            > performance_results.md
+          echo >> performance_results.md
+          tools/perf-compare.sh \
+            --title "NEMU Performance Results - XS Ref Shared Object" \
+            --current performance_ref_so.tsv \
+            --baseline baseline_ref_so.tsv \
             >> performance_results.md
           cat >> performance_results.md <<'EOF'
 
-          * Instructions Executed is the current branch host instruction count measured by DynamoRIO.
-          * Master Instructions Executed is the PR base commit baseline host instruction count measured by DynamoRIO.
-          * Actual NEMU Throughput and Master Actual NEMU Throughput are single-run native measurements.
-          * Host throughput is estimated based on 4GHz CPU frequency and IPC=2.5.
-          * Change vs master (Instructions) is computed from host instruction count; positive means fewer host instructions than master.
-          * Change vs master (Throughput) is computed from native throughput; positive means faster than master.
-          * Master columns are populated on pull_request runs when the PR base commit baseline is built.
-          * Actual throughput may vary based on the host CPU performance.
+          * Host Instructions is measured by DynamoRIO's inscount client.
+          * Estimated Host Throughput assumes a fixed 4GHz CPU and IPC=2.5.
+          * Actual NEMU Throughput is a single native NEMU run and may vary with host CPU performance.
+          * Baseline columns are populated on pull_request runs when the PR base contains the same defconfig.
+          * Change vs Baseline (Instructions) is computed from host instruction count; positive means fewer host instructions than baseline.
+          * Change vs Baseline (Throughput) is computed from native throughput; positive means faster than baseline.
           EOF
           cat performance_results.md
           cat performance_results.md >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,10 @@
 !scripts/*.py
 !tools/perf_profile.py
 !tools/perf_profile/**
+!tools/ref-so-runner/*.sh
+!tools/ref-so-runner/*.patch
 !scripts/checkpoint_example/*
-!docs/perf_profile.md
+!docs/*.md
 __pycache__/
 *.pyc
 include/config

--- a/docs/ref_so_runner.md
+++ b/docs/ref_so_runner.md
@@ -1,0 +1,32 @@
+# NEMU Ref Shared Object Runner
+
+`tools/ref-so-runner/runner` is a minimal NEMU-compatible launcher for
+`$NEMU_HOME/build/riscv64-nemu-interpreter-so`.
+
+It is intended for host-side benchmarking of the ref-mode shared object without
+changing the normal NEMU build flow. Generate a dedicated performance defconfig
+before building so the shared reference can drive Linux standalone without
+modifying `riscv64-xs-ref_defconfig`:
+
+```sh
+tools/ref-so-runner/gen-xs-ref-perf-defconfig.sh \
+  configs/riscv64-xs-ref-perf_defconfig
+make riscv64-xs-ref-perf_defconfig
+make -j"$(nproc)"
+make -C tools/ref-so-runner
+
+tools/ref-so-runner/runner \
+  -b ./workloads/linux/hello/fw_payload.bin
+```
+
+The runner loads the image at `0x80000000`, executes through repeated
+`difftest_exec(1)` calls, initializes the built-in flash reset stub for
+`CONFIG_RESET_FROM_MMIO`, and stops when NEMU reaches a good or bad trap.
+
+When `-I`/`--max-instructions` is reached, the runner exits with code `0` and
+prints NEMU-style statistics:
+
+- `host time spent = ... us`
+- `total guest instructions = ...`
+- `vst count = ...`
+- `simulation frequency = ... instr/s`

--- a/tools/perf-benchmark.sh
+++ b/tools/perf-benchmark.sh
@@ -1,0 +1,406 @@
+#!/usr/bin/env bash
+#***************************************************************************************
+# Copyright (c) 2026 Institute of Computing Technology, Chinese Academy of Sciences
+#
+# NEMU is licensed under Mulan PSL v2.
+# You can use this software according to the terms and conditions of the Mulan PSL v2.
+# You may obtain a copy of Mulan PSL v2 at:
+#          http://license.coscl.org.cn/MulanPSL2
+#
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+# EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+# MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+#
+# See the Mulan PSL v2 for more details.
+#**************************************************************************************/
+
+set -euo pipefail
+
+export NEMU_HOME="${NEMU_HOME:-$PWD}"
+
+defconfig=""
+title=""
+repo_dir=""
+workloads="${CI_WORKLOADS:-./workloads}"
+dynamorio_dir="DynamoRIO-Linux-11.3.0-1"
+output="performance_results.md"
+metrics_output=""
+include_linux=true
+binary=""
+defconfig_patch=""
+defconfig_gen_script=""
+patched_defconfig=""
+defconfig_backup=""
+defconfig_backup_dir=""
+prepared_defconfig_target=""
+
+usage() {
+  cat <<'EOF'
+Usage: tools/perf-benchmark.sh --defconfig DEFCONFIG [options]
+
+Build one NEMU defconfig, run the CI performance workload set, and emit a
+markdown table for that single build.
+
+Options:
+  --defconfig NAME      Defconfig to build, such as riscv64-xs_defconfig.
+  --title TITLE         Markdown section title. Defaults to the defconfig name.
+  --workloads DIR       Workload directory. Defaults to $CI_WORKLOADS or ./workloads.
+  --dynamorio-dir DIR   Extracted DynamoRIO directory.
+  --output FILE         Markdown report path.
+  --metrics-output FILE Optional TSV metrics output for CI comparison.
+  --repo-dir DIR        NEMU repository directory. Defaults to the current dir.
+  --binary FILE         Executable to benchmark. Defaults to build/riscv64-nemu-interpreter.
+  --defconfig-patch FILE
+                        Apply a patch to configs/DEFCONFIG before building.
+  --defconfig-gen-script FILE
+                        Generate configs/DEFCONFIG before building.
+  --no-linux            Skip the linux/hello system workload.
+  -h, --help            Show this help.
+EOF
+}
+
+cleanup() {
+  if [ -n "$defconfig_backup" ] && [ -n "$patched_defconfig" ] && [ -f "$defconfig_backup" ]; then
+    cp "$defconfig_backup" "$patched_defconfig"
+  elif [ -n "$patched_defconfig" ] && [ -f "$patched_defconfig" ]; then
+    rm -f "$patched_defconfig"
+  fi
+  if [ -n "$defconfig_backup_dir" ] && [ -d "$defconfig_backup_dir" ]; then
+    rm -rf "$defconfig_backup_dir"
+  fi
+}
+
+require_value() {
+  if [ "$#" -lt 2 ] || [ -z "$2" ]; then
+    echo "Missing value for $1" >&2
+    exit 2
+  fi
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --defconfig)
+      require_value "$@"
+      defconfig="$2"
+      shift 2
+      ;;
+    --title)
+      require_value "$@"
+      title="$2"
+      shift 2
+      ;;
+    --workloads)
+      require_value "$@"
+      workloads="$2"
+      shift 2
+      ;;
+    --dynamorio-dir)
+      require_value "$@"
+      dynamorio_dir="$2"
+      shift 2
+      ;;
+    --output)
+      require_value "$@"
+      output="$2"
+      shift 2
+      ;;
+    --metrics-output)
+      require_value "$@"
+      metrics_output="$2"
+      shift 2
+      ;;
+    --repo-dir)
+      require_value "$@"
+      repo_dir="$2"
+      shift 2
+      ;;
+    --binary)
+      require_value "$@"
+      binary="$2"
+      shift 2
+      ;;
+    --defconfig-patch)
+      require_value "$@"
+      defconfig_patch="$2"
+      shift 2
+      ;;
+    --defconfig-gen-script)
+      require_value "$@"
+      defconfig_gen_script="$2"
+      shift 2
+      ;;
+    --no-linux)
+      include_linux=false
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$defconfig" ]; then
+  echo "Missing required --defconfig" >&2
+  usage >&2
+  exit 2
+fi
+
+repo_dir="${repo_dir:-$PWD}"
+repo_dir=$(realpath "$repo_dir")
+workloads=$(realpath "$workloads")
+dynamorio_dir=$(realpath "$dynamorio_dir")
+output=$(realpath -m "$output")
+if [ -n "$metrics_output" ]; then
+  metrics_output=$(realpath -m "$metrics_output")
+fi
+if [ -n "$defconfig_patch" ]; then
+  defconfig_patch=$(realpath "$defconfig_patch")
+fi
+if [ -n "$defconfig_gen_script" ]; then
+  defconfig_gen_script=$(realpath "$defconfig_gen_script")
+fi
+export NEMU_HOME="$repo_dir"
+
+if [ -z "$title" ]; then
+  title="$defconfig"
+fi
+
+drrun="${dynamorio_dir}/bin64/drrun"
+inscount="${dynamorio_dir}/samples/bin64/libinscount.so"
+
+binary="${binary:-${repo_dir}/build/riscv64-nemu-interpreter}"
+binary=$(realpath -m "$binary")
+
+if [ ! -x "$drrun" ]; then
+  echo "DynamoRIO drrun not found or not executable: $drrun" >&2
+  exit 1
+fi
+
+if [ ! -f "$inscount" ]; then
+  echo "DynamoRIO inscount client not found: $inscount" >&2
+  exit 1
+fi
+
+if [ -n "$defconfig_patch" ] && [ ! -f "$defconfig_patch" ]; then
+  echo "Defconfig patch not found: $defconfig_patch" >&2
+  exit 1
+fi
+
+if [ -n "$defconfig_gen_script" ] && [ ! -x "$defconfig_gen_script" ]; then
+  echo "Defconfig generation script not found or not executable: $defconfig_gen_script" >&2
+  exit 1
+fi
+
+if [ -n "$defconfig_patch" ] && [ -n "$defconfig_gen_script" ]; then
+  echo "Use either --defconfig-patch or --defconfig-gen-script, not both" >&2
+  exit 1
+fi
+
+trap cleanup EXIT
+
+tests=(
+  am/misc-tests/bin/bitmanip.bin
+  am/coremark/bin/coremark-riscv64-xs-rv64gc-o2.bin
+  am/coremark/bin/coremark-riscv64-xs-rv64gc-o3.bin
+  am/coremark/bin/coremark-riscv64-xs-rv64gcb-o3.bin
+  am/misc-tests/bin/amtest-riscv64-xs.bin
+  am/misc-tests/bin/aliastest-riscv64-xs.bin
+  am/misc-tests/bin/softprefetchtest-riscv64-xs.bin
+  am/misc-tests/bin/zacas-riscv64-xs.bin
+)
+
+configure_perf_flags() {
+  sed -i 's/CONFIG_CC_NATIVE_ARCH=y/# CONFIG_CC_NATIVE_ARCH is not set/g' .config
+  sed -i 's/CONFIG_CC_OPT_FLAGS=""/CONFIG_CC_OPT_FLAGS="-march=x86-64-v3 -mtune=generic -ftree-vectorize"/g' .config
+}
+
+prepare_existing_defconfig_update() {
+  prepared_defconfig_target="$repo_dir/configs/$defconfig"
+
+  if [ ! -f "$prepared_defconfig_target" ]; then
+    echo "Defconfig not found: $prepared_defconfig_target" >&2
+    exit 1
+  fi
+
+  if [ -z "$defconfig_backup" ]; then
+    defconfig_backup_dir=$(mktemp -d)
+    defconfig_backup="$defconfig_backup_dir/$(basename "$prepared_defconfig_target")"
+    patched_defconfig="$prepared_defconfig_target"
+    cp "$prepared_defconfig_target" "$defconfig_backup"
+  fi
+}
+
+apply_defconfig_patch() {
+  prepare_existing_defconfig_update
+  if ! command -v patch >/dev/null 2>&1; then
+    echo "patch command not found" >&2
+    exit 1
+  fi
+
+  if ! patch --dry-run --silent -d "$repo_dir" -p1 < "$defconfig_patch" >/dev/null; then
+    echo "Failed to apply defconfig patch: $defconfig_patch" >&2
+    exit 1
+  fi
+  patch --batch --silent -d "$repo_dir" -p1 < "$defconfig_patch" >/dev/null
+}
+
+prepare_generated_defconfig() {
+  prepared_defconfig_target="$repo_dir/configs/$defconfig"
+
+  if [ -z "$patched_defconfig" ]; then
+    patched_defconfig="$prepared_defconfig_target"
+    if [ -f "$prepared_defconfig_target" ]; then
+      defconfig_backup_dir=$(mktemp -d)
+      defconfig_backup="$defconfig_backup_dir/$(basename "$prepared_defconfig_target")"
+      cp "$prepared_defconfig_target" "$defconfig_backup"
+    fi
+  fi
+}
+
+apply_defconfig_gen_script() {
+  prepare_generated_defconfig
+  "$defconfig_gen_script" "$prepared_defconfig_target"
+}
+
+build_perf_binary() {
+  make clean-all
+  if [ -n "$defconfig_patch" ]; then
+    apply_defconfig_patch
+  fi
+  if [ -n "$defconfig_gen_script" ]; then
+    apply_defconfig_gen_script
+  fi
+  make "$defconfig"
+  configure_perf_flags
+  make -j "$(nproc)"
+  if [ "$(basename "$binary")" = "runner" ] && [ -f "$(dirname "$binary")/runner.c" ]; then
+    make -C "$(dirname "$binary")"
+  fi
+  if [ ! -x "$binary" ]; then
+    echo "Benchmark binary not found or not executable: $binary" >&2
+    exit 1
+  fi
+}
+
+run_target() {
+  local image="$1"
+  shift
+
+  "$@" "$binary" -b "$image"
+}
+
+get_sim_freq() {
+  local line
+
+  line=$(printf '%s\n' "$1" | grep "simulation frequency" | tail -n 1 || true)
+  if [ -z "$line" ]; then
+    return
+  fi
+  printf '%s\n' "${line#*=}" | tr -cd '0-9'
+}
+
+get_host_instr_count() {
+  local line
+
+  line=$(printf '%s\n' "$1" | grep "Instrumentation results:" | tail -n 1 || true)
+  printf '%s\n' "$line" | tr -cd '0-9'
+}
+
+run_native_freq() {
+  local image="$1"
+  local native_output sim_freq
+
+  native_output=$(run_target "$image" | strings)
+  sim_freq=$(get_sim_freq "$native_output")
+  if [ -n "$sim_freq" ]; then
+    printf '%s\n' "$sim_freq"
+  else
+    printf 'N/A\n'
+  fi
+}
+
+format_sci() {
+  python3 -c 'import sys
+value = sys.argv[1]
+if value == "" or value == "N/A":
+    print("N/A")
+else:
+    print(f"{float(value):.3e}")' "$1"
+}
+
+append_result_row() {
+  local test_name="$1"
+  local image="$2"
+  local result guest_instr_count host_instr_count actual_throughput estimated_throughput
+
+  echo "::group::${title} - ${test_name}"
+  result=$(run_target "$image" "$drrun" -c "$inscount" -- | strings)
+  guest_instr_count=$(echo "$result" | grep "total guest instructions" | tail -n 1 | cut -d '=' -f2 | tr -cd '0-9')
+  host_instr_count=$(get_host_instr_count "$result")
+  if [ -z "$guest_instr_count" ] || [ -z "$host_instr_count" ]; then
+    echo "Failed to parse instruction counts for ${test_name}" >&2
+    exit 1
+  fi
+  # Estimate host throughput with a fixed 4GHz CPU and IPC=2.5 model.
+  estimated_throughput=$(python3 -c "print(4e9 * 2.5 / $host_instr_count * $guest_instr_count)")
+  actual_throughput=$(run_native_freq "$image")
+  printf '| %s | %s | %s | %s | %s |\n' \
+    "$test_name" \
+    "$(format_sci "$guest_instr_count")" \
+    "$(format_sci "$host_instr_count")" \
+    "$(format_sci "$estimated_throughput")" \
+    "$(format_sci "$actual_throughput")" \
+    >> "$output"
+  if [ -n "$metrics_output" ]; then
+    printf '%s\t%s\t%s\t%s\t%s\n' \
+      "$test_name" \
+      "$guest_instr_count" \
+      "$host_instr_count" \
+      "$estimated_throughput" \
+      "$actual_throughput" \
+      >> "$metrics_output"
+  fi
+  echo "::endgroup::"
+}
+
+cd "$repo_dir"
+
+build_perf_binary
+
+mkdir -p "$(dirname "$output")"
+cat > "$output" <<EOF
+### ${title}
+
+Defconfig: \`${defconfig}\`
+
+Binary: \`${binary}\`
+
+| Test | Guest Instructions | Host Instructions | Estimated Host Throughput (instr/s) | Actual NEMU Throughput (instr/s) |
+|------|--------------------|-------------------|-------------------------------------|----------------------------------|
+EOF
+
+if [ -n "$metrics_output" ]; then
+  mkdir -p "$(dirname "$metrics_output")"
+  printf 'test\tguest_instructions\thost_instructions\testimated_host_throughput\tactual_nemu_throughput\n' > "$metrics_output"
+fi
+
+for test_bin in "${tests[@]}"; do
+  append_result_row "$(basename "$test_bin")" "${workloads}/${test_bin}"
+done
+
+if [ "$include_linux" = true ]; then
+  append_result_row "linux-hello" "${workloads}/linux/hello/fw_payload.bin"
+fi
+
+cat >> "$output" <<'EOF'
+
+* Host Instructions is measured by DynamoRIO's inscount client.
+* Estimated Host Throughput assumes a fixed 4GHz CPU and IPC=2.5.
+* Actual NEMU Throughput is a single native NEMU run and may vary with host CPU performance.
+EOF

--- a/tools/perf-compare.sh
+++ b/tools/perf-compare.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+#***************************************************************************************
+# Copyright (c) 2026 Institute of Computing Technology, Chinese Academy of Sciences
+#
+# NEMU is licensed under Mulan PSL v2.
+# You can use this software according to the terms and conditions of the Mulan PSL v2.
+# You may obtain a copy of Mulan PSL v2 at:
+#          http://license.coscl.org.cn/MulanPSL2
+#
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+# EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+# MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+#
+# See the Mulan PSL v2 for more details.
+#**************************************************************************************/
+
+set -euo pipefail
+
+title=""
+current=""
+baseline=""
+
+usage() {
+  cat <<'EOF'
+Usage: tools/perf-compare.sh --title TITLE --current FILE [--baseline FILE]
+
+Read current and optional baseline TSV files produced by perf-benchmark.sh and
+write a markdown comparison table to stdout.
+EOF
+}
+
+require_value() {
+  if [ "$#" -lt 2 ] || [ -z "$2" ]; then
+    echo "Missing value for $1" >&2
+    exit 2
+  fi
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --title)
+      require_value "$@"
+      title="$2"
+      shift 2
+      ;;
+    --current)
+      require_value "$@"
+      current="$2"
+      shift 2
+      ;;
+    --baseline)
+      require_value "$@"
+      baseline="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$title" ] || [ -z "$current" ]; then
+  usage >&2
+  exit 2
+fi
+
+python3 - "$title" "$current" "$baseline" <<'PY'
+import csv
+import sys
+from pathlib import Path
+
+title, current_path, baseline_path = sys.argv[1:4]
+
+
+def parse_int(value):
+    return int(value) if value not in ("", "N/A") else None
+
+
+def parse_float(value):
+    return float(value) if value not in ("", "N/A") else None
+
+
+def read_metrics(path):
+    if not path or not Path(path).is_file():
+        return {}
+    with open(path, newline="", encoding="utf-8") as fp:
+        return {
+            row["test"]: {
+                "guest_instructions": parse_int(row["guest_instructions"]),
+                "host_instructions": parse_int(row["host_instructions"]),
+                "estimated_host_throughput": parse_float(row["estimated_host_throughput"]),
+                "actual_nemu_throughput": parse_float(row["actual_nemu_throughput"]),
+            }
+            for row in csv.DictReader(fp, delimiter="\t")
+        }
+
+
+def sci(value):
+    return "N/A" if value is None else f"{value:.3e}"
+
+
+def pct_change(curr, base):
+    if curr is None or base in (None, 0):
+        return "N/A"
+    return f"{(curr - base) * 100.0 / base:+.2f}%"
+
+
+def instr_change(curr, base):
+    if curr is None or base in (None, 0):
+        return "N/A"
+    return f"{(base - curr) * 100.0 / base:+.2f}%"
+
+
+current_rows = read_metrics(current_path)
+baseline_rows = read_metrics(baseline_path)
+
+print(f"### {title}")
+print()
+print("| Test | Guest Instructions | Host Instructions | Estimated Host Throughput (instr/s) | Actual NEMU Throughput (instr/s) | Baseline Host Instructions | Baseline Actual NEMU Throughput (instr/s) | Change vs Baseline (Instructions) | Change vs Baseline (Throughput) |")
+print("|------|--------------------|-------------------|-------------------------------------|----------------------------------|----------------------------|-------------------------------------------|-----------------------------------|---------------------------------|")
+for test, row in current_rows.items():
+    base = baseline_rows.get(test, {})
+    host = row["host_instructions"]
+    actual = row["actual_nemu_throughput"]
+    base_host = base.get("host_instructions")
+    base_actual = base.get("actual_nemu_throughput")
+    print(
+        f"| {test} | "
+        f"{sci(row['guest_instructions'])} | "
+        f"{sci(host)} | "
+        f"{sci(row['estimated_host_throughput'])} | "
+        f"{sci(actual)} | "
+        f"{sci(base_host)} | "
+        f"{sci(base_actual)} | "
+        f"{instr_change(host, base_host)} | "
+        f"{pct_change(actual, base_actual)} |"
+    )
+PY

--- a/tools/ref-so-runner/Makefile
+++ b/tools/ref-so-runner/Makefile
@@ -1,0 +1,30 @@
+#***************************************************************************************
+# Copyright (c) 2026 Institute of Computing Technology, Chinese Academy of Sciences
+#
+# NEMU is licensed under Mulan PSL v2.
+# You can use this software according to the terms and conditions of the Mulan PSL v2.
+# You may obtain a copy of Mulan PSL v2 at:
+#          http://license.coscl.org.cn/MulanPSL2
+#
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+# EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+# MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+#
+# See the Mulan PSL v2 for more details.
+#**************************************************************************************/
+
+CC ?= gcc
+CFLAGS ?= -O2 -g
+LDFLAGS ?=
+
+TARGET := runner
+
+.PHONY: all clean
+
+all: $(TARGET)
+
+$(TARGET): runner.c
+	$(CC) $(CFLAGS) -Wall -Wextra -Werror -std=c11 -o $@ $< -ldl $(LDFLAGS)
+
+clean:
+	rm -f $(TARGET) ref-so-runner

--- a/tools/ref-so-runner/gen-xs-ref-perf-defconfig.sh
+++ b/tools/ref-so-runner/gen-xs-ref-perf-defconfig.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+#***************************************************************************************
+# Copyright (c) 2026 Institute of Computing Technology, Chinese Academy of Sciences
+#
+# NEMU is licensed under Mulan PSL v2.
+# You can use this software according to the terms and conditions of the Mulan PSL v2.
+# You may obtain a copy of Mulan PSL v2 at:
+#          http://license.coscl.org.cn/MulanPSL2
+#
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+# EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+# MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+#
+# See the Mulan PSL v2 for more details.
+#**************************************************************************************/
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: tools/ref-so-runner/gen-xs-ref-perf-defconfig.sh PATH_TO_OUTPUT_DEFCONFIG [PATH_TO_BASE_DEFCONFIG]
+
+Generate an XS performance defconfig for standalone ref-so benchmarking.
+The script starts from `riscv64-xs-ref_defconfig`, prints the config diff, and
+writes the generated output defconfig.
+EOF
+}
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+  usage >&2
+  exit 2
+fi
+
+output="$1"
+base="${2:-$(dirname "$output")/riscv64-xs-ref_defconfig}"
+
+if [ ! -f "$base" ]; then
+  echo "Base defconfig not found: $base" >&2
+  exit 1
+fi
+
+if [ "$(realpath -m "$output")" = "$(realpath -m "$base")" ]; then
+  echo "Output defconfig must be different from the base defconfig" >&2
+  exit 1
+fi
+
+tmp=$(mktemp)
+cleanup() {
+  rm -f "$tmp"
+}
+trap cleanup EXIT
+
+cp "$base" "$tmp"
+
+python3 - "$tmp" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text()
+
+updates = [
+    (
+        "CONFIG_RV_AIA=y\nCONFIG_RV_IMSIC=y\nCONFIG_GEILEN=5",
+        "# CONFIG_RV_AIA is not set",
+    ),
+    (
+        "# CONFIG_CLINT_LOCAL_TIMER_INTERRUPT is not set",
+        "CONFIG_CLINT_LOCAL_TIMER_INTERRUPT=y\n"
+        "CONFIG_CYCLES_PER_MTIME_TICK=128\n"
+        "CONFIG_WFI_TIMEOUT_TICKS=8192",
+    ),
+    (
+        "# CONFIG_HAS_UART16550 is not set",
+        "CONFIG_HAS_UART16550=y\n"
+        "CONFIG_UART16550_PORT=0x3f8\n"
+        "CONFIG_UART16550_MMIO=0x310b0000\n"
+        "# CONFIG_UART16550_REG_SHIFT_0 is not set\n"
+        "CONFIG_UART16550_REG_SHIFT_2=y\n"
+        "# CONFIG_UART16550_INPUT_FIFO is not set",
+    ),
+    (
+        "# CONFIG_HAS_UARTLITE is not set",
+        "CONFIG_HAS_UARTLITE=y\n"
+        "CONFIG_UARTLITE_PORT=0x3f8\n"
+        "CONFIG_UARTLITE_MMIO=0x40600000\n"
+        "# CONFIG_UARTLITE_INPUT_FIFO is not set\n"
+        "CONFIG_UARTLITE_ASSERT_FOUR=y",
+    ),
+    (
+        "# CONFIG_HAS_PLIC is not set",
+        "CONFIG_HAS_PLIC=y\n"
+        "CONFIG_PLIC_ADDRESS=0x3c000000",
+    ),
+]
+
+for old, new in updates:
+    if new in text:
+        continue
+    if old not in text:
+        raise SystemExit(f"Could not find expected config marker: {old}")
+    text = text.replace(old, new, 1)
+
+path.write_text(text)
+PY
+
+diff -u "$base" "$tmp" || true
+
+if cmp -s "$tmp" "$output" 2>/dev/null; then
+  echo "Generated defconfig already up to date: $output"
+  exit 0
+fi
+
+cp "$tmp" "$output"
+echo "Generated $output from $base"

--- a/tools/ref-so-runner/runner.c
+++ b/tools/ref-so-runner/runner.c
@@ -1,0 +1,373 @@
+/***************************************************************************************
+* Copyright (c) 2026 Institute of Computing Technology, Chinese Academy of Sciences
+*
+* NEMU is licensed under Mulan PSL v2.
+* You can use this software according to the terms and conditions of the Mulan PSL v2.
+* You may obtain a copy of Mulan PSL v2 at:
+*          http://license.coscl.org.cn/MulanPSL2
+*
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+* EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+* MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+*
+* See the Mulan PSL v2 for more details.
+***************************************************************************************/
+
+#define _GNU_SOURCE
+#define _POSIX_C_SOURCE 200809L
+
+#include <dlfcn.h>
+#include <errno.h>
+#include <inttypes.h>
+#include <locale.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+enum {
+  DIFFTEST_TO_DUT = 0,
+  DIFFTEST_TO_REF = 1,
+};
+
+enum {
+  NEMU_RUNNING = 0,
+  NEMU_STOP = 1,
+  NEMU_END = 2,
+  NEMU_ABORT = 3,
+  NEMU_QUIT = 4,
+};
+
+typedef struct {
+  int state;
+  uint64_t halt_pc;
+  uint32_t halt_ret;
+} NEMUState;
+
+typedef void (*difftest_init_fn)(void);
+typedef void (*difftest_exec_fn)(uint64_t n);
+typedef void (*difftest_memcpy_fn)(uint64_t nemu_addr, void *dut_buf, size_t n, bool direction);
+typedef void (*difftest_load_flash_fn)(void *flash_bin, size_t size);
+typedef void (*difftest_set_ramsize_fn)(size_t ram_size);
+typedef void (*difftest_close_fn)(void);
+typedef uint64_t (*get_abs_instr_count_fn)(void);
+
+typedef struct {
+  const char *so_path;
+  const char *image_path;
+  uint64_t load_addr;
+  uint64_t max_instructions;
+  size_t ram_size;
+} RunnerConfig;
+
+typedef struct {
+  void *handle;
+  difftest_init_fn init;
+  difftest_exec_fn exec;
+  difftest_memcpy_fn memcpy;
+  difftest_load_flash_fn load_flash;
+  difftest_close_fn close;
+  get_abs_instr_count_fn get_abs_instr_count;
+  uint64_t *nr_vst;
+  uint64_t *nr_vst_unit;
+  uint64_t *nr_vst_unit_optimized;
+  NEMUState *state;
+} RefApi;
+
+static void usage(const char *prog) {
+  fprintf(stderr,
+      "Usage: %s -b IMAGE [options]\n"
+      "\n"
+      "Options:\n"
+      "  -b                      Accepted for NEMU CLI compatibility.\n"
+      "  --so PATH               NEMU shared object, default $NEMU_HOME/build/riscv64-nemu-interpreter-so.\n"
+      "  --load-addr ADDR          Guest physical load address, default 0x80000000.\n"
+      "  --max-instructions NUM    Stop with an error after NUM instructions, default 1000000000.\n"
+      "  -I NUM                  Alias of --max-instructions.\n"
+      "  --ram-size BYTES          Call difftest_set_ramsize before init.\n"
+      "  -h, --help                Show this help.\n",
+      prog);
+}
+
+static uint64_t parse_u64(const char *text, const char *name) {
+  char *end = NULL;
+  errno = 0;
+  uint64_t value = strtoull(text, &end, 0);
+  if (errno != 0 || end == text || *end != '\0') {
+    fprintf(stderr, "Invalid %s: %s\n", name, text);
+    exit(2);
+  }
+  return value;
+}
+
+static char *make_default_so_path(void) {
+  const char *nemu_home = getenv("NEMU_HOME");
+  if (nemu_home == NULL || nemu_home[0] == '\0') {
+    nemu_home = ".";
+  }
+  const char *suffix = "/build/riscv64-nemu-interpreter-so";
+  size_t size = strlen(nemu_home) + strlen(suffix) + 1;
+  char *path = malloc(size);
+  if (path == NULL) {
+    fprintf(stderr, "Failed to allocate shared object path\n");
+    exit(1);
+  }
+  snprintf(path, size, "%s%s", nemu_home, suffix);
+  return path;
+}
+
+static RunnerConfig parse_args(int argc, char **argv) {
+  RunnerConfig cfg = {
+    .so_path = NULL,
+    .image_path = NULL,
+    .load_addr = 0x80000000ull,
+    .max_instructions = 1000000000ull,
+    .ram_size = 0,
+  };
+
+  for (int i = 1; i < argc; i++) {
+    const char *arg = argv[i];
+    if (strcmp(arg, "-b") == 0) {
+      continue;
+    } else if (strcmp(arg, "--so") == 0) {
+      if (++i >= argc) {
+        fprintf(stderr, "Missing value for --so\n");
+        exit(2);
+      }
+      cfg.so_path = argv[i];
+    } else if (strcmp(arg, "--image") == 0) {
+      if (++i >= argc) {
+        fprintf(stderr, "Missing value for --image\n");
+        exit(2);
+      }
+      cfg.image_path = argv[i];
+    } else if (strcmp(arg, "--load-addr") == 0) {
+      if (++i >= argc) {
+        fprintf(stderr, "Missing value for --load-addr\n");
+        exit(2);
+      }
+      cfg.load_addr = parse_u64(argv[i], "--load-addr");
+    } else if (strcmp(arg, "--max-instructions") == 0) {
+      if (++i >= argc) {
+        fprintf(stderr, "Missing value for --max-instructions\n");
+        exit(2);
+      }
+      cfg.max_instructions = parse_u64(argv[i], "--max-instructions");
+    } else if (strcmp(arg, "-I") == 0) {
+      if (++i >= argc) {
+        fprintf(stderr, "Missing value for -I\n");
+        exit(2);
+      }
+      cfg.max_instructions = parse_u64(argv[i], "-I");
+    } else if (strcmp(arg, "--ram-size") == 0) {
+      if (++i >= argc) {
+        fprintf(stderr, "Missing value for --ram-size\n");
+        exit(2);
+      }
+      cfg.ram_size = (size_t)parse_u64(argv[i], "--ram-size");
+    } else if (strcmp(arg, "-h") == 0 || strcmp(arg, "--help") == 0) {
+      usage(argv[0]);
+      exit(0);
+    } else if (arg[0] != '-' && cfg.image_path == NULL) {
+      cfg.image_path = arg;
+    } else {
+      fprintf(stderr, "Unknown argument: %s\n", arg);
+      usage(argv[0]);
+      exit(2);
+    }
+  }
+
+  if (cfg.so_path == NULL) {
+    cfg.so_path = make_default_so_path();
+  }
+  if (cfg.image_path == NULL) {
+    usage(argv[0]);
+    exit(2);
+  }
+  return cfg;
+}
+
+static void *load_required_symbol(void *handle, const char *name) {
+  dlerror();
+  void *symbol = dlsym(handle, name);
+  const char *error = dlerror();
+  if (error != NULL || symbol == NULL) {
+    fprintf(stderr, "Failed to load %s: %s\n", name, error ? error : "symbol is NULL");
+    exit(1);
+  }
+  return symbol;
+}
+
+static void *load_optional_symbol(void *handle, const char *name) {
+  dlerror();
+  void *symbol = dlsym(handle, name);
+  const char *error = dlerror();
+  return error == NULL ? symbol : NULL;
+}
+
+static RefApi load_ref_api(const RunnerConfig *cfg) {
+  RefApi api = {0};
+  api.handle = dlopen(cfg->so_path, RTLD_LAZY | RTLD_DEEPBIND);
+  if (api.handle == NULL) {
+    fprintf(stderr, "Failed to load %s: %s\n", cfg->so_path, dlerror());
+    exit(1);
+  }
+
+  api.init = (difftest_init_fn)load_required_symbol(api.handle, "difftest_init");
+  api.exec = (difftest_exec_fn)load_required_symbol(api.handle, "difftest_exec");
+  api.memcpy = (difftest_memcpy_fn)load_optional_symbol(api.handle, "difftest_memcpy_init");
+  if (api.memcpy == NULL) {
+    api.memcpy = (difftest_memcpy_fn)load_required_symbol(api.handle, "difftest_memcpy");
+  }
+  api.load_flash = (difftest_load_flash_fn)load_optional_symbol(api.handle, "difftest_load_flash");
+  api.close = (difftest_close_fn)load_optional_symbol(api.handle, "difftest_close");
+  api.get_abs_instr_count = (get_abs_instr_count_fn)load_optional_symbol(api.handle, "get_abs_instr_count");
+  api.nr_vst = (uint64_t *)load_optional_symbol(api.handle, "g_nr_vst");
+  api.nr_vst_unit = (uint64_t *)load_optional_symbol(api.handle, "g_nr_vst_unit");
+  api.nr_vst_unit_optimized = (uint64_t *)load_optional_symbol(api.handle, "g_nr_vst_unit_optimized");
+  api.state = (NEMUState *)load_required_symbol(api.handle, "nemu_state");
+
+  difftest_set_ramsize_fn set_ramsize =
+      (difftest_set_ramsize_fn)load_optional_symbol(api.handle, "difftest_set_ramsize");
+  if (cfg->ram_size != 0) {
+    if (set_ramsize == NULL) {
+      fprintf(stderr, "The loaded NEMU shared object does not export difftest_set_ramsize\n");
+      exit(1);
+    }
+    set_ramsize(cfg->ram_size);
+  }
+
+  return api;
+}
+
+static uint8_t *read_file(const char *path, size_t *size) {
+  FILE *fp = fopen(path, "rb");
+  if (fp == NULL) {
+    fprintf(stderr, "Failed to open %s: %s\n", path, strerror(errno));
+    exit(1);
+  }
+  if (fseek(fp, 0, SEEK_END) != 0) {
+    fprintf(stderr, "Failed to seek %s\n", path);
+    exit(1);
+  }
+  long file_size = ftell(fp);
+  if (file_size < 0) {
+    fprintf(stderr, "Failed to get size of %s\n", path);
+    exit(1);
+  }
+  rewind(fp);
+
+  uint8_t *buf = malloc((size_t)file_size);
+  if (buf == NULL && file_size > 0) {
+    fprintf(stderr, "Failed to allocate %ld bytes\n", file_size);
+    exit(1);
+  }
+
+  size_t read_size = fread(buf, 1, (size_t)file_size, fp);
+  if (read_size != (size_t)file_size) {
+    fprintf(stderr, "Failed to read %s\n", path);
+    exit(1);
+  }
+  fclose(fp);
+  *size = read_size;
+  return buf;
+}
+
+static uint64_t monotonic_ns(void) {
+  struct timespec ts;
+  if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
+    fprintf(stderr, "clock_gettime failed: %s\n", strerror(errno));
+    exit(1);
+  }
+  return (uint64_t)ts.tv_sec * 1000000000ull + (uint64_t)ts.tv_nsec;
+}
+
+static uint64_t current_guest_instructions(const RefApi *api, uint64_t fallback) {
+  if (api->get_abs_instr_count != NULL) {
+    return api->get_abs_instr_count();
+  }
+  return fallback;
+}
+
+static void initialize_flash(const RefApi *api) {
+  if (api->load_flash != NULL) {
+    api->load_flash(NULL, 0);
+  }
+}
+
+static uint64_t read_optional_counter(const uint64_t *counter) {
+  return counter != NULL ? *counter : 0;
+}
+
+static void print_statistics(const RefApi *api, uint64_t guest_instructions, uint64_t elapsed_ns) {
+  uint64_t elapsed_us = elapsed_ns / 1000ull;
+  setlocale(LC_NUMERIC, "");
+  printf("host time spent = %'" PRIu64 " us\n", elapsed_us);
+  printf("total guest instructions = %'" PRIu64 "\n", guest_instructions);
+  printf(
+      "vst count = %'" PRIu64 ", vst unit count = %'" PRIu64 ", vst unit optimized count = %'" PRIu64 "\n",
+      read_optional_counter(api->nr_vst),
+      read_optional_counter(api->nr_vst_unit),
+      read_optional_counter(api->nr_vst_unit_optimized));
+  if (elapsed_us > 0) {
+    uint64_t frequency = guest_instructions * 1000000ull / elapsed_us;
+    printf("simulation frequency = %'" PRIu64 " instr/s\n", frequency);
+  } else {
+    printf("Finish running in less than 1 us and can not calculate the simulation frequency\n");
+  }
+  fflush(stdout);
+}
+
+static void cleanup_ref_api(const RefApi *api, uint8_t *image) {
+  free(image);
+  if (api->close != NULL) {
+    api->close();
+  }
+  dlclose(api->handle);
+}
+
+int main(int argc, char **argv) {
+  RunnerConfig cfg = parse_args(argc, argv);
+  RefApi api = load_ref_api(&cfg);
+
+  size_t image_size = 0;
+  uint8_t *image = read_file(cfg.image_path, &image_size);
+
+  api.init();
+  initialize_flash(&api);
+  api.memcpy(cfg.load_addr, image, image_size, DIFFTEST_TO_REF);
+
+  uint64_t guest_instructions = 0;
+  uint64_t start_ns = monotonic_ns();
+  bool hit_max_instructions = false;
+  int exit_code = 0;
+  while (api.state->state != NEMU_END && api.state->state != NEMU_ABORT) {
+    guest_instructions = current_guest_instructions(&api, guest_instructions);
+    if (guest_instructions >= cfg.max_instructions) {
+      hit_max_instructions = true;
+      break;
+    }
+    api.exec(1);
+    if (api.get_abs_instr_count == NULL) {
+      guest_instructions += 1;
+    }
+  }
+  uint64_t elapsed_ns = monotonic_ns() - start_ns;
+
+  guest_instructions = current_guest_instructions(&api, guest_instructions);
+  print_statistics(&api, guest_instructions, elapsed_ns);
+
+  if (api.state->state == NEMU_ABORT || api.state->halt_ret != 0) {
+    fprintf(stderr, "NEMU stopped with bad trap at pc = 0x%" PRIx64 ", code = %" PRIu32 "\n",
+        api.state->halt_pc, api.state->halt_ret);
+    exit_code = 1;
+  }
+  if (hit_max_instructions) {
+    exit_code = 0;
+  }
+
+  cleanup_ref_api(&api, image);
+  return exit_code;
+}


### PR DESCRIPTION
Add riscv64-xs-standalone-ref_defconfig for standalone ref-mode runs and extend the performance CI job to report both the existing XS interpreter results and standalone ref results.