### PR TITLE
feat(checkpoint): build checkpoint sources for SHARE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,10 +70,7 @@ SRCS-$(CONFIG_HAS_SDCARD) += src/device/sdcard.c
 SRCS-$(CONFIG_HAS_FLASH) += src/device/flash.c
 
 DIRS-y += src/profiling
-
-ifndef CONFIG_SHARE
 DIRS-y += src/checkpoint
-endif
 
 SRCS-y += $(shell find $(DIRS-y) -name "*.c")
 
@@ -81,10 +78,8 @@ SRCS = $(SRCS-y)
 
 XSRCS-$(CONFIG_USE_SPARSEMM) += src/memory/sparseram.cpp
 
-ifndef CONFIG_SHARE
 XDIRS-y += src/checkpoint src/base src/iostream3 src/profiling
 XSRCS-y += $(shell find $(XDIRS-y) -name "*.cpp")
-endif
 
 XSRCS-y += src/memory/store_queue_wrapper.cpp
 

--- a/src/isa/riscv64/local-include/csr.h
+++ b/src/isa/riscv64/local-include/csr.h
@@ -1593,6 +1593,7 @@ CSR_STRUCT_START(hviprio1)
 CSR_STRUCT_END(hviprio1)
 
 CSR_STRUCT_START(hviprio2)
+  uint64_t pad0 : 64;
 CSR_STRUCT_END(hviprio2)
 
 CSR_STRUCT_START(vstopei)


### PR DESCRIPTION
Include checkpoint-related C and C++ sources in SHARE builds so ref shared objects can reuse checkpoint infrastructure.

Add a dummy field for hviprio2 to keep the newly compiled clang++ checkpoint path warning-free under -Werror.