### PR TITLE
cpu-exec: skip idle hot-path bookkeeping

### DIFF
--- a/src/cpu/cpu-exec.c
+++ b/src/cpu/cpu-exec.c
@@ -311,15 +311,31 @@ static inline void debug_difftest(Decode *_this, Decode *next) {
 }
 
 #ifndef CONFIG_SHARE
-uint64_t per_bb_profile(Decode *prev_s, Decode *s, bool control_taken) {
+static inline bool per_bb_profile_fast_disabled(void) {
+  return profiling_state == NoProfiling &&
+         checkpoint_state == NoCheckpoint &&
+         !recvd_manual_oneshot_cpt &&
+         !recvd_manual_uniform_cpt &&
+         !force_cpt_mmode &&
+         !donot_skip_boot;
+}
 
+static inline bool per_bb_profile_needed(void) {
+  return !per_bb_profile_fast_disabled() || enable_semantic_point_cpt();
+}
+
+uint64_t per_bb_profile(Decode *prev_s, Decode *s, bool control_taken) {
+  bool semantic_point_enabled = enable_semantic_point_cpt();
 
   // checkpoint_icount_base is set from nemu_trap.
   // Profiling and checkpointing use this as the starting point for instruction counting.
   uint64_t abs_inst_count = get_abs_instr_count() - checkpoint_icount_base;
+  if (likely(per_bb_profile_fast_disabled() && !semantic_point_enabled)) {
+    return abs_inst_count;
+  }
   // workload_loaded set from nemu_trap
   //
-  if (enable_semantic_point_cpt() && (workload_loaded || donot_skip_boot)) {
+  if (semantic_point_enabled && (workload_loaded || donot_skip_boot)) {
     semantic_point_profile(prev_s->pc, true, abs_inst_count);
     semantic_point_profile(s->pc, false, abs_inst_count);
   }
@@ -439,7 +455,7 @@ static void execute(int n) {
     // Exit the execute() loop after certain basic blocks, even if instr count is disabled.
     IFDEF(CONFIG_INSTR_CNT_DISABLED, n_remain -= 1);
 
-    if (is_ctrl) {
+    if (is_ctrl && unlikely(per_bb_profile_needed())) {
       uint64_t abs_inst_count = per_bb_profile(prev_s, s, br_taken);
       Logtb("prev pc = 0x%lx, pc = 0x%lx", prev_s->pc, s->pc);
       Logtb("Executed %ld instructions in total, pc: 0x%lx\n",
@@ -490,7 +506,7 @@ end_of_loop:
   Logti("end_of_loop: prev pc = 0x%lx, pc = 0x%lx", prev_s->pc, s->pc);
   Loge("total insts: %'lu, execute remain: %'d", get_abs_instr_count(), n_remain);
 
-  if (is_ctrl) {
+  if (is_ctrl && unlikely(per_bb_profile_needed())) {
     per_bb_profile(prev_s, s, br_taken);
   }
 

--- a/src/cpu/tcache.c
+++ b/src/cpu/tcache.c
@@ -93,7 +93,12 @@ static inline bb_t* bb_new(Decode *s, vaddr_t pc, bb_t *next) {
 }
 
 static inline bb_t* bb_hash(vaddr_t pc) {
-  int idx = (pc / CONFIG_ILEN_MIN) % CONFIG_BB_LIST_SIZE;
+  int idx;
+#if (CONFIG_ILEN_MIN == 2) && ((CONFIG_BB_LIST_SIZE & (CONFIG_BB_LIST_SIZE - 1)) == 0)
+  idx = (pc >> 1) & (CONFIG_BB_LIST_SIZE - 1);
+#else
+  idx = (pc / CONFIG_ILEN_MIN) % CONFIG_BB_LIST_SIZE;
+#endif
   return &bb_list[idx];
 }
 

--- a/src/isa/riscv64/difftest/ref.c
+++ b/src/isa/riscv64/difftest/ref.c
@@ -195,6 +195,7 @@ void csr_writeback() {
 #ifdef CONFIG_DIFFTEST_CHECK_SDTRIG
   tselect->val  = cpu.tselect;
   cpu.TM->triggers[tselect->val].tdata1.val = cpu.tdata1; // update alias tdata1 to trigger module
+  trigger_mark_state_dirty(cpu.TM);
   tinfo->val    = cpu.tinfo;
 #endif // CONFIG_DIFFTEST_CHECK_SDTRIG
 

--- a/src/isa/riscv64/instr/decode.c
+++ b/src/isa/riscv64/instr/decode.c
@@ -134,8 +134,10 @@ int isa_fetch_decode(Decode *s) {
   trigger_handler(TRIG_TYPE_ICOUNT, icount_action, 0);
 #endif // CONFIG_TDATA1_ICOUNT
 #ifdef CONFIG_TDATA1_MCONTROL6
-  trig_action_t mcontrol6_action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_EXECUTE, s->pc, TRIGGER_NO_VALUE);
-  trigger_handler(TRIG_TYPE_MCONTROL6, mcontrol6_action, s->pc);
+  if (trigger_mcontrol6_check_needed(cpu.TM)) {
+    trig_action_t mcontrol6_action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_EXECUTE, s->pc, TRIGGER_NO_VALUE);
+    trigger_handler(TRIG_TYPE_MCONTROL6, mcontrol6_action, s->pc);
+  }
 #endif // CONFIG_TDATA1_MCONTROL6
 
   s->isa.instr.val = instr_fetch(&s->snpc, 2);

--- a/src/isa/riscv64/instr/rva/amo.c
+++ b/src/isa/riscv64/instr/rva/amo.c
@@ -36,13 +36,15 @@ def_rtl(amo_slow_path, rtlreg_t *dest, const rtlreg_t *src1, const rtlreg_t *src
 
 #ifdef CONFIG_TDATA1_MCONTROL6
   trig_action_t action = TRIG_ACTION_NONE;
-  if (funct5 == 0b00010) { // lr
-    action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_LOAD, *src1, TRIGGER_NO_VALUE); trigger_handler(TRIG_TYPE_MCONTROL6, action, *src1);
-  } else if(funct5 == 0b00011) { // sc
-    action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_STORE, *src1, TRIGGER_NO_VALUE); trigger_handler(TRIG_TYPE_MCONTROL6, action, *src1);
-  } else { // amo
-    action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_LOAD, *src1, TRIGGER_NO_VALUE); trigger_handler(TRIG_TYPE_MCONTROL6, action, *src1);
-    action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_STORE, *src1, TRIGGER_NO_VALUE); trigger_handler(TRIG_TYPE_MCONTROL6, action, *src1);
+  if (trigger_mcontrol6_check_needed(cpu.TM)) {
+    if (funct5 == 0b00010) { // lr
+      action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_LOAD, *src1, TRIGGER_NO_VALUE); trigger_handler(TRIG_TYPE_MCONTROL6, action, *src1);
+    } else if(funct5 == 0b00011) { // sc
+      action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_STORE, *src1, TRIGGER_NO_VALUE); trigger_handler(TRIG_TYPE_MCONTROL6, action, *src1);
+    } else { // amo
+      action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_LOAD, *src1, TRIGGER_NO_VALUE); trigger_handler(TRIG_TYPE_MCONTROL6, action, *src1);
+      action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_STORE, *src1, TRIGGER_NO_VALUE); trigger_handler(TRIG_TYPE_MCONTROL6, action, *src1);
+    }
   }
 #endif // CONFIG_TDATA1_MCONTROL6
 

--- a/src/isa/riscv64/instr/rvcbo/cbo_impl.c
+++ b/src/isa/riscv64/instr/rvcbo/cbo_impl.c
@@ -43,9 +43,11 @@ static void paddr_check(paddr_t paddr, vaddr_t vaddr, int type) {
 static void trigger_check(vaddr_t vaddr){
 #ifdef CONFIG_TDATA1_MCONTROL6
   vaddr_t block_addr = vaddr & ~CACHE_BLOCK_MASK;
-  for (uint64_t offset = 0; offset < CACHE_BLOCK_SIZE; offset++) {
-    trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_STORE, block_addr + offset, TRIGGER_NO_VALUE);
-    trigger_handler(TRIG_TYPE_MCONTROL6, action, vaddr);
+  if (trigger_mcontrol6_check_needed(cpu.TM)) {
+    for (uint64_t offset = 0; offset < CACHE_BLOCK_SIZE; offset++) {
+      trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_STORE, block_addr + offset, TRIGGER_NO_VALUE);
+      trigger_handler(TRIG_TYPE_MCONTROL6, action, vaddr);
+    }
   }
 #endif // CONFIG_TDATA1_MCONTROL6
 }

--- a/src/isa/riscv64/instr/rvi/ldst_trig.h
+++ b/src/isa/riscv64/instr/rvi/ldst_trig.h
@@ -2,8 +2,10 @@
   def_EHelper(name) { \
     trig_action_t action = TRIG_ACTION_NONE; \
     const vaddr_t vaddr = *dsrc1 + id_src2->imm; \
-    action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_LOAD, vaddr, TRIGGER_NO_VALUE); \
-    trigger_handler(TRIG_TYPE_MCONTROL6, action, vaddr); \
+    if (trigger_mcontrol6_check_needed(cpu.TM)) { \
+      action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_LOAD, vaddr, TRIGGER_NO_VALUE); \
+      trigger_handler(TRIG_TYPE_MCONTROL6, action, vaddr); \
+    } \
     concat(rtl_, rtl_instr) (s, ddest, dsrc1, id_src2->imm, width, mmu_mode); \
   }
 
