### PR TITLE
feat(paddr): simplify the memory access handling procedure

### DIFF
--- a/src/memory/paddr.c
+++ b/src/memory/paddr.c
@@ -282,37 +282,16 @@ word_t paddr_read(paddr_t addr, int len, int type, int trap_type, int mode, vadd
   if (!check_paddr(addr, len, type, trap_type, mode, vaddr)) {
     return 0;
   }
-#ifndef CONFIG_SHARE
-  if (likely(in_pmem(addr))) return pmem_read(addr, len);
-  else {
-    if (likely(is_in_mmio(addr))) {
-      // check if the address is misaligned
-      if (cpu.isVldst) {
-        raise_read_access_fault(trap_type, vaddr);
-        return 0;
-      }
 
-      isa_mmio_misalign_data_addr_check(addr, vaddr, len, MEM_TYPE_READ, cross_page_load);
-#ifdef CONFIG_ENABLE_CONFIG_MMIO_SPACE
-      if (!mmio_is_real_device(addr)) {
-        raise_read_access_fault(trap_type, vaddr);
-        return 0;
-      }
-#endif // CONFIG_ENABLE_CONFIG_MMIO_SPACE
-      return mmio_read(addr, len);
-    }
-    else raise_read_access_fault(trap_type, vaddr);
-    return 0;
-  }
-#else
   if (likely(in_pmem(addr))) {
     uint64_t rdata = pmem_read(addr, len);
+#ifdef CONFIG_SHARE
     ref_log_cpu("paddr read addr:" FMT_PADDR ", data: %016lx, len:%d, type:%d, mode:%d",
         addr, rdata, len, type, mode);
+#endif // CONFIG_SHARE
     return rdata;
   }
   else {
-#ifdef CONFIG_HAS_FLASH
     if (likely(is_in_mmio(addr))) {
       // check if the address is misaligned
       if (cpu.isVldst) {
@@ -329,15 +308,14 @@ word_t paddr_read(paddr_t addr, int len, int type, int trap_type, int mode, vadd
 #endif // CONFIG_ENABLE_CONFIG_MMIO_SPACE
       return mmio_read(addr, len);
     }
-#endif
+#ifdef CONFIG_SHARE
     if(dynamic_config.ignore_illegal_mem_access)
       return 0;
+#endif // CONFIG_SHARE
     Logm("ERROR: invalid mem read from paddr " FMT_PADDR ", NEMU raise access exception\n", addr);
     raise_read_access_fault(trap_type, vaddr);
   }
   return 0;
-#endif // CONFIG_SHARE
-}
 
 #ifdef CONFIG_RV_MBMC
 word_t bitmap_read(paddr_t addr, int type, int mode) {
@@ -429,8 +407,17 @@ void paddr_write(paddr_t addr, int len, word_t data, int mode, vaddr_t vaddr) {
   if (!check_paddr(addr, len, MEM_TYPE_WRITE, MEM_TYPE_WRITE, mode, vaddr)) {
     return;
   }
-#ifndef CONFIG_SHARE
-  if (likely(in_pmem(addr))) pmem_write(addr, len, data, cross_page_store);
+
+  if (likely(in_pmem(addr))) {
+#ifdef CONFIG_SHARE
+#ifdef CONFIG_STORE_LOG
+    pmem_record_store(addr);
+#endif // CONFIG_STORE_LOG
+    ref_log_cpu("paddr write addr:" FMT_PADDR ", data:%016lx, len:%d, mode:%d",
+        addr, data, len, mode);
+#endif // CONFIG_SHARE
+    return pmem_write(addr, len, data, cross_page_store);
+  }
   else {
     if (likely(is_in_mmio(addr))) {
       // check if the address is misaligned
@@ -448,42 +435,16 @@ void paddr_write(paddr_t addr, int len, word_t data, int mode, vaddr_t vaddr) {
 #endif // CONFIG_ENABLE_CONFIG_MMIO_SPACE
       mmio_write(addr, len, data);
     }
-    else raise_access_fault(EX_SAF, vaddr);
-  }
-#else
-  if (likely(in_pmem(addr))) {
-#ifdef CONFIG_STORE_LOG
-    pmem_record_store(addr);
-#endif // CONFIG_STORE_LOG
-    ref_log_cpu("paddr write addr:" FMT_PADDR ", data:%016lx, len:%d, mode:%d",
-        addr, data, len, mode);
-    return pmem_write(addr, len, data, cross_page_store);
-  } else {
-    if (likely(is_in_mmio(addr))) {
-      // check if the address is misaligned
-      if (cpu.isVldst) {
-        raise_access_fault(EX_SAF, vaddr);
-        return;
-      }
-
-      isa_mmio_misalign_data_addr_check(addr, vaddr, len, MEM_TYPE_WRITE, cross_page_store);
-#ifdef CONFIG_ENABLE_CONFIG_MMIO_SPACE
-      if (!mmio_is_real_device(addr)) {
-        raise_access_fault(EX_SAF, vaddr);
-        return;
-      }
-#endif // CONFIG_ENABLE_CONFIG_MMIO_SPACE
-      mmio_write(addr, len, data);
-    }
     else {
+#ifdef CONFIG_SHARE
       if(dynamic_config.ignore_illegal_mem_access)
         return;
+#endif // CONFIG_SHARE
       printf("ERROR: invalid mem write to paddr " FMT_PADDR ", NEMU raise access exception\n", addr);
       raise_access_fault(EX_SAF, vaddr);
       return;
     }
   }
-#endif
 }
 
 #ifdef CONFIG_MEMORY_REGION_ANALYSIS

--- a/src/memory/paddr.c
+++ b/src/memory/paddr.c
@@ -316,6 +316,7 @@ word_t paddr_read(paddr_t addr, int len, int type, int trap_type, int mode, vadd
     raise_read_access_fault(trap_type, vaddr);
   }
   return 0;
+}
 
 #ifdef CONFIG_RV_MBMC
 word_t bitmap_read(paddr_t addr, int type, int mode) {


### PR DESCRIPTION
Avoid using `CONFIG_SHARE` for two code blocks.