### PR TITLE
perf(riscv64): enable LTO for inline PMP/PMA CSR accessors

### DIFF
--- a/configs/riscv64-xs-ref_defconfig
+++ b/configs/riscv64-xs-ref_defconfig
@@ -129,7 +129,7 @@ CONFIG_CC_O2=y
 CONFIG_CC_OPT="-O2"
 CONFIG_CC_OPT_FLAGS=""
 # CONFIG_CC_NATIVE_ARCH is not set
-# CONFIG_CC_LTO is not set
+CONFIG_CC_LTO=y
 # CONFIG_CC_DEBUG is not set
 # CONFIG_CC_ASAN is not set
 # end of Build Options

--- a/src/isa/riscv64/system/priv.c
+++ b/src/isa/riscv64/system/priv.c
@@ -854,7 +854,7 @@ inline word_t sstatus_read(bool vsreg_read, bool bare_read) {
 
 #ifdef CONFIG_RV_PMP_CSR
 // get 8-bit config of one PMP entries by index.
-uint8_t pmpcfg_from_index(int idx) {
+uint8_t inline pmpcfg_from_index(int idx) {
   // Nemu support up to 64 pmp entries in a XLEN=64 machine.
   int xlen = 64;
   // Configuration register of one entry is 8-bit.
@@ -868,7 +868,7 @@ uint8_t pmpcfg_from_index(int idx) {
   return *(cfg_reg + (idx % cfgs_per_csr));
 }
 
-word_t pmpaddr_from_index(int idx) {
+word_t inline pmpaddr_from_index(int idx) {
   return csr_array[CSR_PMPADDR_BASE + idx];
 }
 
@@ -879,7 +879,7 @@ word_t inline pmp_tor_mask() {
 
 #ifdef CONFIG_RV_PMA_CSR
 // get 8-bit config of one PMA entries by index.
-uint8_t pmacfg_from_index(int idx) {
+uint8_t inline pmacfg_from_index(int idx) {
   int xlen = 64;
   // Configuration register of one entry is 8-bit.
   int bits_per_cfg = 8;
@@ -892,7 +892,7 @@ uint8_t pmacfg_from_index(int idx) {
   return *(cfg_reg + (idx % cfgs_per_csr));
 }
 
-word_t pmaaddr_from_index(int idx) {
+word_t inline pmaaddr_from_index(int idx) {
   return csr_array[CSR_PMAADDR_BASE + idx];
 }
 


### PR DESCRIPTION
PMP/PMA cfg and addr accessors are hot in MMU permission checks. Mark them inline to eliminate repeated call overhead and fold CSR indexing and masks into the permission-check loops.

Keep the definitions in priv.c. Enable CONFIG_CC_LTO in the GCC-based riscv64-xs-ref_defconfig so the compiler can inline them at mmu.c call sites. Keep riscv64-xs-clang-ref_defconfig on no-LTO for Clang sanitizer compatibility.

Co-authored-by: Kami <fengkehan@bosc.ac.cn>