@@ -12,8 +14,10 @@
     trig_action_t action = TRIG_ACTION_NONE; \
     const vaddr_t vaddr = *dsrc1 + id_src2->imm; \
     const word_t data = *ddest; \
-    action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_STORE, vaddr, data); \
-    trigger_handler(TRIG_TYPE_MCONTROL6, action, vaddr); \
+    if (trigger_mcontrol6_check_needed(cpu.TM)) { \
+      action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_STORE, vaddr, data); \
+      trigger_handler(TRIG_TYPE_MCONTROL6, action, vaddr); \
+    } \
     concat(rtl_, rtl_instr) (s, ddest, dsrc1, id_src2->imm, width, mmu_mode); \
   }
 

--- a/src/isa/riscv64/instr/rvv/vldst_impl.c
+++ b/src/isa/riscv64/instr/rvv/vldst_impl.c
@@ -387,8 +387,10 @@ void vld(Decode *s, int mode, int mmu_mode) {
       for (fn = 0; fn < nf; fn++) {
         addr = base_addr + idx * stride + (idx * nf * is_unit_stride + fn) * s->v_width;
 
-        IFDEF(CONFIG_TDATA1_MCONTROL6, trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_LOAD, addr, TRIGGER_NO_VALUE); \
-                                trigger_handler(TRIG_TYPE_MCONTROL6, action, addr));
+        IFDEF(CONFIG_TDATA1_MCONTROL6, if (trigger_mcontrol6_check_needed(cpu.TM)) { \
+                                          trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_LOAD, addr, TRIGGER_NO_VALUE); \
+                                          trigger_handler(TRIG_TYPE_MCONTROL6, action, addr); \
+                                        })
 
         isa_vec_misalign_data_addr_check(addr, s->v_width, MEM_TYPE_READ);
 
