### PR TITLE
fix(ci): fetch perf baseline by exact commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -455,7 +455,7 @@ jobs:
             git config --global --add safe.directory "${GITHUB_WORKSPACE}"
             git config --global --add safe.directory "${GITHUB_WORKSPACE}/perf-baseline"
             echo "Building perf baseline from PR base commit ${PERF_BASE_SHA} (${PERF_BASE_REF})"
-            git fetch --depth=1 origin "${PERF_BASE_REF}"
+            git fetch --depth=1 origin "${PERF_BASE_SHA}"
             git worktree prune
             rm -rf perf-baseline
             git worktree add --detach perf-baseline "${PERF_BASE_SHA}"


### PR DESCRIPTION
### Motivation

The performance CI builds a baseline from the pull request base commit. However, the current workflow fetches the base branch name with `--depth=1` and then tries to create a worktree from `github.event.pull_request.base.sha`.

This can fail when the PR base SHA is not the current tip fetched by the shallow branch fetch:

```text
fatal: invalid reference: <PERF_BASE_SHA>
