### PR TITLE
perf(riscv64/aia): speed up priority index lookup

### DIFF
--- a/src/isa/riscv64/local-include/aia.h
+++ b/src/isa/riscv64/local-include/aia.h
@@ -38,6 +38,7 @@ void set_iprios_sort(uint64_t topi_gather, IpriosSort* iprios_sort, IpriosModule
 void set_viprios_sort(uint64_t topi_gather);
 uint8_t high_iprio(IpriosSort* ipriosSort, uint8_t xei);
 uint8_t get_prio_idx_in_group(uint8_t irq);
+void init_aia_prio_idx();
 
 extern int interrupt_default_prio[IPRIO_ENABLE_NUM];
 

--- a/src/isa/riscv64/system/aia.c
+++ b/src/isa/riscv64/system/aia.c
@@ -35,14 +35,19 @@ int interrupt_default_prio[IPRIO_ENABLE_NUM] = {
   49, 24, 48
 };
 
-uint8_t get_prio_idx_in_group(uint8_t irq) {
-  uint8_t idx = 0;
+static uint8_t interrupt_prio_idx[64];
+
+void init_aia_prio_idx() {
   for (int i = 0; i < IPRIO_ENABLE_NUM; i++) {
-    if (irq == interrupt_default_prio[i]) {
-      idx = i;
-    }
+    interrupt_prio_idx[interrupt_default_prio[i]] = i;
   }
-  return idx;
+}
+
+uint8_t get_prio_idx_in_group(uint8_t irq) {
+  if (unlikely(irq >= 64)) {
+    return 0;
+  }
+  return interrupt_prio_idx[irq];
 }
 
 bool intr_enable(uint64_t topi_gather, uint64_t idx) {
@@ -117,6 +122,7 @@ void set_viprios_sort(uint64_t topi_gather) {
 
 uint8_t high_iprio(IpriosSort* ipriosSort, uint8_t xei) {
   uint8_t high_prio_idx = 0;
+  uint8_t xei_prio_idx = get_prio_idx_in_group(xei);
 
   for (int i = 1; i < IPRIO_ENABLE_NUM; i ++) {
     // enable
@@ -133,8 +139,8 @@ uint8_t high_iprio(IpriosSort* ipriosSort, uint8_t xei) {
     bool right_prio_is_not_zero = !right_prio_is_zero;
 
     // idx
-    bool left_idx_leq_xei = high_prio_idx <= get_prio_idx_in_group(xei);
-    bool right_idx_leq_xei = i <= get_prio_idx_in_group(xei);
+    bool left_idx_leq_xei = high_prio_idx <= xei_prio_idx;
+    bool right_idx_leq_xei = i <= xei_prio_idx;
 
     bool left_idx_greater_xei = !left_idx_leq_xei;
 

--- a/src/isa/riscv64/system/priv.c
+++ b/src/isa/riscv64/system/priv.c
@@ -100,6 +100,7 @@ void init_trigger() {
 
 #ifdef CONFIG_RV_IMSIC
 void init_iprio() {
+  init_aia_prio_idx();
   cpu.external_interrupt_select = false;
   cpu.MIprios  = (IpriosModule*) malloc(sizeof (IpriosModule));
   cpu.SIprios  = (IpriosModule*) malloc(sizeof (IpriosModule));


### PR DESCRIPTION
AIA priority handling maps IRQ numbers back to priority-group indices. The previous helper scanned interrupt_default_prio[] on each query, and high_iprio() repeated the xei lookup in the loop.

Build a reverse lookup table from interrupt_default_prio[] during AIA priority initialization, and cache xei_prio_idx for repeated high_iprio()