### PR TITLE
docs(agent): document NEMU agent maintenance standards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 !README.md
 !Kconfig
 !.github/workflows/*.yml
+!agent/
+!agent/**
 !scripts/*.sh
 !scripts/ci/*.sh
 !scripts/*.py

--- a/agent/architecture.md
+++ b/agent/architecture.md
@@ -1,0 +1,202 @@
+# NEMU Software Architecture For Agents
+
+This document gives AI agents a stable map of NEMU before editing code. Use it to choose the right module, keep commits narrow, and pick validation that matches the changed path.
+
+## Top-Level Shape
+
+NEMU has two major runtime shapes:
+
+- **Standalone emulator**: `src/nemu-main.c` calls `init_monitor()` and then `engine_start()`. This path boots images, runs devices, can take or restore checkpoints, and can run DiffTest against Spike or another reference.
+- **Reference shared object**: `CONFIG_SHARE` builds `riscv64-nemu-interpreter-so` for external DUTs. The exported DiffTest ABI is implemented through CPU and ISA reference code, especially `src/cpu/difftest/ref.c` and `src/isa/riscv64/difftest/ref.c`.
+
+Most changes should be classified by the module that owns the state being changed, not by the file extension or call site.
+
+## Startup Flow
+
+Standalone execution follows this control flow:
+
+```text
+src/nemu-main.c
+  -> init_monitor(argc, argv)
+     -> parse CLI flags
+     -> init_log()
+     -> init_mem()
+     -> init_isa()
+     -> init_device()
+     -> fill_memory(image, flash, restorer)
+     -> init_difftest(ref_so, image_size, flash_size, port)
+     -> init_regex(), init_wp_pool(), init_aligncheck()
+  -> engine_start()
+     -> cpu_exec()
+```
+
+Important files:
+
+- `src/monitor/monitor.c`: command-line options, monitor initialization, DiffTest initialization point.
+- `src/monitor/image_loader.c`: raw, gz, zstd image and checkpoint loading.
+- `src/memory/paddr.c`: physical memory allocation and host/guest address mapping.
+- `src/isa/riscv64/init.c`: RISC-V reset and ISA initialization.
+- `src/device/device.c`: device initialization fan-out.
+
+## Execution Flow
+
+The CPU execution loop is centered in `src/cpu/cpu-exec.c`:
+
+```text
+cpu_exec(n)
+  -> execute loop
+     -> fetch/decode/execute through ISA-specific helpers
+     -> update instruction count
+     -> run DiffTest step when enabled
+     -> handle traps, exceptions, longjmp exits
+```
+
+Key state:
+
+- `CPU_state cpu`: global architectural state.
+- `nemu_state`: run status and trap result.
+- instruction counters from `get_abs_instr_count()` and `get_abs_instr_count_csr()`.
+- `context_stack`: longjmp contexts used for execution exits and exceptions.
+
+Execution changes are usually `cpu-core` unless they touch ISA-specific decode, CSR, MMU, interrupt, or vector behavior.
+
+## RISC-V ISA Flow
+
+RISC-V code lives under `src/isa/riscv64/` and should be treated as the `riscv64-isa` module.
+
+Important subareas:
+
+- `instr/`: decode and instruction helpers.
+- `system/priv.c`: privileged CSRs and mode behavior.
+- `system/mmu.c`: address translation and memory access permission checks.
+- `system/intr.c`: traps and interrupt routing.
+- `system/aia.c`: AIA/IMSIC-related interrupt state.
+- `system/trigger.c`: trigger and debug-related behavior.
+- `difftest/`: RISC-V architectural state copy and compare.
+- `include/isa-def.h`: `CPU_state` layout and DiffTest-synchronized region.
+
+Do not casually change the order or layout of DiffTest-synchronized CPU state. If a state-layout change is required, document how ref and DUT copy/check paths stay compatible.
+
+## DiffTest Architecture
+
+NEMU has two DiffTest roles:
+
+- **DUT mode**: NEMU runs the workload and compares against a reference shared object, usually Spike.
+- **Reference mode**: NEMU is compiled as a shared object and is driven by XiangShan, GEM5, or a runner.
+
+DUT-mode path:
+
+```text
+monitor init
+  -> init_difftest(ref_so)
+     -> dlopen ref shared object
+     -> resolve difftest_memcpy/regcpy/exec/raise_intr
+     -> copy image and register state to ref
+
+cpu_exec loop
+  -> difftest_step(pc, npc)
+     -> ref_difftest_exec(1)
+     -> ref_difftest_regcpy(..., DIFFTEST_TO_DUT)
+     -> isa_difftest_checkregs()
+```
+
+Reference-mode path:
+
+```text
+external DUT or ref-so-runner
+  -> difftest_memcpy()
+  -> difftest_regcpy()
+  -> difftest_exec(n)
+  -> difftest_raise_intr()
+```
+
+Important files:
+
+- `include/cpu/difftest.h`: common DiffTest declarations and register/store check helpers.
+- `src/cpu/difftest/dut.c`: DUT-mode reference loading and step control.
+- `src/cpu/difftest/ref.c`: reference shared-object ABI surface.
+- `src/isa/riscv64/difftest/dut.c`: RISC-V register compare.
+- `src/isa/riscv64/difftest/ref.c`: RISC-V register copy and reference-side helpers.
+- `tools/ref-so-runner/`: standalone runner for NEMU-as-reference shared object.
+
+DiffTest changes often cross CPU and RISC-V paths. Keep commits narrow: generic ABI/control changes belong in `cpu-core` or `difftest`; RISC-V architectural state copy/check changes belong in `riscv64-isa`.
+
+## Memory And Image Loading
+
+Memory ownership is split as:
+
+- `src/memory/`, `include/memory/`: host memory, physical memory, virtual memory, sparse memory, store queue wrappers.
+- `src/monitor/image_loader.c`: loading images/checkpoints into memory.
+- `src/isa/riscv64/system/mmu.c`: RISC-V address translation and permission behavior.
+
+Image and checkpoint loading bugs can look like memory bugs. Classify by the failing invariant:
+
+- decompression, file format, load size: `monitor-loader`
+- guest physical memory allocation or host address mapping: `memory`
+- RISC-V translation or permission: `riscv64-isa`
+
+## Checkpoint Architecture
+
+Checkpoint support spans several modules:
+
+- `src/checkpoint/`, `include/checkpoint/`: serializer, path management, simpoint and semantic checkpoint metadata.
+- `src/profiling/`: profiling state that can drive checkpoint timing.
+- `resource/gcpt_restore/`: GCPT restorer program.
+- `scripts/take_zstd.sh`, `scripts/restore_zstd.sh`: smoke flows.
+- `scripts/checkpoint_example/`: user-facing checkpoint examples.
+- `src/monitor/monitor.c`: CLI flags and mode selection.
+- `src/monitor/image_loader.c`: restore image loading.
+
+Checkpoint restore depends on matching the checkpoint corpus and restorer. Do not assume one global restorer is valid for every checkpoint corpus.
+
+## Device Architecture
+
+Device code is under `src/device/` and `include/device/`.
+
+Important areas:
+
+- `src/device/device.c`: device initialization.
+- `src/device/io/`: MMIO and port IO map handling.
+- `src/device/plic.c`, `src/isa/riscv64/clint.c`: interrupt-related device state.
+- UART, disk, flash, timer, keyboard, VGA, audio device files.
+
+Device changes can affect Linux boot and DiffTest determinism. For execution-sensitive device changes, the delivery standard requires the Linux DiffTest smoke unless blocked.
+
+## Build, Config, And CI
+
+Build/config ownership:
+
+- `configs/`: checked-in defconfigs.
+- `Kconfig` and nested `Kconfig` files: option definitions.
+- `scripts/*.mk`: build fragments.
+- `include/generated/` and `include/config/`: generated, not normally committed.
+
+CI/harness ownership:
+
+- `.github/workflows/`: GitHub Actions jobs.
+- `scripts/init-ready-to-run.py`: ready-to-run artifact setup.
+- runner scripts under `scripts/`.
+- `tools/ref-so-runner/`.
+- `agent/`: agent-facing guidance.
+
+When changing configs, run `NEMU_HOME=$PWD bash ./scripts/bump_configs.sh` when practical and report if it was not run.
+
+## Module-To-Validation Guide
+
+- **ci-harness**: `git diff --check`, syntax checks for changed scripts, focused dry-run/smoke when available.
+- **build-config**: target defconfig, build, and `scripts/bump_configs.sh`.
+- **monitor-loader**: image/checkpoint load smoke and Linux DiffTest smoke.
+- **cpu-core**: build plus Linux DiffTest smoke.
+- **riscv64-isa**: build plus Linux DiffTest smoke; add focused workload for CSR/MMU/vector/interrupt if the change is local to one feature.
+- **memory**: build plus Linux DiffTest smoke; checkpoint or large-image smoke if load/size behavior changes.
+- **device**: Linux boot or device-specific workload plus Linux DiffTest smoke.
+- **checkpoint**: take/restore smoke when possible, plus Linux DiffTest smoke if execution behavior changes.
+- **docs-only**: `git diff --check`; no execution smoke is required unless examples or commands are generated and should be validated.
+
+## Agent Editing Rules
+
+1. Identify the module before editing.
+2. Keep each commit inside one module boundary.
+3. If a change appears to require multiple modules, split it or explain the exception in `Constraint:`.
+4. Prefer existing NEMU configuration, Makefile, and script patterns.
+5. Verification claims must name exact commands and results.

--- a/agent/skills/nemu-delivery-standard.md
+++ b/agent/skills/nemu-delivery-standard.md
@@ -7,6 +7,8 @@ description: Enforce local AI-agent delivery standards for NEMU changes, requiri
 
 Use this skill before handing off NEMU code or harness changes.
 
+Use `agent/architecture.md` as the source of truth for module boundaries and execution-sensitive data flows.
+
 ## Commit Scope
 
 Each AI-authored commit must modify only one NEMU module. If a task needs multiple modules, split it into stacked commits or stacked PRs.

--- a/agent/skills/nemu-delivery-standard.md
+++ b/agent/skills/nemu-delivery-standard.md
@@ -1,0 +1,116 @@
+---
+name: nemu-delivery-standard
+description: Enforce local AI-agent delivery standards for NEMU changes, requiring a NEMU DiffTest-with-Spike Linux smoke run before handoff whenever the change can affect build, execution, CI, DiffTest, checkpoint, memory, device, or RISC-V behavior.
+---
+
+# NEMU Delivery Standard
+
+Use this skill before handing off NEMU code or harness changes.
+
+## Commit Scope
+
+Each AI-authored commit must modify only one NEMU module. If a task needs multiple modules, split it into stacked commits or stacked PRs.
+
+Use the module boundaries listed in `agent/skills/nemu-harness.md`.
+
+Allowed cross-module exceptions in one commit:
+
+- a public interface change plus its direct implementation in the same module family, such as `include/memory/` with `src/memory/`
+- a test or CI harness update that verifies the same module change
+- mechanical rename/move with no behavior change
+
+When using an exception, explain it in the commit body with `Constraint:`.
+
+## Commit Format
+
+Every AI-authored commit must use NEMU's existing Conventional Commit title style plus the repository Lore trailers:
+
+```text
+<type>(<scope>): <imperative intent>
+
+<commit introduction: module boundary, motivation, and expected unchanged behavior>
+
+Constraint: <external constraint or module boundary that shaped the change>
+Rejected: <alternative considered> | <reason>
+Confidence: <low|medium|high>
+Scope-risk: <narrow|moderate|broad>
+Directive: <future-maintainer guidance>
+Tested: <commands actually run>
+Not-tested: <known verification gaps>
+```
+
+Allowed `type` values for AI-authored commits:
+
+- `fix`: correct wrong behavior
+- `feat`: add supported behavior or coverage
+- `perf`: improve performance without changing behavior
+- `refactor`: restructure without intended behavior change
+- `test`: add or adjust tests only
+- `ci`: change CI or automation
+- `docs`: change documentation or agent guidance
+- `chore`: mechanical maintenance that does not fit the above
+
+The `scope` must be a NEMU module name or a well-established local scope, for example `ci`, `agent`, `checkpoint`, `difftest`, `monitor`, `riscv64`, `memory`, `device`, `tcache`, or `Makefile`.
+
+The title must be imperative, lower-case after the colon, and specific. Good examples:
+
+- `fix(difftest): preserve store queue bounds during replay`
+- `ci(agent): document NEMU delivery gates`
+- `docs(agent): define AI commit boundaries`
+
+Bad examples:
+
+- `fix`
+- `update files`
+- `misc changes`
+- `Document agent maintenance standards for NEMU`
+
+The commit introduction/body must state:
+
+- the touched module
+- why the change is needed
+- why it belongs in one commit
+- what behavior is expected to stay unchanged
+
+## Required Gate
+
+For any change that can affect NEMU build, execution, CI, DiffTest, checkpoint restore, memory, devices, or RISC-V behavior, the delivery claim must include a local Linux smoke run under NEMU DiffTest with Spike.
+
+Default command shape:
+
+```bash
+NEMU_HOME=$PWD make riscv64-xs-diff-spike_defconfig
+NEMU_HOME=$PWD make -j"$(nproc)"
+make init-ready-to-run
+./build/riscv64-nemu-interpreter \
+  -b --diff ./ready-to-run/spike-xiangshan-ref.so \
+  ./workloads/linux/hello/fw_payload.bin
+```
+
+If the workload directory is not initialized, first use the repository's normal workload setup path from CI or `make init-ready-to-run` as applicable. Do not silently substitute a non-Linux bare-metal test for this required gate.
+
+## Acceptable Result
+
+The Linux smoke passes when NEMU exits without a DiffTest mismatch, crash, assertion, or bad trap. Capture the exact command and the relevant final output in the handoff.
+
+## When It Cannot Run
+
+If the local environment lacks workloads, ready-to-run artifacts, Spike shared object, compiler, or time budget, report this as `Not-tested` with the exact blocker and run the strongest available fallback:
+
+- `git diff --check`
+- `bash -n` for changed shell scripts
+- `python3 -m py_compile` for changed Python scripts
+- `NEMU_HOME=$PWD make <changed defconfig>` for config-sensitive changes
+- focused unit/smoke command relevant to the changed subsystem
+
+Do not claim the change is fully delivered if the NEMU DiffTest-with-Spike Linux smoke was skipped.
+
+## Handoff Wording
+
+Always state:
+
+- the branch and commit
+- the touched module and commit introduction
+- the Linux DiffTest smoke command and result, or the blocker
+- any weaker fallback checks that ran
+- remaining risk if the required gate did not run

--- a/agent/skills/nemu-harness.md
+++ b/agent/skills/nemu-harness.md
@@ -12,6 +12,8 @@ Use this skill when changing NEMU automation surfaces rather than ISA behavior i
 - DiffTest harness code, ref shared-object runner, checkpoint restore scripts
 - agent-facing maintenance instructions for this repository
 
+Before editing, read `agent/architecture.md` to classify the touched module and understand the relevant data flow.
+
 ## Operating Rules
 
 1. Start from the current checkout, not memory. Inspect branch, dirty files, and relevant scripts before editing.

--- a/agent/skills/nemu-harness.md
+++ b/agent/skills/nemu-harness.md
@@ -1,0 +1,84 @@
+---
+name: nemu-harness
+description: Maintain NEMU automation and verification harnesses, including DiffTest runner scripts, ready-to-run setup, checkpoint restore flows, CI workload coverage, and AI-agent-safe maintenance workflows for this repository.
+---
+
+# NEMU Harness
+
+Use this skill when changing NEMU automation surfaces rather than ISA behavior itself:
+
+- GitHub Actions, workload runners, or helper scripts
+- `init-ready-to-run`, `ready-to-run`, Spike/NEMU reference setup
+- DiffTest harness code, ref shared-object runner, checkpoint restore scripts
+- agent-facing maintenance instructions for this repository
+
+## Operating Rules
+
+1. Start from the current checkout, not memory. Inspect branch, dirty files, and relevant scripts before editing.
+2. Keep harness changes split by review topic: dependency/auth setup, runner structure, parallelism/logging, and new workload coverage should be separate commits or stacked PRs.
+3. Do not mix emulator behavior fixes with harness-only changes unless the failing harness exposes a real NEMU bug and the user asked to fix both.
+4. Preserve reproducibility: every random workload selection needs an explicit seed, manifest, and enough log output to identify the failing case.
+5. Prefer repo scripts and defconfigs over ad hoc shell fragments in workflows.
+
+## File Map
+
+- `.github/workflows/ci.yml`: required CI jobs for build, basic boot, DiffTest, performance, and workload coverage.
+- `.github/workflows/build.yml`: shared-object build checks.
+- `scripts/init-ready-to-run.py`: fetches ready-to-run artifacts and GitHub release metadata.
+- `scripts/ready-to-run.mk`: Makefile integration for ready-to-run setup.
+- `scripts/bump_configs.sh`: canonical config refresh check used by CI.
+- `scripts/compilation-test.sh`: all-config compilation check.
+- `tools/ref-so-runner/`: minimal host-side runner for `riscv64-nemu-interpreter-so`.
+- `docs/ref_so_runner.md`: documented ref shared-object runner behavior.
+- `include/cpu/difftest.h`: shared DiffTest declarations.
+- `src/cpu/difftest/dut.c`: DUT-side DiffTest control.
+- `src/cpu/difftest/ref.c`: reference-side DiffTest dynamic loading and calls.
+- `src/monitor/monitor.c`: CLI flags, image loading, checkpoint options, DiffTest initialization.
+- `src/isa/riscv64/difftest/dut.c`: RISC-V architectural state comparison.
+- `src/isa/riscv64/difftest/ref.c`: RISC-V reference shared-object API implementation.
+- `src/isa/riscv64/include/isa-def.h`: CPU state layout; the DiffTest synchronized region is marked in comments.
+- `resource/gcpt_restore/`: GCPT restore program source.
+- `scripts/take_zstd.sh`, `scripts/restore_zstd.sh`: zstd checkpoint smoke flows.
+- `scripts/checkpoint_example/`: checkpoint and profiling examples.
+- `src/checkpoint/`: checkpoint serializer and metadata code.
+- `src/monitor/image_loader.c`: image/checkpoint loading and decompression limits.
+
+## Module Boundaries
+
+- **build-config**: `Makefile`, `Kconfig`, `configs/`, `scripts/*.mk`.
+- **ci-harness**: `.github/`, runner scripts under `scripts/`, `tools/ref-so-runner/`, `agent/`.
+- **monitor-loader**: `src/monitor/`.
+- **cpu-core**: `src/cpu/`, `include/cpu/`.
+- **riscv64-isa**: `src/isa/riscv64/`.
+- **memory**: `src/memory/`, `include/memory/`.
+- **device**: `src/device/`, `include/device/`.
+- **checkpoint**: `src/checkpoint/`, `include/checkpoint/`, `resource/gcpt_restore/`, checkpoint scripts.
+- **profiling**: `src/profiling/`, `include/profiling/`, profiling tools/docs.
+- **docs-only**: documentation and agent guidance.
+
+One commit should stay inside one module boundary unless it is a direct interface+implementation pair, a same-change test/CI update, or a pure mechanical move.
+
+## Standard Workflow
+
+1. Discover current state:
+   - `git status --short --branch`
+   - inspect `.github/workflows/*.yml`, relevant `scripts/*.sh`, `scripts/*.py`, and `docs/*.md`
+   - search with `grep -RIn` if `rg` is unavailable
+2. Edit narrowly:
+   - use `apply_patch`
+   - keep script options documented in `usage()`
+   - keep CI env names explicit and stable
+3. Verify in layers:
+   - shell scripts: `bash -n <script>`
+   - Python scripts: `python3 -m py_compile <script>`
+   - workflow/script diffs: `git diff --check`
+   - config changes: `NEMU_HOME=$PWD make <defconfig>` and `NEMU_HOME=$PWD bash ./scripts/bump_configs.sh`
+   - runner behavior: use dry-run or small local smoke before full workload jobs
+4. Report what was actually run and what remains untested.
+
+## Harness Boundaries
+
+- NEMU-as-DUT with Spike uses `./build/riscv64-nemu-interpreter -b --diff <spike-so> <image>`.
+- NEMU-as-reference shared object is `./build/riscv64-nemu-interpreter-so`.
+- Checkpoint restore tests must use the matching restorer for the checkpoint corpus when one exists.
+- Required CI should avoid private machine assumptions unless the job is explicitly pinned to a self-hosted runner and guarded for fork PRs.


### PR DESCRIPTION
This PR adds repository-local guidance for AI-assisted NEMU maintenance under `agent/`.

It introduces:

- `agent/skills/nemu-harness.md`
  - maps NEMU harness-related entry points such as CI, ready-to-run, DiffTest, checkpoint restore, and ref-so-runner
  - defines module boundaries for keeping agent-authored commits narrow

- `agent/skills/nemu-delivery-standard.md`
  - requires AI-authored commits to stay within one NEMU module unless a narrow exception is explained
  - documents the expected NEMU commit format: `type(scope): intent` plus Lore trailers
  - defines the expected Linux + Spike DiffTest smoke gate for execution-sensitive changes

- `agent/architecture.md`
  - summarizes NEMU startup, execution, DiffTest, memory, checkpoint, device, build/config, and CI architecture
  - gives agents a first-read architecture map before editing code

This PR is documentation-only and does not change executable NEMU behavior.

Tested:
- `git diff --check`

Not-tested:
- Loading these documents through an external AI-agent runtime
- Linux DiffTest smoke, because this PR only documents maintenance standards