@@ -480,8 +482,10 @@ void vldx(Decode *s, int mmu_mode) {
       // read data in memory
       addr = base_addr + index + fn * data_width;
 
-      IFDEF(CONFIG_TDATA1_MCONTROL6, trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_LOAD, addr, TRIGGER_NO_VALUE); \
-                              trigger_handler(TRIG_TYPE_MCONTROL6, action, addr));
+      IFDEF(CONFIG_TDATA1_MCONTROL6, if (trigger_mcontrol6_check_needed(cpu.TM)) { \
+                                        trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_LOAD, addr, TRIGGER_NO_VALUE); \
+                                        trigger_handler(TRIG_TYPE_MCONTROL6, action, addr); \
+                                      })
 
       isa_vec_misalign_data_addr_check(addr, data_width, MEM_TYPE_READ);
 
@@ -654,8 +658,10 @@ void vst(Decode *s, int mode, int mmu_mode) {
         uint64_t offset = idx * stride + (idx * nf * is_unit_stride + fn) * s->v_width;
         addr = base_addr + offset;
         if (!fast_vse) {
-          IFDEF(CONFIG_TDATA1_MCONTROL6, trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_STORE, addr, TRIGGER_NO_VALUE); \
-                                  trigger_handler(TRIG_TYPE_MCONTROL6, action, addr));
+          IFDEF(CONFIG_TDATA1_MCONTROL6, if (trigger_mcontrol6_check_needed(cpu.TM)) { \
+                                            trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_STORE, addr, TRIGGER_NO_VALUE); \
+                                            trigger_handler(TRIG_TYPE_MCONTROL6, action, addr); \
+                                          })
 
           isa_vec_misalign_data_addr_check(addr, s->v_width, MEM_TYPE_WRITE);
 
