### PR TITLE
perf(riscv64): cache inactive mcontrol6 trigger state

### DIFF
--- a/src/isa/riscv64/difftest/ref.c
+++ b/src/isa/riscv64/difftest/ref.c
@@ -195,6 +195,7 @@ void csr_writeback() {
 #ifdef CONFIG_DIFFTEST_CHECK_SDTRIG
   tselect->val  = cpu.tselect;
   cpu.TM->triggers[tselect->val].tdata1.val = cpu.tdata1; // update alias tdata1 to trigger module
+  trigger_mark_state_dirty(cpu.TM);
   tinfo->val    = cpu.tinfo;
 #endif // CONFIG_DIFFTEST_CHECK_SDTRIG
 

--- a/src/isa/riscv64/local-include/trigger.h
+++ b/src/isa/riscv64/local-include/trigger.h
@@ -166,6 +166,8 @@ typedef struct {
 typedef struct TriggerModule {
   // the last trigger is used to check maximum number of supported triggers
   Trigger triggers[CONFIG_TRIGGER_NUM + 1];
+  uint8_t mcontrol6_active_count;
+  bool mcontrol6_state_dirty;
 } TriggerModule;
 
 extern trig_action_t trigger_action;
@@ -178,12 +180,7 @@ bool mcontrol6_check_chain_legal(const TriggerModule* TM, const int max_chain_le
 void mcontrol6_checked_write(trig_mcontrol6_t* mcontrol6, word_t* wdata, const TriggerModule* TM);
 
 static inline bool trigger_mcontrol6_active(const TriggerModule* TM) {
-  for (int i = 0; i < CONFIG_TRIGGER_NUM; i++) {
-    if (TM->triggers[i].tdata1.common.type == TRIG_TYPE_MCONTROL6) {
-      return true;
-    }
-  }
-  return false;
+  return TM->mcontrol6_state_dirty || TM->mcontrol6_active_count != 0;
 }
 
 trig_action_t check_triggers_etrigger(TriggerModule* TM, uint64_t cause);
@@ -200,6 +197,7 @@ void icount_checked_write(trig_icount_t* icount, word_t* wdata);
 
 bool trigger_reentrancy_check(); 
 void trigger_handler(const trig_type_t type, const trig_action_t action, word_t tval);
+void trigger_mark_state_dirty(TriggerModule* TM);
 
 static inline word_t get_tdata1(TriggerModule* TM) {return TM->triggers[tselect->val].tdata1.val;}
 static inline word_t get_tdata2(TriggerModule* TM) {return TM->triggers[tselect->val].tdata2.val;}

--- a/src/isa/riscv64/system/priv.c
+++ b/src/isa/riscv64/system/priv.c
@@ -89,6 +89,8 @@ void init_trigger() {
     cpu.TM->triggers[i].tdata1.val = 0;
     cpu.TM->triggers[i].tdata1.common.type = TRIG_TYPE_DISABLE;
   }
+  cpu.TM->mcontrol6_active_count = 0;
+  cpu.TM->mcontrol6_state_dirty = false;
   tselect->val = 0;
   tinfo->val = 0
     IFDEF(CONFIG_TDATA1_MCONTROL, | (1 << TRIG_TYPE_MCONTROL))
@@ -2830,6 +2832,7 @@ static void csr_write(uint32_t csrid, word_t src) {
         break;
       }
       set_sys_state_flag(SYS_STATE_FLUSH_TCACHE);
+      trigger_mark_state_dirty(cpu.TM);
       break;
     }
     case CSR_TDATA2:

--- a/src/isa/riscv64/system/trigger.c
+++ b/src/isa/riscv64/system/trigger.c
@@ -9,6 +9,21 @@
 trig_action_t trigger_action = TRIG_ACTION_NONE;
 word_t triggered_tval;
 
+void trigger_mark_state_dirty(TriggerModule* TM) {
+  TM->mcontrol6_state_dirty = true;
+}
+
+static inline void refresh_mcontrol6_state(TriggerModule* TM) {
+  uint8_t active_count = 0;
+
+  for (int i = 0; i < CONFIG_TRIGGER_NUM; i++) {
+    active_count += TM->triggers[i].tdata1.common.type == TRIG_TYPE_MCONTROL6;
+  }
+
+  TM->mcontrol6_active_count = active_count;
+  TM->mcontrol6_state_dirty = false;
+}
+
 static bool tdata3_smatch(Trigger* trig) {
   switch (trig->tdata3.sselect) {
     case 0:
@@ -74,6 +89,12 @@ trig_action_t check_triggers_mcontrol6(
   vaddr_t addr,
   word_t data
 ) {
+  if (TM->mcontrol6_state_dirty) {
+    refresh_mcontrol6_state(TM);
+  }
+  if (TM->mcontrol6_active_count == 0) {
+    return TRIG_ACTION_NONE;
+  }
 #ifdef CONFIG_RV_SDEXT
   // do nothing in debug mode
   if (cpu.debug_mode)


### PR DESCRIPTION
The common path has mcontrol6 support enabled but normally has no active mcontrol6 trigger. Each execute and memory probe still scans the trigger array before returning TRIG_ACTION_NONE.

Cache the active mcontrol6 count and refresh it only after tdata1 changes through an architectural CSR write or DiffTest CSR import. Active-trigger matching, chaining, timing, and exception behavior are unchanged.