### PR TITLE
refactor(ame): reorganize AME code by execution mode

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,6 @@
 * @poemonsense @good-circle @Anzooooo
+
+# XSAI AME extension.
+/configs/riscv64-matrix-* @yu-yake2002
+**/ame/ @yu-yake2002
+**/ctrl/ @yu-yake2002

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ SRCS-$(CONFIG_HAS_FLASH) += src/device/flash.c
 
 DIRS-y += src/profiling
 DIRS-y += src/checkpoint
-DIRS-y += src/ext
+DIRS-$(CONFIG_SHARE_CTRL) += src/ctrl
 
 SRCS-y += $(shell find $(DIRS-y) -name "*.c")
 
@@ -80,12 +80,11 @@ SRCS = $(SRCS-y)
 XSRCS-$(CONFIG_USE_SPARSEMM) += src/memory/sparseram.cpp
 
 XDIRS-y += src/checkpoint src/base src/iostream3 src/profiling
+XDIRS-$(CONFIG_RV_AME) += src/isa/riscv64/ame
+XDIRS-$(CONFIG_SHARE_REF) += src/cpu/difftest/ame
 XSRCS-y += $(shell find $(XDIRS-y) -name "*.cpp")
 
 XSRCS-y += src/memory/store_queue_wrapper.cpp
-XSRCS-y += src/ext/amu_ctrl_queue_wrapper.cpp
-XSRCS-y += src/ext/msync_queue_wrapper.cpp
-XSRCS-y += src/ext/mstore_queue_wrapper.cpp
 
 XSRCS = $(XSRCS-y)
 

--- a/include/ame/event.h
+++ b/include/ame/event.h
@@ -1,13 +1,12 @@
-#ifndef __EXT_AMUCTRL_H__
-#define __EXT_AMUCTRL_H__
+#ifndef __AME_EVENT_H__
+#define __AME_EVENT_H__
 
 #include <common.h>
 
 #ifdef CONFIG_RV_AME
 
