### PR TITLE
perf(cpu-exec): skip timer in ref/shared mode

### DIFF
--- a/src/cpu/cpu-exec.c
+++ b/src/cpu/cpu-exec.c
@@ -781,7 +781,9 @@ void cpu_exec(uint64_t n) {
     Loge("Setting NEMU state to RUNNING");
   }
 
+#ifndef CONFIG_SHARE
   uint64_t timer_start = get_time();
+#endif
 
   n_remain_total = n; // + AHEAD_LENGTH; // deal with setjmp()
   Loge("cpu_exec will exec %lu instrunctions", n_remain_total);
@@ -925,8 +927,10 @@ void cpu_exec(uint64_t n) {
     nemu_state.state = NEMU_QUIT;
   }
 
+#ifndef CONFIG_SHARE
   uint64_t timer_end = get_time();
   g_timer += timer_end - timer_start;
+#endif
 
   switch (nemu_state.state) {
   case NEMU_RUNNING:


### PR DESCRIPTION
`cpu_exec` uses get_time() only for standalone NEMU runtime statistics, including host elapsed time and MIPS reporting. The value is not part of REF architectural state when NEMU is built as a DiffTest shared library.

Skip this accounting under CONFIG_SHARE to avoid repeated host time queries. In the measured run, get_time accounted for 20% speedup in riscv64-nemu-interpreter-so for fpga difftest.