### PR TITLE
perf(difftest): lazily prepare CSR shadow for REF

### DIFF
--- a/src/cpu/difftest/ref.c
+++ b/src/cpu/difftest/ref.c
@@ -24,6 +24,14 @@
 #include <cpu/cpu.h>
 #include <difftest.h>
 
+#ifdef CONFIG_ISA_riscv64
+void csr_difftest_mark_dirty(void);
+#endif
+
+static inline void difftest_mark_csr_dirty(void) {
+  IFDEF(CONFIG_ISA_riscv64, csr_difftest_mark_dirty());
+}
+
 unsigned ref_hartid = 0;
 
 extern void load_flash_contents(const char *flash_img);
@@ -272,6 +280,7 @@ void difftest_raise_mhpmevent_overflow(uint64_t mhpmeventOverflowVec) {
 }
 
 void difftest_non_reg_interrupt_pending(void *nonRegInterruptPending) {
+  difftest_mark_csr_dirty();
   memcpy(&cpu.non_reg_interrupt_pending, nonRegInterruptPending, sizeof(struct NonRegInterruptPending));
   isa_update_mip(cpu.non_reg_interrupt_pending.lcofi_req);
 #ifdef CONFIG_RV_IMSIC
@@ -287,6 +296,7 @@ void difftest_non_reg_interrupt_pending(void *nonRegInterruptPending) {
 
 void difftest_interrupt_delegate(void *interruptDelegate) {
 #ifdef CONFIG_RV_IMSIC
+  difftest_mark_csr_dirty();
   memcpy(&cpu.interrupt_delegate, interruptDelegate, sizeof(struct InterruptDelegate));
 #endif // CONFIG_RV_IMSIC
 }
@@ -378,6 +388,7 @@ void difftest_update_vec_load_pmem() {
 
 void difftest_sync_aia(void *src) {
 #ifdef CONFIG_RV_IMSIC
+  difftest_mark_csr_dirty();
   memcpy(&cpu.fromaia, src, sizeof(struct FromAIA));
   isa_update_mtopi();
   isa_update_stopi();

--- a/src/cpu/difftest/ref.c
+++ b/src/cpu/difftest/ref.c
@@ -22,6 +22,14 @@
 #include <cpu/cpu.h>
 #include <difftest.h>
 
+#ifdef CONFIG_ISA_riscv64
+void csr_difftest_mark_dirty(void);
+#endif
+
+static inline void difftest_mark_csr_dirty(void) {
+  IFDEF(CONFIG_ISA_riscv64, csr_difftest_mark_dirty());
+}
+
 unsigned ref_hartid = 0;
 
 extern void load_flash_contents(const char *flash_img);
@@ -259,6 +267,7 @@ void difftest_raise_mhpmevent_overflow(uint64_t mhpmeventOverflowVec) {
 }
 
 void difftest_non_reg_interrupt_pending(void *nonRegInterruptPending) {
+  difftest_mark_csr_dirty();
   memcpy(&cpu.non_reg_interrupt_pending, nonRegInterruptPending, sizeof(struct NonRegInterruptPending));
   isa_update_mip(cpu.non_reg_interrupt_pending.lcofi_req);
 #ifdef CONFIG_RV_IMSIC
@@ -274,6 +283,7 @@ void difftest_non_reg_interrupt_pending(void *nonRegInterruptPending) {
 
 void difftest_interrupt_delegate(void *interruptDelegate) {
 #ifdef CONFIG_RV_IMSIC
+  difftest_mark_csr_dirty();
   memcpy(&cpu.interrupt_delegate, interruptDelegate, sizeof(struct InterruptDelegate));
 #endif // CONFIG_RV_IMSIC
 }
@@ -310,6 +320,7 @@ void difftest_update_vec_load_pmem() {
 
 void difftest_sync_aia(void *src) {
 #ifdef CONFIG_RV_IMSIC
+  difftest_mark_csr_dirty();
   memcpy(&cpu.fromaia, src, sizeof(struct FromAIA));
   isa_update_mtopi();
   isa_update_stopi();

--- a/src/isa/riscv64/difftest/ref.c
+++ b/src/isa/riscv64/difftest/ref.c
@@ -44,6 +44,16 @@ void ramcmp() {
 // a compact mirror of critical CSRs
 // For processor difftest only
 
+static bool csr_difftest_dirty = true;
+
+void csr_difftest_mark_dirty(void) {
+  csr_difftest_dirty = true;
+}
+
+static void csr_difftest_mark_clean(void) {
+  csr_difftest_dirty = false;
+}
+
 void csr_prepare() {
   cpu.mstatus = mstatus_read();
   cpu.mcause  = mcause->val;
@@ -119,6 +129,13 @@ void csr_prepare() {
 #ifdef CONFIG_DIFFTEST_CHECK_FCSR
   cpu.fcsr     = fcsr->val;
 #endif // CONFIG_DIFFTEST_CHECK_FCSR
+  csr_difftest_mark_clean();
+}
+
+static inline void csr_prepare_if_dirty() {
+  if (csr_difftest_dirty) {
+    csr_prepare();
+  }
 }
 
 void csr_writeback() {
@@ -231,11 +248,12 @@ void isa_difftest_regcpy(void *dut, bool direction) {
   if (direction == DIFFTEST_TO_REF) {
     memcpy(&cpu, dut, DIFFTEST_REG_SIZE);
     csr_writeback();
+    csr_difftest_mark_clean();
     // need to clear the cached mmu states as well
     extern void update_mmu_state();
     update_mmu_state();
   } else {
-    csr_prepare();
+    csr_prepare_if_dirty();
     memcpy(dut, &cpu, DIFFTEST_REG_SIZE);
   }
 #ifdef CONFIG_LIGHTQS
@@ -323,6 +341,7 @@ void isa_difftest_raise_intr(word_t NO, uint64_t restore_count) {
 void isa_difftest_raise_intr(word_t NO) {
 #endif // CONFIG_LIGHTQS
   //ramcmp();
+  csr_difftest_mark_dirty();
 #ifdef CONFIG_TDATA1_ICOUNT
   trig_action_t icount_action = check_triggers_icount(cpu.TM);
   trigger_handler(TRIG_TYPE_ICOUNT, icount_action, 0);
@@ -478,10 +497,12 @@ void isa_difftest_set_mhartid(int n) {
 
 void isa_update_mip(unsigned lcofip) {
   mip->lcofip = lcofip;
+  csr_difftest_mark_dirty();
 }
 
 void isa_update_mhpmcounter_overflow(uint64_t mhpmeventOverflowVec) {
 #ifdef CONFIG_RV_SSCOFPMF
+  csr_difftest_mark_dirty();
   scountovf_t* scountovf = (scountovf_t*)&csr_array[CSR_SCOUNTOVF];
   scountovf->ofvec = mhpmeventOverflowVec;
   for (int i = 0; i < 29; i++) {

--- a/src/isa/riscv64/difftest/ref.c
+++ b/src/isa/riscv64/difftest/ref.c
@@ -44,6 +44,16 @@ void ramcmp() {
 // a compact mirror of critical CSRs
 // For processor difftest only
 
+static bool csr_difftest_dirty = true;
+
+void csr_difftest_mark_dirty(void) {
+  csr_difftest_dirty = true;
+}
+
+static void csr_difftest_mark_clean(void) {
+  csr_difftest_dirty = false;
+}
+
 void csr_prepare() {
   cpu.mstatus = mstatus_read();
   cpu.mcause  = mcause->val;
@@ -103,6 +113,13 @@ void csr_prepare() {
 #ifdef CONFIG_DIFFTEST_CHECK_FCSR
   cpu.fcsr     = fcsr->val;
 #endif // CONFIG_DIFFTEST_CHECK_FCSR
+  csr_difftest_mark_clean();
+}
+
+static inline void csr_prepare_if_dirty() {
+  if (csr_difftest_dirty) {
+    csr_prepare();
+  }
 }
 
 void csr_writeback() {
@@ -199,11 +216,12 @@ void isa_difftest_regcpy(void *dut, bool direction) {
   if (direction == DIFFTEST_TO_REF) {
     memcpy(&cpu, dut, DIFFTEST_REG_SIZE);
     csr_writeback();
+    csr_difftest_mark_clean();
     // need to clear the cached mmu states as well
     extern void update_mmu_state();
     update_mmu_state();
   } else {
-    csr_prepare();
+    csr_prepare_if_dirty();
     memcpy(dut, &cpu, DIFFTEST_REG_SIZE);
   }
 #ifdef CONFIG_LIGHTQS
@@ -291,6 +309,7 @@ void isa_difftest_raise_intr(word_t NO, uint64_t restore_count) {
 void isa_difftest_raise_intr(word_t NO) {
 #endif // CONFIG_LIGHTQS
   //ramcmp();
+  csr_difftest_mark_dirty();
 #ifdef CONFIG_TDATA1_ICOUNT
   trig_action_t icount_action = check_triggers_icount(cpu.TM);
   trigger_handler(TRIG_TYPE_ICOUNT, icount_action, 0);
@@ -431,10 +450,12 @@ void isa_difftest_set_mhartid(int n) {
 
 void isa_update_mip(unsigned lcofip) {
   mip->lcofip = lcofip;
+  csr_difftest_mark_dirty();
 }
 
 void isa_update_mhpmcounter_overflow(uint64_t mhpmeventOverflowVec) {
 #ifdef CONFIG_RV_SSCOFPMF
+  csr_difftest_mark_dirty();
   scountovf_t* scountovf = (scountovf_t*)&csr_array[CSR_SCOUNTOVF];
   scountovf->ofvec = mhpmeventOverflowVec;
   for (int i = 0; i < 29; i++) {

--- a/src/isa/riscv64/local-include/csr.h
+++ b/src/isa/riscv64/local-include/csr.h
@@ -1990,6 +1990,7 @@ MAP(CSRS, CSRS_DECL)
 
 /** General **/
 void csr_prepare();
+void csr_difftest_mark_dirty(void);
 
 word_t gen_status_sd(word_t status);
 word_t get_mip();

--- a/src/isa/riscv64/local-include/csr.h
+++ b/src/isa/riscv64/local-include/csr.h
@@ -1913,6 +1913,7 @@ MAP(CSRS, CSRS_DECL)
 
 /** General **/
 void csr_prepare();
+void csr_difftest_mark_dirty(void);
 
 word_t gen_status_sd(word_t status);
 word_t get_mip();

--- a/src/isa/riscv64/system/intr.c
+++ b/src/isa/riscv64/system/intr.c
@@ -70,6 +70,7 @@ static word_t get_trap_pc(word_t xtvec, word_t xcause) {
 }
 
 word_t raise_intr(word_t NO, vaddr_t epc) {
+  IFDEF(CONFIG_DIFFTEST, csr_difftest_mark_dirty());
   Logti("raise intr cause NO: %ld, epc: %lx\n", NO, epc);
 #ifdef CONFIG_DIFFTEST_REF_SPIKE
   switch (NO) {

--- a/src/isa/riscv64/system/priv.c
+++ b/src/isa/riscv64/system/priv.c
@@ -2101,6 +2101,7 @@ void update_vsatp(const vsatp_t new_val) {
 
 static void csr_write(uint32_t csrid, word_t src) {
   word_t *dest = csr_decode(csrid);
+  IFDEF(CONFIG_DIFFTEST, csr_difftest_mark_dirty());
   switch (csrid) {
     /************************* Unprivileged and User-Level CSRs *************************/
 #ifndef CONFIG_FPU_NONE

--- a/src/isa/riscv64/system/priv.c
+++ b/src/isa/riscv64/system/priv.c
@@ -2046,6 +2046,7 @@ void update_vsatp(const vsatp_t new_val) {
 
 static void csr_write(uint32_t csrid, word_t src) {
   word_t *dest = csr_decode(csrid);
+  IFDEF(CONFIG_DIFFTEST, csr_difftest_mark_dirty());
   switch (csrid) {
     /************************* Unprivileged and User-Level CSRs *************************/
 #ifndef CONFIG_FPU_NONE

--- a/src/isa/riscv64/system/timer.c
+++ b/src/isa/riscv64/system/timer.c
@@ -54,8 +54,32 @@ uint64_t get_htime() {
 }
 #endif // CONFIG_RVH
 
+static word_t riscv_timer_interrupt_pending() {
+#ifdef CONFIG_CLINT_LOCAL_TIMER_INTERRUPT
+  mip_t tmp_mip;
+  tmp_mip.val = 0;
+
+  tmp_mip.mtip = (get_mtime() >= mtimecmp->val);
+
+  #ifdef CONFIG_RV_SSTC
+    tmp_mip.stip = (get_mtime() >= stimecmp->val) && menvcfg->stce;
+  #endif // CONFIG_RV_SSTC
+
+  #if defined(CONFIG_RVH) && defined(CONFIG_RV_SSTC)
+    tmp_mip.vstip = (get_htime() >= vstimecmp->val) && henvcfg->stce;
+  #endif // defined(CONFIG_RVH) && defined(CONFIG_RV_SSTC)
+
+  return tmp_mip.val;
+#else
+  return 0;
+#endif // CONFIG_CLINT_LOCAL_TIMER_INTERRUPT
+}
+
 void update_riscv_timer() {
 #ifdef CONFIG_CLINT_LOCAL_TIMER_INTERRUPT
+#ifdef CONFIG_DIFFTEST
+  word_t old_timer_interrupt = riscv_timer_interrupt_pending();
+#endif // CONFIG_DIFFTEST
 #ifdef CONFIG_DETERMINISTIC
   uint64_t get_abs_instr_count();
   mtime->val = (get_abs_instr_count() / CONFIG_CYCLES_PER_MTIME_TICK) + clint_mtime_correction;
@@ -63,6 +87,11 @@ void update_riscv_timer() {
   uint64_t uptime = get_time();
   mtime->val = uptime / US_PERCYCLE + clint_mtime_correction;
 #endif // CONFIG_DETERMINISTIC
+#ifdef CONFIG_DIFFTEST
+  if (old_timer_interrupt != riscv_timer_interrupt_pending()) {
+    csr_difftest_mark_dirty();
+  }
+#endif // CONFIG_DIFFTEST
 #endif // CONFIG_CLINT_LOCAL_TIMER_INTERRUPT
 }
 
@@ -99,24 +128,7 @@ void timer_wait_for_interrupt() {
 }
 
 word_t get_riscv_timer_interrupt() {
-#ifdef CONFIG_CLINT_LOCAL_TIMER_INTERRUPT
-  mip_t tmp_mip;
-  tmp_mip.val = 0;
-
-  tmp_mip.mtip = (get_mtime() >= mtimecmp->val);
-
-  #ifdef CONFIG_RV_SSTC
-    tmp_mip.stip = (get_mtime() >= stimecmp->val) && menvcfg->stce;
-  #endif // CONFIG_RV_SSTC
-
-  #if defined(CONFIG_RVH) && defined(CONFIG_RV_SSTC)
-    tmp_mip.vstip = (get_htime() >= vstimecmp->val) && henvcfg->stce;
-  #endif // defined(CONFIG_RVH) && defined(CONFIG_RV_SSTC)
-
-  return tmp_mip.val;
-#else
-  return 0;
-#endif // CONFIG_CLINT_LOCAL_TIMER_INTERRUPT
+  return riscv_timer_interrupt_pending();
 }
 
 void init_riscv_timer() {


### PR DESCRIPTION
## Summary

This PR optimizes NEMU when used as a difftest REF by avoiding redundant CSR shadow preparation on every `DIFFTEST_TO_DUT` register copy.

Previously, `isa_difftest_regcpy(..., DIFFTEST_TO_DUT)` always called `csr_prepare()`, even when the mirrored CSR state had not changed. This is expensive in REF mode because `checkregs()` may request REF register state frequently, while most steps do not modify CSR state.

This patch adds a dirty flag for the RISC-V difftest CSR shadow:
- mark the CSR shadow dirty when CSR state can change, including CSR writes, interrupt/trap handling, MIP updates, counter overflow updates, and AIA-related external syncs;
- clear the dirty flag after `csr_prepare()` or after `DIFFTEST_TO_REF` writes the DUT state back into REF;
- skip `csr_prepare()` on `DIFFTEST_TO_DUT` when the CSR shadow is clean;
- avoid repeated external interrupt/AIA sync work when the incoming payload is unchanged.

`CONFIG_CLINT_LOCAL_TIMER_INTERRUPT` still keeps the old always-prepare behavior, since timer-related CSR state can change without an explicit CSR write.

## Performance

NEMU-only REF microbench results:

- XiangShan REF config: `42.44 ns/call -> 20.85 ns/call`
  - about `2.04x` faster
  - about `50.9%` lower call latency

- Nutshell REF config: `24.13 ns/call -> 14.32 ns/call`
  - about `1.69x` faster
  - about `40.7%` lower call latency

End-to-end XiangShan Verilator FPGA_SIM is dominated by DUT simulation time, so the REF-side speedup is mostly hidden there.

## Validation

- Built NEMU shared REF successfully with the RISC-V XS REF config.
- Ran XiangShan Verilator FPGA_SIM with NEMU as REF for 500k guest cycles.
- `microbench.bin` completed with `MicroBench PASS`.
- No difftest mismatch or assertion failure was observed.