-// Attention: the order of fields in this class must be the same as the order
-//            in the corresponding struct in XiangShan(or XSAI)'s diffstate.h.
-typedef struct  {
+// The field order is part of the AMU control ABI shared with XSAI.
+typedef struct {
   uint8_t  valid;
   uint8_t  op;
   uint8_t  rm;
@@ -27,10 +26,6 @@ typedef struct  {
   uint64_t pc;
 } amu_ctrl_event_t;
 
-int check_amu_ctrl(amu_ctrl_event_t *cmp);
-amu_ctrl_event_t get_amu_ctrl_info();
-int exec_amu(void *amu_ctrl, void *res);
-void exec_amu_lazy(void *amu_ctrl, void *res, void *src1, void *src2, void *src3);
-
 #endif // CONFIG_RV_AME
-#endif // __EXT_AMUCTRL_H__
+
+#endif // __AME_EVENT_H__

--- a/include/ame/mstore.h
+++ b/include/ame/mstore.h
@@ -1,5 +1,5 @@
-#ifndef __EXT_MSTORE_H__
-#define __EXT_MSTORE_H__
+#ifndef __AME_MSTORE_H__
+#define __AME_MSTORE_H__
 
 #include <common.h>
 
@@ -21,5 +21,5 @@ typedef struct {
 } mstore_info_t;
 
 #endif // CONFIG_RV_AME
-#endif // __EXT_MSTORE_H__
+#endif // __AME_MSTORE_H__
 

--- a/include/ame/mstore_queue_wrapper.h
+++ b/include/ame/mstore_queue_wrapper.h
@@ -1,8 +1,8 @@
-#ifndef NEMU_MSTORE_QUEUE_WRAPPER_H
-#define NEMU_MSTORE_QUEUE_WRAPPER_H
+#ifndef __AME_MSTORE_QUEUE_WRAPPER_H__
+#define __AME_MSTORE_QUEUE_WRAPPER_H__
 
 #include <common.h>
-#include <ext/mstore.h>
+#include <ame/mstore.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -31,5 +31,5 @@ bool mstore_queue_check_addr_conflict(uint64_t addr, int len);
 }
 #endif
 
-#endif // NEMU_MSTORE_QUEUE_WRAPPER_H
+#endif // __AME_MSTORE_QUEUE_WRAPPER_H__
 

--- a/include/cpu/difftest/ame/amu_ctrl_queue_wrapper.h
+++ b/include/cpu/difftest/ame/amu_ctrl_queue_wrapper.h
@@ -1,14 +1,14 @@
-#ifndef NEMU_AMU_CTRL_QUEUE_WRAPPER_H
-#define NEMU_AMU_CTRL_QUEUE_WRAPPER_H
+#ifndef __AME_AMU_CTRL_QUEUE_WRAPPER_H__
+#define __AME_AMU_CTRL_QUEUE_WRAPPER_H__
 
 #include <common.h>
-#include <ext/amuctrl.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#ifdef CONFIG_RV_AME
+#if defined(CONFIG_RV_AME) && defined(CONFIG_SHARE_REF)
+#include <ame/event.h>
 void amu_ctrl_queue_reset();
 void amu_ctrl_queue_push(amu_ctrl_event_t amu_ctrl_event);
 void amu_ctrl_queue_pop();
@@ -26,10 +26,10 @@ void amu_ctrl_queue_mls_emplace(uint8_t ms, bool ls, bool transpose, bool isacc,
                                 uint16_t row, uint16_t column, uint8_t msew);
 void amu_ctrl_queue_mrelease_emplace(uint8_t msyncRd);
 void amu_ctrl_queue_mzero_emplace(bool isacc, uint8_t md);
-#endif // CONFIG_RV_AME
+#endif // defined(CONFIG_RV_AME) && defined(CONFIG_SHARE_REF)
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif // NEMU_AMU_CTRL_QUEUE_WRAPPER_H
+#endif // __AME_AMU_CTRL_QUEUE_WRAPPER_H__

--- a/include/cpu/difftest/ame/amuctrl.h
+++ b/include/cpu/difftest/ame/amuctrl.h
@@ -1,0 +1,13 @@
+#ifndef __AME_AMUCTRL_H__
+#define __AME_AMUCTRL_H__
+
+#include <ame/event.h>
+
+#if defined(CONFIG_RV_AME) && defined(CONFIG_SHARE_REF)
+int check_amu_ctrl(amu_ctrl_event_t *cmp);
+amu_ctrl_event_t get_amu_ctrl_info();
+int exec_amu(void *amu_ctrl, void *res);
+void exec_amu_lazy(void *amu_ctrl, void *res, void *src1, void *src2, void *src3);
+#endif // defined(CONFIG_RV_AME) && defined(CONFIG_SHARE_REF)
+
+#endif // __AME_AMUCTRL_H__

--- a/include/cpu/difftest/ame/msync.h
+++ b/include/cpu/difftest/ame/msync.h
@@ -1,5 +1,5 @@
-#ifndef __EXT_MSYNC_H__
-#define __EXT_MSYNC_H__
+#ifndef __AME_MSYNC_H__
+#define __AME_MSYNC_H__
 
 #include <common.h>
 
@@ -18,4 +18,4 @@ int check_msync(msync_event_t *cmp);
 msync_event_t get_msync_info();
 
 #endif // defined(CONFIG_RV_AME) && defined(CONFIG_SHARE_REF)
-#endif // __EXT_MSYNC_H__
+#endif // __AME_MSYNC_H__

--- a/include/cpu/difftest/ame/msync_queue_wrapper.h
+++ b/include/cpu/difftest/ame/msync_queue_wrapper.h
@@ -1,8 +1,8 @@
-#ifndef NEMU_MSYNC_QUEUE_WRAPPER_H
-#define NEMU_MSYNC_QUEUE_WRAPPER_H
+#ifndef __AME_MSYNC_QUEUE_WRAPPER_H__
+#define __AME_MSYNC_QUEUE_WRAPPER_H__
 
 #include <common.h>
-#include <ext/msync.h>
+#include <cpu/difftest/ame/msync.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -24,4 +24,4 @@ void msync_queue_emplace(uint8_t op, uint8_t msyncRd);
 }
 #endif
 
-#endif // NEMU_MSYNC_QUEUE_WRAPPER_H
+#endif // __AME_MSYNC_QUEUE_WRAPPER_H__

--- a/include/ctrl/ame/cutest.h
+++ b/include/ctrl/ame/cutest.h
@@ -1,10 +1,10 @@
-#ifndef NEMU_CUTEST_H
-#define NEMU_CUTEST_H
+#ifndef __CTRL_AME_CUTEST_H__
+#define __CTRL_AME_CUTEST_H__
 
 #include <common.h>
