### PR TITLE
fix(Makefile): statically link libstdc++ for shared objects

### DIFF
--- a/scripts/build.mk
+++ b/scripts/build.mk
@@ -3,7 +3,9 @@
 ifdef SHARE
 SO = -so
 CFLAGS  += -fPIC -D_SHARE=1
+CXXFLAGS += -ffunction-sections -fdata-sections
 LDFLAGS += -rdynamic -shared -fPIC -Wl,--no-undefined -lz
+LDFLAGS += -static-libstdc++ -Wl,--gc-sections -Wl,--exclude-libs,ALL
 endif
 
 WORK_DIR  = $(shell pwd)


### PR DESCRIPTION
NEMU shared objects may be loaded by XiangShan CI on CentOS 7 nodes, where the system libstdc++ can miss newer GLIBCXX symbols required by Ubuntu-built artifacts.

Add -static-libstdc++ to the common SHARE link flags instead of passing LDFLAGS on the workflow make command line, so the existing shared-object flags such as -shared, -fPIC, -Wl,--no-undefined, and -lz are preserved.

Hide symbols from linked static archives to reduce C++ runtime symbol exposure from the generated .so files.