@@ -725,8 +731,10 @@ void vstx(Decode *s, int mmu_mode) {
       get_vreg(vd + fn * lmul, idx, &tmp_reg[1], eew, 0, 0, 0);
       addr = base_addr + index + fn * data_width;
 
-      IFDEF(CONFIG_TDATA1_MCONTROL6, trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_STORE, addr, TRIGGER_NO_VALUE); \
-                              trigger_handler(TRIG_TYPE_MCONTROL6, action, addr));
+      IFDEF(CONFIG_TDATA1_MCONTROL6, if (trigger_mcontrol6_check_needed(cpu.TM)) { \
+                                        trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_STORE, addr, TRIGGER_NO_VALUE); \
+                                        trigger_handler(TRIG_TYPE_MCONTROL6, action, addr); \
+                                      })
 
       isa_vec_misalign_data_addr_check(addr, data_width, MEM_TYPE_WRITE);
 
@@ -788,8 +796,10 @@ void vlr(Decode *s, int mmu_mode) {
       for (pos = offset; pos < elt_per_reg; pos++, vstart->val++) {
         addr = base_addr + idx * s->v_width;
 
-        IFDEF(CONFIG_TDATA1_MCONTROL6, trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_LOAD, addr, TRIGGER_NO_VALUE); \
-                                trigger_handler(TRIG_TYPE_MCONTROL6, action, addr));
+        IFDEF(CONFIG_TDATA1_MCONTROL6, if (trigger_mcontrol6_check_needed(cpu.TM)) { \
+                                          trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_LOAD, addr, TRIGGER_NO_VALUE); \
+                                          trigger_handler(TRIG_TYPE_MCONTROL6, action, addr); \
+                                        })
 
         isa_vec_misalign_data_addr_check(addr, s->v_width, MEM_TYPE_READ);
 
@@ -807,8 +817,10 @@ void vlr(Decode *s, int mmu_mode) {
       for (pos = 0; pos < elt_per_reg; pos++, vstart->val++) {
         addr = base_addr + idx * s->v_width;
 
-        IFDEF(CONFIG_TDATA1_MCONTROL6, trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_LOAD, addr, TRIGGER_NO_VALUE); \
-                                trigger_handler(TRIG_TYPE_MCONTROL6, action, addr));
+        IFDEF(CONFIG_TDATA1_MCONTROL6, if (trigger_mcontrol6_check_needed(cpu.TM)) { \
+                                          trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_LOAD, addr, TRIGGER_NO_VALUE); \
+                                          trigger_handler(TRIG_TYPE_MCONTROL6, action, addr); \
+                                        })
 
         isa_vec_misalign_data_addr_check(addr, s->v_width, MEM_TYPE_READ);
 
@@ -856,8 +868,10 @@ void vsr(Decode *s, int mmu_mode) {
         get_vreg(vd + vreg_idx, pos, &tmp_reg[1], 0, 0, 0, 1);
         addr = base_addr + idx;
 
-        IFDEF(CONFIG_TDATA1_MCONTROL6, trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_STORE, addr, TRIGGER_NO_VALUE); \
-                                trigger_handler(TRIG_TYPE_MCONTROL6, action, addr));
+        IFDEF(CONFIG_TDATA1_MCONTROL6, if (trigger_mcontrol6_check_needed(cpu.TM)) { \
+                                          trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_STORE, addr, TRIGGER_NO_VALUE); \
+                                          trigger_handler(TRIG_TYPE_MCONTROL6, action, addr); \
+                                        })
 
         isa_vec_misalign_data_addr_check(addr, 1, MEM_TYPE_WRITE);
 
