### PR TITLE
fix(RVH): use effective virtual mode for VA width check

### DIFF
--- a/src/isa/riscv64/system/mmu.c
+++ b/src/isa/riscv64/system/mmu.c
@@ -638,9 +638,9 @@ int isa_mmu_check(vaddr_t vaddr, int len, int type) {
   // Instruction fetch addresses and load and store effective addresses,
   // which are 64 bits, must have bits 63–39 all equal to bit 38, or else a page-fault exception will occur.
 #ifdef CONFIG_RVH
-  bool virt = get_mprv() && mstatus->mpp != MODE_M ? mstatus->mpv : cpu.v;
-  bool enable_39 = satp->mode == SATP_MODE_Sv39 || ((cpu.v || hld_st) && (vsatp->mode == SATP_MODE_Sv39 || hgatp->mode == HGATP_MODE_Sv39x4));
-  bool enable_48 = satp->mode == SATP_MODE_Sv48 || ((cpu.v || hld_st) && (vsatp->mode == SATP_MODE_Sv48 || hgatp->mode == HGATP_MODE_Sv48x4));
+  bool virt = get_mprv() && !is_ifetch && mstatus->mpp != MODE_M ? mstatus->mpv : cpu.v;
+  bool enable_39 = satp->mode == SATP_MODE_Sv39 || ((virt || hld_st) && (vsatp->mode == SATP_MODE_Sv39 || hgatp->mode == HGATP_MODE_Sv39x4));
+  bool enable_48 = satp->mode == SATP_MODE_Sv48 || ((virt || hld_st) && (vsatp->mode == SATP_MODE_Sv48 || hgatp->mode == HGATP_MODE_Sv48x4));
   bool vm_enable = (get_mprv() && (!is_ifetch) ? mstatus->mpp : cpu.mode) < MODE_M && (enable_39 || enable_48);
   bool hyperinst_vm_enable = hld_st && (vsatp->mode == SATP_MODE_Sv39 || vsatp->mode == SATP_MODE_Sv48 || hgatp->mode == HGATP_MODE_Sv39x4 || hgatp->mode == HGATP_MODE_Sv48x4);
 #else


### PR DESCRIPTION
RVH data accesses with MPRV can use MPP and MPV instead of the current virtualization state. The early virtual-address width check still used cpu.v when it selected the VS/G-stage address width.

This can reject a valid guest Sv48 data address as an invalid Sv39 address before page-table walking runs.

Use the effective virtual mode for non-instruction accesses when selecting whether VS/G-stage Sv39 or Sv48 translation is enabled. Keep instruction fetches based on cpu.v, since MPRV does not affect fetch.
