### PR TITLE
feat(difftest): add checkpoint trigger entry

### DIFF
--- a/src/cpu/difftest/ref.c
+++ b/src/cpu/difftest/ref.c
@@ -405,3 +405,16 @@ void difftest_store_log_restore() {
 }
 #endif
 #endif // CONFIG_STORE_LOG
+
+extern void set_store_cpt_in_flash(bool enable);
+extern void serialize_checkpoint(const char *base_filepath);
+
+void difftest_trigger_checkpoint(const char *base_filepath) {
+  if (cpu.mode == 3) {
+    Log("Skipping M-mode checkpoint: mode=%lu, PC=0x%lx", cpu.mode, cpu.pc);
+    return;
+  }
+
+  set_store_cpt_in_flash(true);
+  serialize_checkpoint(base_filepath);
+}


### PR DESCRIPTION
Add difftest_trigger_checkpoint() so REF users can request checkpoint generation from NEMU.

Skip M-mode because the current checkpoint restore path does not reliably support restoring M-mode state. For supported modes, enable the flash checkpoint layout before serializing the checkpoint.