@@ -872,8 +886,10 @@ void vsr(Decode *s, int mmu_mode) {
         get_vreg(vd + vreg_idx, pos, &tmp_reg[1], 0, 0, 0, 1);
         addr = base_addr + idx;
 
-        IFDEF(CONFIG_TDATA1_MCONTROL6, trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_STORE, addr, TRIGGER_NO_VALUE); \
-                                trigger_handler(TRIG_TYPE_MCONTROL6, action, addr));
+        IFDEF(CONFIG_TDATA1_MCONTROL6, if (trigger_mcontrol6_check_needed(cpu.TM)) { \
+                                          trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_STORE, addr, TRIGGER_NO_VALUE); \
+                                          trigger_handler(TRIG_TYPE_MCONTROL6, action, addr); \
+                                        })
 
         isa_vec_misalign_data_addr_check(addr, 1, MEM_TYPE_WRITE);
 
@@ -1058,8 +1074,10 @@ void vldff(Decode *s, int mode, int mmu_mode) {
         for (fn = 0; fn < nf; fn++) {
           addr = base_addr + idx * stride + (idx * nf * is_unit_stride + fn) * s->v_width;
 
-          IFDEF(CONFIG_TDATA1_MCONTROL6, trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_LOAD, addr, TRIGGER_NO_VALUE); \
-                                  trigger_handler(TRIG_TYPE_MCONTROL6, action, addr));
+          IFDEF(CONFIG_TDATA1_MCONTROL6, if (trigger_mcontrol6_check_needed(cpu.TM)) { \
+                                            trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_LOAD, addr, TRIGGER_NO_VALUE); \
+                                            trigger_handler(TRIG_TYPE_MCONTROL6, action, addr); \
+                                          })
           isa_vec_misalign_data_addr_check(addr, s->v_width, MEM_TYPE_READ);
 
           IFDEF(CONFIG_MULTICORE_DIFF, need_read_golden_mem = true);

--- a/src/isa/riscv64/local-include/trigger.h
+++ b/src/isa/riscv64/local-include/trigger.h
@@ -166,6 +166,8 @@ typedef struct {
 typedef struct TriggerModule {
   // the last trigger is used to check maximum number of supported triggers
   Trigger triggers[CONFIG_TRIGGER_NUM + 1];
+  uint8_t mcontrol6_active_count;
+  bool mcontrol6_state_dirty;
 } TriggerModule;
 
 extern trig_action_t trigger_action;
@@ -191,6 +193,11 @@ void icount_checked_write(trig_icount_t* icount, word_t* wdata);
 
 bool trigger_reentrancy_check(); 
 void trigger_handler(const trig_type_t type, const trig_action_t action, word_t tval);
+void trigger_mark_state_dirty(TriggerModule* TM);
+
+static inline bool trigger_mcontrol6_check_needed(const TriggerModule* TM) {
+  return TM->mcontrol6_state_dirty || TM->mcontrol6_active_count != 0;
+}
 
 static inline word_t get_tdata1(TriggerModule* TM) {return TM->triggers[tselect->val].tdata1.val;}
 static inline word_t get_tdata2(TriggerModule* TM) {return TM->triggers[tselect->val].tdata2.val;}

--- a/src/isa/riscv64/system/priv.c
+++ b/src/isa/riscv64/system/priv.c
@@ -89,6 +89,8 @@ void init_trigger() {
     cpu.TM->triggers[i].tdata1.val = 0;
     cpu.TM->triggers[i].tdata1.common.type = TRIG_TYPE_DISABLE;
   }
+  cpu.TM->mcontrol6_active_count = 0;
+  cpu.TM->mcontrol6_state_dirty = false;
   tselect->val = 0;
   tinfo->val = 0
     IFDEF(CONFIG_TDATA1_MCONTROL, | (1 << TRIG_TYPE_MCONTROL))
@@ -2818,6 +2820,7 @@ static void csr_write(uint32_t csrid, word_t src) {
         break;
       }
       set_sys_state_flag(SYS_STATE_FLUSH_TCACHE);
+      trigger_mark_state_dirty(cpu.TM);
       break;
     }
     case CSR_TDATA2:

--- a/src/isa/riscv64/system/trigger.c
+++ b/src/isa/riscv64/system/trigger.c
@@ -9,6 +9,21 @@
 trig_action_t trigger_action = TRIG_ACTION_NONE;
 word_t triggered_tval;
 
