### PR TITLE
fix(cbo): accessing nc space from cbo should not trigger access fault

### DIFF
--- a/src/isa/riscv64/instr/rvcbo/cbo_impl.c
+++ b/src/isa/riscv64/instr/rvcbo/cbo_impl.c
@@ -61,11 +61,6 @@ static paddr_t translate_and_check(vaddr_t vaddr, int type) {
     if (ret == MEM_RET_OK) {
       paddr = pg_base | (vaddr & PAGE_MASK);
     }
-    if (cpu.pbmt != 0) {
-      cpu.trapInfo.tval = vaddr;
-      cpu.amo = false;
-      longjmp_exception(EX_SAF);
-    }
   }
   paddr_check(paddr, vaddr, type);
   return paddr;


### PR DESCRIPTION
CBO operations on NC space should be allowed and should not trigger an access fault. This PR updates the access check logic to match the expected behavior.