### PR TITLE
fix(image_loader): match prototypes with implementations

### DIFF
--- a/include/memory/image_loader.h
+++ b/include/memory/image_loader.h
@@ -19,11 +19,11 @@
 #include <stddef.h>
 
 
-long load_gz_img(const char *filename);
+long load_gz_img(const char *filename, uint8_t* load_start, size_t img_size);
 
-long load_zstd_img(const char *filename);
+long load_zstd_img(const char *filename, uint8_t* load_start, size_t img_size);
 
-long load_img(char *img_name, const char *which_img, uint8_t* load_start, size_t img_size);
+long load_img(const char *img_name, const char *which_img, uint8_t* load_start, size_t img_size);
 
 void fill_memory(const char* img_file, const char* flash_image, const char* cpt_image, int64_t* img_size, int64_t* flash_size);
 


### PR DESCRIPTION
The image loader header still declared old load_gz_img/load_zstd_img signatures and a non-const load_img path argument, while the implementations already take an explicit destination buffer and const input path.

Update the header before reusing load_img from flash.c, so new callers include the actual interface instead of stale prototypes.