### PR TITLE
feat(checkpoint): expose explicit checkpoint control for SHARE

### DIFF
--- a/include/checkpoint/serializer.h
+++ b/include/checkpoint/serializer.h
@@ -57,6 +57,8 @@ class Serializer
 
     void serializeRegs(uint8_t* serialize_base_addr);
 
+    void setStoreCptInFlash(bool enable);
+
     explicit Serializer();
 #ifdef CONFIG_LIBCHECKPOINT_RESTORER
     void init(bool store_cpt_in_flash, bool enable_libcheckpoint);

--- a/src/checkpoint/serializer.cpp
+++ b/src/checkpoint/serializer.cpp
@@ -504,6 +504,10 @@ void Serializer::serialize(uint64_t inst_count, const char *checkpoint_base_path
 #endif
 }
 
+void Serializer::setStoreCptInFlash(bool enable) {
+  store_cpt_in_flash = enable;
+}
+
 #ifdef CONFIG_LIBCHECKPOINT_RESTORER
 
 #define USING_METADATA_OVERRIDE_DEFAULT_MEMLAYOUT(variable_name) \
@@ -660,6 +664,14 @@ bool try_take_cpt(uint64_t icount) {
 
 void serialize_reg_to_mem() {
   serializer.serializeRegs(get_pmem());
+}
+
+void set_store_cpt_in_flash(bool enable) {
+  serializer.setStoreCptInFlash(enable);
+}
+
+void serialize_checkpoint(const char *base_filepath) {
+  serializer.serialize(0, base_filepath);
 }
 
 }


### PR DESCRIPTION
Expose C entry points so SHARE users can request checkpoint serialization with a caller-provided output prefix and select the flash checkpoint layout explicitly.