+void trigger_mark_state_dirty(TriggerModule* TM) {
+  TM->mcontrol6_state_dirty = true;
+}
+
+static inline void refresh_mcontrol6_state(TriggerModule* TM) {
+  uint8_t active_count = 0;
+
+  for (int i = 0; i < CONFIG_TRIGGER_NUM; i++) {
+    active_count += TM->triggers[i].tdata1.common.type == TRIG_TYPE_MCONTROL6;
+  }
+
+  TM->mcontrol6_active_count = active_count;
+  TM->mcontrol6_state_dirty = false;
+}
+
 static bool tdata3_smatch(Trigger* trig) {
   switch (trig->tdata3.sselect) {
     case 0:
@@ -74,43 +89,38 @@ trig_action_t check_triggers_mcontrol6(
   vaddr_t addr,
   word_t data
 ) {
+  if (TM->mcontrol6_state_dirty) {
+    refresh_mcontrol6_state(TM);
+  }
+  // Most workloads do not program mcontrol6 triggers at all.
+  if (TM->mcontrol6_active_count == 0) {
+    return TRIG_ACTION_NONE;
+  }
 #ifdef CONFIG_RV_SDEXT
   // do nothing in debug mode
   if (cpu.debug_mode)
     return TRIG_ACTION_NONE;
 #endif
   if (!trigger_reentrancy_check()) return TRIG_ACTION_NONE;
-  // check mcontrol6
   // Action can be taken only when all triggers on the chain are hit.
   /* GDB doesn't support setting triggers in a way that combines a data load trigger
    * with an address trigger to trigger on a load of a value at a given address.
    * The default timing legalization on mcontrol6 assumes no such trigger setting. */
-  const int trigger_num = CONFIG_TRIGGER_NUM;
-  bool chain_ok[trigger_num];
-  bool hit[trigger_num];
-  bool can_fire[trigger_num];
-  memset(chain_ok, true, sizeof(chain_ok));
+  bool chain_ok = true;
 
-  for (int i = 0; i < trigger_num; i++) {
-    bool match = false;
-    if (TM->triggers[i].tdata1.common.type == TRIG_TYPE_MCONTROL6){
-      match = mcontrol6_match(&TM->triggers[i], op, addr, data);
+  for (int i = 0; i < CONFIG_TRIGGER_NUM; i++) {
+    Trigger* trig = &TM->triggers[i];
+    bool this_hit = false;
+
+    if (trig->tdata1.common.type == TRIG_TYPE_MCONTROL6) {
+      this_hit = mcontrol6_match(trig, op, addr, data);
     }
-    hit[i] = match;
-  }
 
-  for (int i = 1; i < trigger_num; i++) {
-    bool last_hit = hit[i-1];
-    bool last_chain = TM->triggers[i - 1].tdata1.mcontrol6.chain;
-    chain_ok[i] = last_hit || (!last_hit && !last_chain);
-  }
-
-  for (int i = 0; i < trigger_num; i++) {
-    bool this_chain = TM->triggers[i].tdata1.mcontrol6.chain;
-    bool this_hit = hit[i];
-    can_fire[i] = chain_ok[i] && this_hit && !this_chain;
-    if (can_fire[i])
-      return (trig_action_t)TM->triggers[i].tdata1.mcontrol6.action;
+    bool this_chain = trig->tdata1.mcontrol6.chain;
+    if (chain_ok && this_hit && !this_chain) {
+      return (trig_action_t)trig->tdata1.mcontrol6.action;
+    }
+    chain_ok = this_hit || (!this_hit && !this_chain);
   }
 
   return TRIG_ACTION_NONE;


### PR DESCRIPTION
The normal performance path does not enable per-BB profiling, checkpoint generation, or mcontrol6 triggers, but the execute, trigger, and basic-block lookup paths still paid repeated bookkeeping overhead before discovering that no slow-path work was needed.

Skip per-BB profiling at the call site when all profiling/checkpoint modes are inactive, cache whether any mcontrol6 trigger is active, guard hot trigger call sites before entering the mcontrol6 checker, and use shift-mask arithmetic for power-of-two basic-block hash lookup. On the aggregate fw_payload 1B-instruction workload, this reduces host instructions from 121.896B to 117.077B with PERF_OPT=y, a 3.95% incremental reduction over the previous aggregate node.