-#include <ext/amuctrl.h>
 
 #ifdef CONFIG_SHARE_CTRL
+#include <ame/event.h>
 
 void cutest_mma_emplace(uint8_t md, bool sat, bool isfp,
   uint8_t ms1, uint8_t ms2,
@@ -20,4 +20,4 @@ void cutest_mrelease_emplace(uint8_t msyncRd);
 void cutest_mzero_emplace(bool isacc, uint8_t md);
 
 #endif // CONFIG_SHARE_CTRL
-#endif // NEMU_CUTEST_H
+#endif // __CTRL_AME_CUTEST_H__

--- a/include/ctrl/ctrl.h
+++ b/include/ctrl/ctrl.h
@@ -1,0 +1,26 @@
+#ifndef __CTRL_CTRL_H__
+#define __CTRL_CTRL_H__
+
+#include <ame/event.h>
+#include <common.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef CONFIG_SHARE_CTRL
+extern void (*amu_ctrl_callback_)(amu_ctrl_event_t);
+
+void ctrl_init();
+void ctrl_memcpy_init(paddr_t nemu_addr, void *dut_buf, size_t n, bool direction);
+void ctrl_exec();
+int ctrl_status();
+void ctrl_info(void *reg_buf);
+void ctrl_register_amu_callback(void (*callback)(amu_ctrl_event_t));
+#endif // CONFIG_SHARE_CTRL
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // __CTRL_CTRL_H__

--- a/src/cpu/difftest/ame/amu_ctrl_queue_wrapper.cpp
+++ b/src/cpu/difftest/ame/amu_ctrl_queue_wrapper.cpp
@@ -1,8 +1,8 @@
-#include <ext/amuctrl.h>
-#include <ext/amu_ctrl_queue_wrapper.h>
+#include <cpu/difftest/ame/amuctrl.h>
+#include <cpu/difftest/ame/amu_ctrl_queue_wrapper.h>
 #include <cpu/decode.h>
 
-#ifdef CONFIG_RV_AME
+#if defined(CONFIG_RV_AME) && defined(CONFIG_SHARE_REF)
 #include <queue>
 
 std::queue<amu_ctrl_event_t> cpp_amu_ctrl_queue;
@@ -96,4 +96,4 @@ void amu_ctrl_queue_mzero_emplace(bool isacc, uint8_t md) {
   amu_ctrl_queue_push(event);
 }
 
-#endif // CONFIG_RV_AME
+#endif // defined(CONFIG_RV_AME) && defined(CONFIG_SHARE_REF)

--- a/src/cpu/difftest/ame/amuctrl.c
+++ b/src/cpu/difftest/ame/amuctrl.c
@@ -1,10 +1,10 @@
-#include <ext/amuctrl.h>
-#include <ext/amu_ctrl_queue_wrapper.h>
-#include <ext/mstore_queue_wrapper.h>
+#include <cpu/difftest/ame/amuctrl.h>
+#include <cpu/difftest/ame/amu_ctrl_queue_wrapper.h>
+#include <ame/mstore_queue_wrapper.h>
 #include <isa.h>
 #include <memory/host.h>
 
-#ifdef CONFIG_RV_AME
+#if defined(CONFIG_RV_AME) && defined(CONFIG_SHARE_REF)
 
 #ifndef MATRIX_DIFF_PRINT_CNT
 #define MATRIX_DIFF_PRINT_CNT 32
@@ -272,4 +272,4 @@ void exec_amu_lazy(void *amu_ctrl, void *res, void *src1, void *src2, void *src3
   memcpy(cpu.macc[md - 4], res, ALEN / 8);
 }
 
-#endif // CONFIG_RV_AME
+#endif // defined(CONFIG_RV_AME) && defined(CONFIG_SHARE_REF)

--- a/src/cpu/difftest/ame/msync.c
+++ b/src/cpu/difftest/ame/msync.c
@@ -1,5 +1,5 @@
-#include <ext/msync.h>
-#include <ext/msync_queue_wrapper.h>
+#include <cpu/difftest/ame/msync.h>
+#include <cpu/difftest/ame/msync_queue_wrapper.h>
 
 #if defined(CONFIG_RV_AME) && defined(CONFIG_SHARE_REF)
 

--- a/src/cpu/difftest/ame/msync_queue_wrapper.cpp
+++ b/src/cpu/difftest/ame/msync_queue_wrapper.cpp
@@ -1,5 +1,5 @@
-#include <ext/msync.h>
-#include <ext/msync_queue_wrapper.h>
+#include <cpu/difftest/ame/msync.h>
+#include <cpu/difftest/ame/msync_queue_wrapper.h>
 #include <cpu/decode.h>
 
 #if defined(CONFIG_RV_AME) && defined(CONFIG_SHARE_REF)

--- a/src/cpu/difftest/ref.c
+++ b/src/cpu/difftest/ref.c
@@ -15,8 +15,8 @@
 ***************************************************************************************/
 
 #include <isa.h>
-#include <ext/amuctrl.h>
-#include <ext/msync.h>
+#include <cpu/difftest/ame/amuctrl.h>
+#include <cpu/difftest/ame/msync.h>
 #include <memory/paddr.h>
 #include <memory/host.h>
 #include <memory/store_queue_wrapper.h>
@@ -299,9 +299,9 @@ void difftest_get_store_event_other_info(void *info) {
 
 
 void difftest_get_amu_ctrl_event_other_info(void *info) {
-#ifdef CONFIG_RV_AME
+#if defined(CONFIG_RV_AME) && defined(CONFIG_SHARE_REF)
   *(uint64_t*)info = get_amu_ctrl_info().pc;
-#endif // CONFIG_RV_AME
+#endif // defined(CONFIG_RV_AME) && defined(CONFIG_SHARE_REF)
 }
 
 void difftest_get_msync_event_other_info(void *info) {
@@ -317,12 +317,12 @@ int difftest_amu_ctrl(void *cmp) {
   //   0:  Queue head matches cmp
   //   1:  Queue head does not match cmp
   //   -1: Queue is empty, no cmp to check
-#ifdef CONFIG_RV_AME
+#if defined(CONFIG_RV_AME) && defined(CONFIG_SHARE_REF)
   amu_ctrl_event_t *amu_ctrl = (amu_ctrl_event_t *)cmp;
   return check_amu_ctrl(amu_ctrl);
 #else
   return 0;
-#endif // CONFIG_RV_AME
+#endif // defined(CONFIG_RV_AME) && defined(CONFIG_SHARE_REF)
 }
 
 int difftest_msync_event(void *cmp) {
@@ -341,17 +341,17 @@ int difftest_msync_event(void *cmp) {
 }
 
 int difftest_amu_exec(void *amu_ctrl, void *res) {
-#ifdef CONFIG_RV_AME
+#if defined(CONFIG_RV_AME) && defined(CONFIG_SHARE_REF)
   return exec_amu(amu_ctrl, res);
 #else
   return 0;
-#endif // CONFIG_RV_AME
+#endif // defined(CONFIG_RV_AME) && defined(CONFIG_SHARE_REF)
 }
 
 void difftest_amu_lazy(void *amu_ctrl, void *res, void *src1, void *src2, void *src3) {
-#ifdef CONFIG_RV_AME
+#if defined(CONFIG_RV_AME) && defined(CONFIG_SHARE_REF)
   exec_amu_lazy(amu_ctrl, res, src1, src2, src3);
-#endif // CONFIG_RV_AME
+#endif // defined(CONFIG_RV_AME) && defined(CONFIG_SHARE_REF)
 }
 
 #if defined(CONFIG_MULTICORE_DIFF) && defined(CONFIG_RVV)

--- a/src/ctrl/ame/cutest.c
+++ b/src/ctrl/ame/cutest.c
@@ -1,10 +1,9 @@
+#include <ctrl/ame/cutest.h>
 #include <cpu/decode.h>
-#include <ext/amu_ctrl_queue_wrapper.h>
-#include <ext/amuctrl.h>
+#include <ctrl/ctrl.h>
 
 #ifdef CONFIG_SHARE_CTRL
 
-extern void (*amu_ctrl_callback_)(amu_ctrl_event_t);
 extern Decode *prev_s;
 
 void cutest_mma_emplace(uint8_t md, bool sat, bool isfp,

--- a/src/ctrl/ctrl.c
+++ b/src/ctrl/ctrl.c
@@ -15,9 +15,8 @@
 ***************************************************************************************/
 
 #include "utils.h"
+#include <ctrl/ctrl.h>
 #include <isa.h>
-#include <ext/amuctrl.h>
-#include <ext/msync.h>
 #include <memory/paddr.h>
 #include <memory/host.h>
 #include <memory/store_queue_wrapper.h>

--- a/src/isa/riscv64/ame/mstore_queue_wrapper.cpp
+++ b/src/isa/riscv64/ame/mstore_queue_wrapper.cpp
@@ -1,6 +1,6 @@
 #include <cstdint>
-#include <ext/mstore.h>
-#include <ext/mstore_queue_wrapper.h>
+#include <ame/mstore.h>
+#include <ame/mstore_queue_wrapper.h>
 #include <cpu/decode.h>
 
 #ifdef CONFIG_RV_AME

--- a/src/isa/riscv64/instr/ame/mcfg.h
+++ b/src/isa/riscv64/instr/ame/mcfg.h
@@ -18,12 +18,12 @@
 #ifdef CONFIG_RV_AME
 
 #include "cpu/exec.h"
-#include "ext/amu_ctrl_queue_wrapper.h"
-#include <ext/cutest.h>
+#include "cpu/difftest/ame/amu_ctrl_queue_wrapper.h"
+#include <ctrl/ame/cutest.h>
 #ifdef CONFIG_SHARE_REF
-#include "ext/msync_queue_wrapper.h"
+#include "cpu/difftest/ame/msync_queue_wrapper.h"
 #endif // CONFIG_SHARE_REF
-#include "ext/mstore_queue_wrapper.h"
+#include "ame/mstore_queue_wrapper.h"
 #include "mcommon.h"
 #include "../local-include/csr.h"
 #include "../local-include/intr.h"

--- a/src/isa/riscv64/instr/ame/mcompute.h
+++ b/src/isa/riscv64/instr/ame/mcompute.h
@@ -24,8 +24,8 @@
 #include "../local-include/rtl.h"
 #include "../local-include/reg.h"
 #include <cpu/cpu.h>
-#include <ext/amu_ctrl_queue_wrapper.h>
-#include <ext/cutest.h>
+#include <cpu/difftest/ame/amu_ctrl_queue_wrapper.h>
+#include <ctrl/ame/cutest.h>
 #include "mcommon.h"
 #include "mcompute_impl.h"
 #include "rtl/fp.h"

--- a/src/isa/riscv64/instr/ame/mldst.h
+++ b/src/isa/riscv64/instr/ame/mldst.h
@@ -24,7 +24,7 @@
 #include "../local-include/intr.h"
 #include "../local-include/rtl.h"
 #include "../local-include/reg.h"
-#include "ext/mstore_queue_wrapper.h"
+#include "ame/mstore_queue_wrapper.h"
 #include "mcommon.h"
 
 // #define PRINT_AMUCTRLIO

--- a/src/memory/host-tlb.c
+++ b/src/memory/host-tlb.c
@@ -14,8 +14,8 @@
 * See the Mulan PSL v2 for more details.
 ***************************************************************************************/
 
-#include <ext/amu_ctrl_queue_wrapper.h>
-#include <ext/cutest.h>
+#include <cpu/difftest/ame/amu_ctrl_queue_wrapper.h>
+#include <ctrl/ame/cutest.h>
 #include <isa.h>
 #include <memory/host.h>
 #include <memory/vaddr.h>

--- a/src/memory/paddr.c
+++ b/src/memory/paddr.c
@@ -15,8 +15,8 @@
 ***************************************************************************************/
 
 #include <assert.h>
-#include <ext/amu_ctrl_queue_wrapper.h>
-#include <ext/cutest.h>
+#include <cpu/difftest/ame/amu_ctrl_queue_wrapper.h>
+#include <ctrl/ame/cutest.h>
 #include <isa.h>
 #include <memory/host.h>
 #include <memory/paddr.h>


### PR DESCRIPTION
Split AME support into architecture, REF, and CTRL-owned directories. Keep the existing ISA instruction layout and cutest naming intact while moving shared event types, REF queues/reference execution, and CTRL integration into their respective modules.

Update build discovery, include paths, and CODEOWNERS accordingly.