### PR TITLE
feat(checkpoint): embed gcpt restorer in flash checkpoint

### DIFF
--- a/scripts/LibcheckpointAlpha.mk
+++ b/scripts/LibcheckpointAlpha.mk
@@ -1,17 +1,26 @@
-CPT_CROSS_COMPILE ?= riscv64-unknown-linux-gnu-
+CPT_CROSS_COMPILE ?= riscv64-linux-gnu-
 
 CPT_REPO = $(RESOURCE_PATH)/gcpt_restore
 CPT_BIN = $(CPT_REPO)/build/gcpt.bin
 CPT_MEMLAYOUT_HEADER = $(CPT_REPO)/src/restore_rom_addr.h
+GCPT_RESTORER_SRC = $(CPT_REPO)/build/generated/gcpt_restorer.c
 
 ifeq ($(wildcard $(CPT_MEMLAYOUT_HEADER)),)
   $(shell git clone --depth=1 https://github.com/OpenXiangShan/LibCheckpointAlpha.git $(CPT_REPO) 1>&2)
+endif
+
+ifdef CONFIG_HAS_FLASH
+SRCS-y += $(GCPT_RESTORER_SRC)
 endif
 
 gcpt_restore_bin: $(CPT_BIN)
 
 $(CPT_BIN):
 	$(Q)$(MAKE) $(silent) -C $(CPT_REPO) CROSS_COMPILE=$(CPT_CROSS_COMPILE)
+
+$(GCPT_RESTORER_SRC): $(CPT_BIN) $(NEMU_HOME)/scripts/gen_gcpt_restorer_c.py
+	@mkdir -p $(@D)
+	$(Q)python3 $(NEMU_HOME)/scripts/gen_gcpt_restorer_c.py $< $@
 
 clean-libcheckpointalpha:
 	$(Q)$(MAKE) -s -C $(CPT_REPO) clean

--- a/scripts/gen_gcpt_restorer_c.py
+++ b/scripts/gen_gcpt_restorer_c.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+import sys
+from pathlib import Path
+
+if len(sys.argv) != 3:
+  sys.exit(f"Usage: {sys.argv[0]} INPUT_GCPT_BIN OUTPUT_C")
+
+input_path = Path(sys.argv[1])
+output_path = Path(sys.argv[2])
+data = input_path.read_bytes()
+
+restorer_size = int.from_bytes(data[4:8], "little")
+restorer = data[:restorer_size]
+lines = [
+    "#include <stddef.h>",
+    "#include <stdint.h>",
+    "",
+    "const uint8_t gcpt_restorer_bin[] = {",
+]
+
+for offset in range(0, len(restorer), 12):
+  lines.append("  " + ", ".join(f"0x{byte:02x}" for byte in restorer[offset:offset + 12]) + ",")
+
+lines += [
+    "};",
+    "const size_t gcpt_restorer_size = sizeof(gcpt_restorer_bin);",
+]
+output_path.parent.mkdir(parents=True, exist_ok=True)
+output_path.write_text("\n".join(lines) + "\n")

--- a/src/checkpoint/serializer.cpp
+++ b/src/checkpoint/serializer.cpp
@@ -148,6 +148,17 @@ extern uint64_t clint_get_mtime();
 extern uint64_t clint_get_mtimecmp();
 }
 
+#ifdef CONFIG_HAS_FLASH
+extern "C" {
+extern const uint8_t gcpt_restorer_bin[];
+extern const size_t gcpt_restorer_size;
+}
+
+static void load_gcpt_restorer_to_flash() {
+  memcpy(get_flash_base(), gcpt_restorer_bin, gcpt_restorer_size);
+}
+#endif
+
 // Some configurations reserve a huge mmap-backed pmem range, while only the low
 // part is actually touched by the workload/restorer. Dumping the full configured
 // range would make checkpoint generation impractically slow and produce oversized
@@ -482,7 +493,7 @@ void Serializer::serialize(uint64_t inst_count, const char *checkpoint_base_path
   uint64_t serialize_buffer_size;
 
   if (store_cpt_in_flash) {
-    IFDEF(CONFIG_HAS_FLASH, serialize_reg_base_addr = get_flash_base(); assert(get_flash_size() >= 0x100000U); serialize_buffer_size = get_flash_size(););
+    IFDEF(CONFIG_HAS_FLASH, load_gcpt_restorer_to_flash(); serialize_reg_base_addr = get_flash_base(); assert(get_flash_size() >= 0x100000U); serialize_buffer_size = get_flash_size(););
     IFNDEF(CONFIG_HAS_FLASH, Log("Please enable the flash device to activate the functionality of saving checkpoints to flash."); assert(0));
   } else {
     serialize_reg_base_addr = get_pmem();


### PR DESCRIPTION
Flash checkpoints already store the checkpoint register payload in flash, but the GCPT restorer code itself was not part of the generated flash image.

The old restore flow relied on loading gcpt.bin separately and placing it at the flash base before execution. However, XiangShan does not support this restore-time gcpt.bin injection flow.

Generate a C source from gcpt.bin at build time and link the restorer bytes into NEMU. Use the riscv64-linux-gnu toolchain prefix by default for this implicit gcpt.bin build, matching the toolchain available in NEMU CI.

Before serializing a flash checkpoint, copy the embedded restorer to the flash base and then serialize the checkpoint register state using the existing flash layout.

With this, the generated _flash_.gz contains both the GCPT restorer and the register checkpoint payload, so XiangShan can restore from the flash image without separately loading gcpt.bin.