### PR TITLE
fix(aia): mstateen0.AIA shouldn't have effect on attempts in VS-mode to access sireg

### DIFF
--- a/src/isa/riscv64/system/priv.c
+++ b/src/isa/riscv64/system/priv.c
@@ -2861,7 +2861,6 @@ static inline bool csrind_permit_check(const uint32_t addr) {
       if (vsiselect->val <= ISELECT_2F_MASK) longjmp_exception(EX_II);
       else if (vsiselect->val <= ISELECT_3F_MASK) {
 #ifdef CONFIG_RV_AIA
-        IFDEF(CONFIG_RV_SMSTATEEN, if (!mstateen0->aia) longjmp_exception(EX_II);)
         has_vi = true;
 #else
         longjmp_exception(EX_II);


### PR DESCRIPTION
 * The AIA bit controls access to AIA CSRs siph, sieh, stopi, hidelegh, hvien/hvienh, hviph, hvictl, hviprio1/hviprio1h, hviprio2/hviprio2h, vsiph, vsieh, and vstopi, as well as to the supervisor level interrupt priorities accessed through siselect + sireg (the iprio array of Section 5.4.1)
 *  mstateen0.AIA have no effect on attempts in VS-mode to access sireg when vsiselect has a value in the range 0x30-0x3F. So for {V=1, vsiselect ∈ 0x30–0x3F, CSRIND=1, AIA=0}, the conforming result is a virtual instruction exception.