### PR TITLE
perf(riscv64): skip inactive mcontrol6 checks at call sites

### DIFF
--- a/src/isa/riscv64/instr/decode.c
+++ b/src/isa/riscv64/instr/decode.c
@@ -134,8 +134,10 @@ int isa_fetch_decode(Decode *s) {
   trigger_handler(TRIG_TYPE_ICOUNT, icount_action, 0);
 #endif // CONFIG_TDATA1_ICOUNT
 #ifdef CONFIG_TDATA1_MCONTROL6
-  trig_action_t mcontrol6_action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_EXECUTE, s->pc, TRIGGER_NO_VALUE);
-  trigger_handler(TRIG_TYPE_MCONTROL6, mcontrol6_action, s->pc);
+  if (trigger_mcontrol6_active(cpu.TM)) {
+    trig_action_t mcontrol6_action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_EXECUTE, s->pc, TRIGGER_NO_VALUE);
+    trigger_handler(TRIG_TYPE_MCONTROL6, mcontrol6_action, s->pc);
+  }
 #endif // CONFIG_TDATA1_MCONTROL6
 
   s->isa.instr.val = instr_fetch(&s->snpc, 2);

--- a/src/isa/riscv64/instr/rva/amo.c
+++ b/src/isa/riscv64/instr/rva/amo.c
@@ -36,13 +36,15 @@ def_rtl(amo_slow_path, rtlreg_t *dest, const rtlreg_t *src1, const rtlreg_t *src
 
 #ifdef CONFIG_TDATA1_MCONTROL6
   trig_action_t action = TRIG_ACTION_NONE;
-  if (funct5 == 0b00010) { // lr
-    action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_LOAD, *src1, TRIGGER_NO_VALUE); trigger_handler(TRIG_TYPE_MCONTROL6, action, *src1);
-  } else if(funct5 == 0b00011) { // sc
-    action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_STORE, *src1, TRIGGER_NO_VALUE); trigger_handler(TRIG_TYPE_MCONTROL6, action, *src1);
-  } else { // amo
-    action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_LOAD, *src1, TRIGGER_NO_VALUE); trigger_handler(TRIG_TYPE_MCONTROL6, action, *src1);
-    action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_STORE, *src1, TRIGGER_NO_VALUE); trigger_handler(TRIG_TYPE_MCONTROL6, action, *src1);
+  if (trigger_mcontrol6_active(cpu.TM)) {
+    if (funct5 == 0b00010) { // lr
+      action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_LOAD, *src1, TRIGGER_NO_VALUE); trigger_handler(TRIG_TYPE_MCONTROL6, action, *src1);
+    } else if(funct5 == 0b00011) { // sc
+      action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_STORE, *src1, TRIGGER_NO_VALUE); trigger_handler(TRIG_TYPE_MCONTROL6, action, *src1);
+    } else { // amo
+      action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_LOAD, *src1, TRIGGER_NO_VALUE); trigger_handler(TRIG_TYPE_MCONTROL6, action, *src1);
+      action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_STORE, *src1, TRIGGER_NO_VALUE); trigger_handler(TRIG_TYPE_MCONTROL6, action, *src1);
+    }
   }
 #endif // CONFIG_TDATA1_MCONTROL6
 

--- a/src/isa/riscv64/instr/rvcbo/cbo_impl.c
+++ b/src/isa/riscv64/instr/rvcbo/cbo_impl.c
@@ -43,9 +43,11 @@ static void paddr_check(paddr_t paddr, vaddr_t vaddr, int type) {
 static void trigger_check(vaddr_t vaddr){
 #ifdef CONFIG_TDATA1_MCONTROL6
   vaddr_t block_addr = vaddr & ~CACHE_BLOCK_MASK;
-  for (uint64_t offset = 0; offset < CACHE_BLOCK_SIZE; offset++) {
-    trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_STORE, block_addr + offset, TRIGGER_NO_VALUE);
-    trigger_handler(TRIG_TYPE_MCONTROL6, action, vaddr);
+  if (trigger_mcontrol6_active(cpu.TM)) {
+    for (uint64_t offset = 0; offset < CACHE_BLOCK_SIZE; offset++) {
+      trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_STORE, block_addr + offset, TRIGGER_NO_VALUE);
+      trigger_handler(TRIG_TYPE_MCONTROL6, action, vaddr);
+    }
   }
 #endif // CONFIG_TDATA1_MCONTROL6
 }

