### PR TITLE
perf(riscv64): static inline PMP/PMA CSR accessors

### DIFF
--- a/src/isa/riscv64/local-include/csr.h
+++ b/src/isa/riscv64/local-include/csr.h
@@ -2003,13 +2003,56 @@ void update_vstopi();
 #endif
 
 /** PMP **/
-uint8_t pmpcfg_from_index(int idx);
-word_t pmpaddr_from_index(int idx);
-word_t pmp_tor_mask();
+extern rtlreg_t csr_array[4096];
+
+#ifdef CONFIG_RV_PMP_CSR
+// get 8-bit config of one PMP entries by index.
+static inline uint8_t pmpcfg_from_index(int idx) {
+  // Nemu support up to 64 pmp entries in a XLEN=64 machine.
+  int xlen = 64;
+  // Configuration register of one entry is 8-bit.
+  int bits_per_cfg = 8;
+  // For RV64, one pmpcfg CSR contains configuration of 8 entries (64 / 8 = 8).
+  int cfgs_per_csr = xlen / bits_per_cfg;
+  // For RV64, only 8 even-numbered pmpcfg CSRs hold the configuration.
+  int pmpcfg_csr_addr = CSR_PMPCFG_BASE + idx / cfgs_per_csr * 2;
+
+  uint8_t *cfg_reg = (uint8_t *)&csr_array[pmpcfg_csr_addr];
+  return *(cfg_reg + (idx % cfgs_per_csr));
+}
+
+static inline word_t pmpaddr_from_index(int idx) {
+  return csr_array[CSR_PMPADDR_BASE + idx];
+}
+
+static inline word_t pmp_tor_mask() {
+  return -((word_t)1 << (CONFIG_PMP_GRANULARITY - PMP_SHIFT));
+}
+#endif // CONFIG_RV_PMP_CSR
 
 /** PMA */
-uint8_t pmacfg_from_index(int idx);
-word_t pmaaddr_from_index(int idx);
-word_t pma_tor_mask();
+#ifdef CONFIG_RV_PMA_CSR
+// get 8-bit config of one PMA entries by index.
+static inline uint8_t pmacfg_from_index(int idx) {
+  int xlen = 64;
+  // Configuration register of one entry is 8-bit.
+  int bits_per_cfg = 8;
+  // For RV64, one pmacfg CSR contains configuration of 8 entries (64 / 8 = 8).
+  int cfgs_per_csr = xlen / bits_per_cfg;
+  // For RV64, only 8 even-numbered pmacfg CSRs hold the configuration.
+  int pmacfg_csr_addr = CSR_PMACFG_BASE + idx / cfgs_per_csr * 2;
+
+  uint8_t *cfg_reg = (uint8_t *)&csr_array[pmacfg_csr_addr];
+  return *(cfg_reg + (idx % cfgs_per_csr));
+}
+
+static inline word_t pmaaddr_from_index(int idx) {
+  return csr_array[CSR_PMAADDR_BASE + idx];
+}
+
+static inline word_t pma_tor_mask() {
+  return -((word_t)1 << (CONFIG_PMA_GRANULARITY - PMA_SHIFT));
+}
+#endif // CONFIG_RV_PMA_CSR
 
 #endif // __CSR_H__

--- a/src/isa/riscv64/system/priv.c
+++ b/src/isa/riscv64/system/priv.c
@@ -852,55 +852,6 @@ inline word_t sstatus_read(bool vsreg_read, bool bare_read) {
   return gen_status_sd(mstatus->val) | (mstatus->val & sstatus_rmask);
 }
 
-#ifdef CONFIG_RV_PMP_CSR
-// get 8-bit config of one PMP entries by index.
-uint8_t pmpcfg_from_index(int idx) {
-  // Nemu support up to 64 pmp entries in a XLEN=64 machine.
-  int xlen = 64;
-  // Configuration register of one entry is 8-bit.
-  int bits_per_cfg = 8;
-  // For RV64, one pmpcfg CSR contains configuration of 8 entries (64 / 8 = 8).
-  int cfgs_per_csr = xlen / bits_per_cfg;
-  // For RV64, only 8 even-numbered pmpcfg CSRs hold the configuration.
-  int pmpcfg_csr_addr = CSR_PMPCFG_BASE + idx / cfgs_per_csr * 2;
-
-  uint8_t *cfg_reg = (uint8_t *)&csr_array[pmpcfg_csr_addr];
-  return *(cfg_reg + (idx % cfgs_per_csr));
-}
-
-word_t pmpaddr_from_index(int idx) {
-  return csr_array[CSR_PMPADDR_BASE + idx];
-}
-
-word_t inline pmp_tor_mask() {
-  return -((word_t)1 << (CONFIG_PMP_GRANULARITY - PMP_SHIFT));
-}
-#endif // CONFIG_RV_PMP_CSR
-
-#ifdef CONFIG_RV_PMA_CSR
-// get 8-bit config of one PMA entries by index.
-uint8_t pmacfg_from_index(int idx) {
-  int xlen = 64;
-  // Configuration register of one entry is 8-bit.
-  int bits_per_cfg = 8;
-  // For RV64, one pmacfg CSR contains configuration of 8 entries (64 / 8 = 8).
-  int cfgs_per_csr = xlen / bits_per_cfg;
-  // For RV64, only 8 even-numbered pmacfg CSRs hold the configuration.
-  int pmacfg_csr_addr = CSR_PMACFG_BASE + idx / cfgs_per_csr * 2;
-
-  uint8_t *cfg_reg = (uint8_t *)&csr_array[pmacfg_csr_addr];
-  return *(cfg_reg + (idx % cfgs_per_csr));
-}
-
-word_t pmaaddr_from_index(int idx) {
-  return csr_array[CSR_PMAADDR_BASE + idx];
-}
-
-word_t inline pma_tor_mask() {
-  return -((word_t)1 << (CONFIG_PMA_GRANULARITY - PMA_SHIFT));
-}
-#endif // CONFIG_RV_PMA_CSR
-
 #ifndef CONFIG_FPU_NONE
 static inline bool require_fs() {
   if ((mstatus->val & MSTATUS_WMASK_FS) != 0) {


### PR DESCRIPTION
PMP/PMA CSR accessor helpers are on the hot path of memory permission checks. Keeping these small helpers out of line introduces repeated function-call overhead, although they only perform CSR array indexing or mask generation.

Move the PMP/PMA configuration, address, and TOR-mask accessors into csr.h as static inline helpers. This allows the compiler to fold the indexing and mask operations into the permission-check path without changing PMP/PMA state, CSR layout, or RISC-V permission semantics.

With riscv64-xs-ref-perf_defconfig and PERF_OPT=OFF, host instructions are reduced as follows:

- microbench: 752,246,127 -> 540,143,051 (-28.20%)
- coremark: 1,303,041,641 -> 985,279,499 (-24.39%)
- combined: 2,055,287,768 -> 1,525,422,550 (-25.78%)

The REF shared-object smoke test and the non-SHARE riscv64-xs_defconfig build both pass.