### PR TITLE
fix(uart): display when SHARE is defined

### DIFF
--- a/src/device/uartlite.c
+++ b/src/device/uartlite.c
@@ -125,9 +125,7 @@ static void serial_io_handler(uint32_t offset, int len, bool is_write) {
     /* We bind the serial port with the host stdout in NEMU. */
     case UARTLITE_TX_FIFO:
       if (is_write) {
-	  #ifndef CONFIG_SHARE
           putc(serial_base[UARTLITE_TX_FIFO], stderr);
-          #endif // CONFIG_SHARE
       }
       else panic("Cannot read UARTLITE_TX_FIFO");
       break;


### PR DESCRIPTION
When the user enables the UART device, the UART is expected to display the characters.

UART is expected to be disabled in SHARE mode as the REF should not handle any MMIO requests.