--- a/src/isa/riscv64/instr/rvi/ldst_trig.h
+++ b/src/isa/riscv64/instr/rvi/ldst_trig.h
@@ -2,8 +2,10 @@
   def_EHelper(name) { \
     trig_action_t action = TRIG_ACTION_NONE; \
     const vaddr_t vaddr = *dsrc1 + id_src2->imm; \
-    action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_LOAD, vaddr, TRIGGER_NO_VALUE); \
-    trigger_handler(TRIG_TYPE_MCONTROL6, action, vaddr); \
+    if (trigger_mcontrol6_active(cpu.TM)) { \
+      action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_LOAD, vaddr, TRIGGER_NO_VALUE); \
+      trigger_handler(TRIG_TYPE_MCONTROL6, action, vaddr); \
+    } \
     concat(rtl_, rtl_instr) (s, ddest, dsrc1, id_src2->imm, width, mmu_mode); \
   }
 
@@ -12,8 +14,10 @@
     trig_action_t action = TRIG_ACTION_NONE; \
     const vaddr_t vaddr = *dsrc1 + id_src2->imm; \
     const word_t data = *ddest; \
-    action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_STORE, vaddr, data); \
-    trigger_handler(TRIG_TYPE_MCONTROL6, action, vaddr); \
+    if (trigger_mcontrol6_active(cpu.TM)) { \
+      action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_STORE, vaddr, data); \
+      trigger_handler(TRIG_TYPE_MCONTROL6, action, vaddr); \
+    } \
     concat(rtl_, rtl_instr) (s, ddest, dsrc1, id_src2->imm, width, mmu_mode); \
   }
 

--- a/src/isa/riscv64/instr/rvv/vldst_impl.c
+++ b/src/isa/riscv64/instr/rvv/vldst_impl.c
@@ -399,8 +399,10 @@ void vld(Decode *s, int mode, int mmu_mode) {
       for (fn = 0; fn < nf; fn++) {
         addr = base_addr + idx * stride + (idx * nf * is_unit_stride + fn) * s->v_width;
 
-        IFDEF(CONFIG_TDATA1_MCONTROL6, trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_LOAD, addr, TRIGGER_NO_VALUE); \
-                                trigger_handler(TRIG_TYPE_MCONTROL6, action, addr));
+        IFDEF(CONFIG_TDATA1_MCONTROL6, if (trigger_mcontrol6_active(cpu.TM)) { \
+                                          trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_LOAD, addr, TRIGGER_NO_VALUE); \
+                                          trigger_handler(TRIG_TYPE_MCONTROL6, action, addr); \
+                                        })
 
         isa_vec_misalign_data_addr_check(addr, s->v_width, MEM_TYPE_READ);
 
@@ -492,8 +494,10 @@ void vldx(Decode *s, int mmu_mode) {
       // read data in memory
       addr = base_addr + index + fn * data_width;
 
-      IFDEF(CONFIG_TDATA1_MCONTROL6, trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_LOAD, addr, TRIGGER_NO_VALUE); \
-                              trigger_handler(TRIG_TYPE_MCONTROL6, action, addr));
+      IFDEF(CONFIG_TDATA1_MCONTROL6, if (trigger_mcontrol6_active(cpu.TM)) { \
+                                        trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_LOAD, addr, TRIGGER_NO_VALUE); \
+                                        trigger_handler(TRIG_TYPE_MCONTROL6, action, addr); \
+                                      })
 
       isa_vec_misalign_data_addr_check(addr, data_width, MEM_TYPE_READ);
 
