### PR TITLE
perf(log): guard ref_log_cpu before varargs call

### DIFF
--- a/include/cpu/cpu.h
+++ b/include/cpu/cpu.h
@@ -94,19 +94,27 @@ struct lightqs_reg_ss {
 };
 
 extern unsigned ref_hartid;
-static inline void ref_log_cpu(const char *fmt, ...) {
 #ifdef CONFIG_SHARE
-  if (unlikely(dynamic_config.debug_difftest)) {
-    va_list ap;
-    va_start(ap, fmt);
+static inline void ref_log_cpu_impl(const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
 
-    fprintf(stderr, "[NEMU][%u] ", ref_hartid);
-    vfprintf(stderr, fmt, ap);
-    fprintf(stderr, "\n");
+  fprintf(stderr, "[NEMU][%u] ", ref_hartid);
+  vfprintf(stderr, fmt, ap);
+  fprintf(stderr, "\n");
 
-    va_end(ap);
-  }
-#endif
+  va_end(ap);
 }
+#define ref_log_cpu(...) \
+  do { \
+    if (unlikely(dynamic_config.debug_difftest)) { \
+      ref_log_cpu_impl(__VA_ARGS__); \
+    } \
+  } while (0)
+#else
+static inline void ref_log_cpu(const char *fmt, ...) {
+  (void)fmt;
+}
+#endif
 
 #endif


### PR DESCRIPTION
ref_log_cpu() is used in hot REF paths, while normal DiffTest runs leave dynamic_config.debug_difftest disabled. The previous variadic function still paid call and argument setup cost before checking it.

This change move the guard to the call site and keep printing in ref_log_cpu_impl().