### PR TITLE
ci(build): statically link libstdc++ for release artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Compile dynamic library
       run: |
         make riscv64-${{ matrix.cpu }}-${{ matrix.type }}_defconfig
-        make -j
+        make -j LDFLAGS="-static-libstdc++ -Wl,--exclude-libs,ALL"
 
     - name: Prepare artifact
       run: |


### PR DESCRIPTION
NEMU release shared objects are consumed by XiangShan CI on CentOS 7 nodes, where the system libstdc++ may not provide newer GLIBCXX symbols required by Ubuntu-built artifacts.

Keep the existing Ubuntu 20.04 release container and only pass -static-libstdc++ when linking the shared object. Hide symbols from linked static archives to reduce C++ runtime symbol exposure.