@@ -666,8 +670,10 @@ void vst(Decode *s, int mode, int mmu_mode) {
         uint64_t offset = idx * stride + (idx * nf * is_unit_stride + fn) * s->v_width;
         addr = base_addr + offset;
         if (!fast_vse) {
-          IFDEF(CONFIG_TDATA1_MCONTROL6, trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_STORE, addr, TRIGGER_NO_VALUE); \
-                                  trigger_handler(TRIG_TYPE_MCONTROL6, action, addr));
+          IFDEF(CONFIG_TDATA1_MCONTROL6, if (trigger_mcontrol6_active(cpu.TM)) { \
+                                            trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_STORE, addr, TRIGGER_NO_VALUE); \
+                                            trigger_handler(TRIG_TYPE_MCONTROL6, action, addr); \
+                                          })
 
           isa_vec_misalign_data_addr_check(addr, s->v_width, MEM_TYPE_WRITE);
 
@@ -737,8 +743,10 @@ void vstx(Decode *s, int mmu_mode) {
       get_vreg(vd + fn * lmul, idx, &tmp_reg[1], eew, 0, 0, 0);
       addr = base_addr + index + fn * data_width;
 
-      IFDEF(CONFIG_TDATA1_MCONTROL6, trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_STORE, addr, TRIGGER_NO_VALUE); \
-                              trigger_handler(TRIG_TYPE_MCONTROL6, action, addr));
+      IFDEF(CONFIG_TDATA1_MCONTROL6, if (trigger_mcontrol6_active(cpu.TM)) { \
+                                        trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_STORE, addr, TRIGGER_NO_VALUE); \
+                                        trigger_handler(TRIG_TYPE_MCONTROL6, action, addr); \
+                                      })
 
       isa_vec_misalign_data_addr_check(addr, data_width, MEM_TYPE_WRITE);
 
@@ -800,8 +808,10 @@ void vlr(Decode *s, int mmu_mode) {
       for (pos = offset; pos < elt_per_reg; pos++, vstart->val++) {
         addr = base_addr + idx * s->v_width;
 
-        IFDEF(CONFIG_TDATA1_MCONTROL6, trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_LOAD, addr, TRIGGER_NO_VALUE); \
-                                trigger_handler(TRIG_TYPE_MCONTROL6, action, addr));
+        IFDEF(CONFIG_TDATA1_MCONTROL6, if (trigger_mcontrol6_active(cpu.TM)) { \
+                                          trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_LOAD, addr, TRIGGER_NO_VALUE); \
+                                          trigger_handler(TRIG_TYPE_MCONTROL6, action, addr); \
+                                        })
 
         isa_vec_misalign_data_addr_check(addr, s->v_width, MEM_TYPE_READ);
 
@@ -819,8 +829,10 @@ void vlr(Decode *s, int mmu_mode) {
       for (pos = 0; pos < elt_per_reg; pos++, vstart->val++) {
         addr = base_addr + idx * s->v_width;
 
-        IFDEF(CONFIG_TDATA1_MCONTROL6, trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_LOAD, addr, TRIGGER_NO_VALUE); \
-                                trigger_handler(TRIG_TYPE_MCONTROL6, action, addr));
+        IFDEF(CONFIG_TDATA1_MCONTROL6, if (trigger_mcontrol6_active(cpu.TM)) { \
+                                          trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_LOAD, addr, TRIGGER_NO_VALUE); \
+                                          trigger_handler(TRIG_TYPE_MCONTROL6, action, addr); \
+                                        })
 
         isa_vec_misalign_data_addr_check(addr, s->v_width, MEM_TYPE_READ);
 
@@ -868,8 +880,10 @@ void vsr(Decode *s, int mmu_mode) {
         get_vreg(vd + vreg_idx, pos, &tmp_reg[1], 0, 0, 0, 1);
         addr = base_addr + idx;
 
-        IFDEF(CONFIG_TDATA1_MCONTROL6, trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_STORE, addr, TRIGGER_NO_VALUE); \
-                                trigger_handler(TRIG_TYPE_MCONTROL6, action, addr));
+        IFDEF(CONFIG_TDATA1_MCONTROL6, if (trigger_mcontrol6_active(cpu.TM)) { \
+                                          trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_STORE, addr, TRIGGER_NO_VALUE); \
+                                          trigger_handler(TRIG_TYPE_MCONTROL6, action, addr); \
+                                        })
 
         isa_vec_misalign_data_addr_check(addr, 1, MEM_TYPE_WRITE);
 
@@ -884,8 +898,10 @@ void vsr(Decode *s, int mmu_mode) {
         get_vreg(vd + vreg_idx, pos, &tmp_reg[1], 0, 0, 0, 1);
         addr = base_addr + idx;
 
-        IFDEF(CONFIG_TDATA1_MCONTROL6, trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_STORE, addr, TRIGGER_NO_VALUE); \
-                                trigger_handler(TRIG_TYPE_MCONTROL6, action, addr));
+        IFDEF(CONFIG_TDATA1_MCONTROL6, if (trigger_mcontrol6_active(cpu.TM)) { \
+                                          trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_STORE, addr, TRIGGER_NO_VALUE); \
+                                          trigger_handler(TRIG_TYPE_MCONTROL6, action, addr); \
+                                        })
 
         isa_vec_misalign_data_addr_check(addr, 1, MEM_TYPE_WRITE);
 
@@ -1070,8 +1086,10 @@ void vldff(Decode *s, int mode, int mmu_mode) {
         for (fn = 0; fn < nf; fn++) {
           addr = base_addr + idx * stride + (idx * nf * is_unit_stride + fn) * s->v_width;
 
-          IFDEF(CONFIG_TDATA1_MCONTROL6, trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_LOAD, addr, TRIGGER_NO_VALUE); \
-                                  trigger_handler(TRIG_TYPE_MCONTROL6, action, addr));
+          IFDEF(CONFIG_TDATA1_MCONTROL6, if (trigger_mcontrol6_active(cpu.TM)) { \
+                                            trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_LOAD, addr, TRIGGER_NO_VALUE); \
+                                            trigger_handler(TRIG_TYPE_MCONTROL6, action, addr); \
+                                          })
           isa_vec_misalign_data_addr_check(addr, s->v_width, MEM_TYPE_READ);
 
           IFDEF(CONFIG_MULTICORE_DIFF, need_read_golden_mem = true);

--- a/src/isa/riscv64/local-include/trigger.h
+++ b/src/isa/riscv64/local-include/trigger.h
@@ -177,6 +177,15 @@ bool mcontrol6_value_match(Trigger* trig, word_t value);
 bool mcontrol6_check_chain_legal(const TriggerModule* TM, const int max_chain_len);
 void mcontrol6_checked_write(trig_mcontrol6_t* mcontrol6, word_t* wdata, const TriggerModule* TM);
 
+static inline bool trigger_mcontrol6_active(const TriggerModule* TM) {
+  for (int i = 0; i < CONFIG_TRIGGER_NUM; i++) {
+    if (TM->triggers[i].tdata1.common.type == TRIG_TYPE_MCONTROL6) {
+      return true;
+    }
+  }
+  return false;
+}
+
 trig_action_t check_triggers_etrigger(TriggerModule* TM, uint64_t cause);
 bool etrigger_match(Trigger* trig, uint64_t cause);
 void etrigger_checked_write(trig_etrigger_t* etrigger, word_t* wdata);


### PR DESCRIPTION
Hot execute, scalar load/store, AMO, CBO, and vector load/store paths enter the full mcontrol6 checker even when the trigger array contains no active mcontrol6 entry.

Check the authoritative trigger types at those call sites and skip the checker in the common inactive case. CSR writes and DiffTest imports update the same trigger array, so no derived state or synchronization is needed.

Active-trigger access order, timing, exception handling, and vector restart behavior are unchanged.