### PR TITLE
perf(riscv64): streamline page-table reads

### DIFF
--- a/include/memory/paddr.h
+++ b/include/memory/paddr.h
@@ -63,6 +63,10 @@ static inline bool in_pmem(paddr_t addr) {
 }
 
 word_t paddr_read(paddr_t addr, int len, int type, int trap_type, int mode, vaddr_t vaddr);
+/* Read an address that the caller has already classified as PMEM. */
+__attribute__((visibility("hidden")))
+word_t paddr_read_pmem_checked(paddr_t addr, int len, int type, int trap_type,
+                               int mode, vaddr_t vaddr);
 void paddr_read_matrix(paddr_t base, paddr_t stride, int row, int column, int msew, bool transpose,
                         int mode, vaddr_t vbase, char m_name, int mreg_id);
 void paddr_write(paddr_t addr, int len, word_t data, int mode, vaddr_t vaddr);

--- a/include/memory/paddr.h
+++ b/include/memory/paddr.h
@@ -67,6 +67,10 @@ static inline bool in_pmem(paddr_t addr) {
 }
 
 word_t paddr_read(paddr_t addr, int len, int type, int trap_type, int mode, vaddr_t vaddr);
+/* Read an address that the caller has already classified as PMEM. */
+__attribute__((visibility("hidden")))
+word_t paddr_read_pmem_checked(paddr_t addr, int len, int type, int trap_type,
+                               int mode, vaddr_t vaddr);
 void paddr_read_matrix(paddr_t base, paddr_t stride, int row, int column, int msew, bool transpose,
                         int mode, vaddr_t vbase, char m_name, int mreg_id);
 void paddr_write(paddr_t addr, int len, word_t data, int mode, vaddr_t vaddr);

--- a/src/isa/riscv64/system/mmu.c
+++ b/src/isa/riscv64/system/mmu.c
@@ -539,7 +539,19 @@ static word_t pte_read(paddr_t addr, int type, int mode, vaddr_t vaddr) {
   int paddr_read_type = type == MEM_TYPE_IFETCH ? MEM_TYPE_IFETCH_READ :
                         type == MEM_TYPE_WRITE  ? MEM_TYPE_WRITE_READ  :
                                                   MEM_TYPE_READ;
+#ifdef CONFIG_SHARE
+  if (unlikely(cpu.guided_exec)) {
+    return paddr_read(addr, PTE_SIZE, paddr_read_type, paddr_read_type,
+                      mode, vaddr);
+  }
+  // PTE addresses have already been classified as PMEM above. Keep the
+  // physical-access checks and PMEM backend behavior, but skip generic address
+  // routing that would classify the same address again.
+  return paddr_read_pmem_checked(addr, PTE_SIZE, paddr_read_type,
+                                 paddr_read_type, mode, vaddr);
+#else
   return paddr_read(addr, PTE_SIZE, paddr_read_type, paddr_read_type, mode, vaddr);
+#endif
 }
 #endif // CONFIG_MULTICORE_DIFF
 
@@ -917,6 +929,9 @@ void isa_amo_misalign_data_addr_check(vaddr_t vaddr, int len, int type) {
 paddr_t isa_mmu_translate(vaddr_t vaddr, int len, int type) {
   paddr_t ptw_result = ptw(vaddr, type);
 #ifdef FORCE_RAISE_PF
+  if (likely(!cpu.guided_exec || !cpu.execution_guide.force_raise_exception)) {
+    return ptw_result;
+  }
 #ifdef CONFIG_RVH
   if(ptw_result != MEM_RET_FAIL && (force_raise_pf(vaddr, type) != MEM_RET_OK || force_raise_gpf(vaddr, type) != MEM_RET_OK))
     return MEM_RET_FAIL;

--- a/src/isa/riscv64/system/mmu.c
+++ b/src/isa/riscv64/system/mmu.c
@@ -551,7 +551,19 @@ static word_t pte_read(paddr_t addr, int type, int mode, vaddr_t vaddr) {
   int paddr_read_type = type == MEM_TYPE_IFETCH ? MEM_TYPE_IFETCH_READ :
                         type == MEM_TYPE_WRITE  ? MEM_TYPE_WRITE_READ  :
                                                   MEM_TYPE_READ;
+#ifdef CONFIG_SHARE
+  if (unlikely(cpu.guided_exec)) {
+    return paddr_read(addr, PTE_SIZE, paddr_read_type, paddr_read_type,
+                      mode, vaddr);
+  }
+  // PTE addresses have already been classified as PMEM above. Keep the
+  // physical-access checks and PMEM backend behavior, but skip generic address
+  // routing that would classify the same address again.
+  return paddr_read_pmem_checked(addr, PTE_SIZE, paddr_read_type,
+                                 paddr_read_type, mode, vaddr);
+#else
   return paddr_read(addr, PTE_SIZE, paddr_read_type, paddr_read_type, mode, vaddr);
+#endif
 }
 #endif // CONFIG_MULTICORE_DIFF
 
@@ -1060,6 +1072,9 @@ paddr_t isa_mmu_translate(vaddr_t vaddr, int len, int type) {
   ptw_result = ptw(vaddr, type);
 #endif
 #ifdef FORCE_RAISE_PF
+  if (likely(!cpu.guided_exec || !cpu.execution_guide.force_raise_exception)) {
+    return ptw_result;
+  }
 #ifdef CONFIG_RVH
   if(ptw_result != MEM_RET_FAIL && (force_raise_pf(vaddr, type) != MEM_RET_OK || force_raise_gpf(vaddr, type) != MEM_RET_OK))
     return MEM_RET_FAIL;

--- a/src/memory/paddr.c
+++ b/src/memory/paddr.c
@@ -333,28 +333,53 @@ bool check_paddr(paddr_t addr, int len, int type, int trap_type, int mode, vaddr
   return true;
 }
 
-word_t paddr_read(paddr_t addr, int len, int type, int trap_type, int mode, vaddr_t vaddr) {
+static inline bool paddr_read_check(paddr_t addr, int len, int type,
+                                    int trap_type, int mode, vaddr_t vaddr,
+                                    int cross_page_load) {
   IFDEF(CONFIG_SHARE, hardware_error_check(vaddr);)
-
-  __attribute__((unused)) int cross_page_load = (mode & CROSS_PAGE_LD_FLAG) != 0;
-  mode &= ~CROSS_PAGE_LD_FLAG;
 
   assert(type == MEM_TYPE_READ || type == MEM_TYPE_IFETCH_READ || type == MEM_TYPE_IFETCH || type == MEM_TYPE_WRITE_READ || type == MEM_TYPE_MATRIX_READ || type == MEM_TYPE_MATRIX_WRITE);
   if (cpu.pbmt != 0) {
     isa_mmio_misalign_data_addr_check(addr, vaddr, len, MEM_TYPE_READ, cross_page_load);
   }
 
-  if (!check_paddr(addr, len, type, trap_type, mode, vaddr)) {
+  return check_paddr(addr, len, type, trap_type, mode, vaddr);
+}
+
+static inline word_t paddr_read_pmem_after_check(paddr_t addr, int len,
+                                                 int type, int mode) {
+  uint64_t rdata = pmem_read(addr, len);
+#ifdef CONFIG_SHARE
+  ref_log_cpu("paddr read addr:" FMT_PADDR ", data: %016lx, len:%d, type:%d, mode:%d",
+      addr, rdata, len, type, mode);
+#endif // CONFIG_SHARE
+  return rdata;
+}
+
+word_t paddr_read_pmem_checked(paddr_t addr, int len, int type, int trap_type,
+                               int mode, vaddr_t vaddr) {
+  int cross_page_load = (mode & CROSS_PAGE_LD_FLAG) != 0;
+  mode &= ~CROSS_PAGE_LD_FLAG;
+
+  if (!paddr_read_check(addr, len, type, trap_type, mode, vaddr,
+                        cross_page_load)) {
+    return 0;
+  }
+
+  return paddr_read_pmem_after_check(addr, len, type, mode);
+}
+
+word_t paddr_read(paddr_t addr, int len, int type, int trap_type, int mode, vaddr_t vaddr) {
+  int cross_page_load = (mode & CROSS_PAGE_LD_FLAG) != 0;
+  mode &= ~CROSS_PAGE_LD_FLAG;
+
+  if (!paddr_read_check(addr, len, type, trap_type, mode, vaddr,
+                        cross_page_load)) {
     return 0;
   }
 
   if (likely(in_pmem(addr))) {
-    uint64_t rdata = pmem_read(addr, len);
-#ifdef CONFIG_SHARE
-    ref_log_cpu("paddr read addr:" FMT_PADDR ", data: %016lx, len:%d, type:%d, mode:%d",
-        addr, rdata, len, type, mode);
-#endif // CONFIG_SHARE
-    return rdata;
+    return paddr_read_pmem_after_check(addr, len, type, mode);
   }
   else {
     if (likely(is_in_mmio(addr))) {

--- a/src/memory/paddr.c
+++ b/src/memory/paddr.c
@@ -367,28 +367,53 @@ bool mpt_paddr_read(paddr_t addr, int len, word_t *data) {
 }
 #endif
 
-word_t paddr_read(paddr_t addr, int len, int type, int trap_type, int mode, vaddr_t vaddr) {
+static inline bool paddr_read_check(paddr_t addr, int len, int type,
+                                    int trap_type, int mode, vaddr_t vaddr,
+                                    int cross_page_load) {
   IFDEF(CONFIG_SHARE, hardware_error_check(vaddr);)
-
-  __attribute__((unused)) int cross_page_load = (mode & CROSS_PAGE_LD_FLAG) != 0;
-  mode &= ~CROSS_PAGE_LD_FLAG;
 
   assert(type == MEM_TYPE_READ || type == MEM_TYPE_IFETCH_READ || type == MEM_TYPE_IFETCH || type == MEM_TYPE_WRITE_READ || type == MEM_TYPE_MATRIX_READ || type == MEM_TYPE_MATRIX_WRITE);
   if (cpu.pbmt != 0) {
     isa_mmio_misalign_data_addr_check(addr, vaddr, len, MEM_TYPE_READ, cross_page_load);
   }
 
-  if (!check_paddr(addr, len, type, trap_type, mode, vaddr)) {
+  return check_paddr(addr, len, type, trap_type, mode, vaddr);
+}
+
+static inline word_t paddr_read_pmem_after_check(paddr_t addr, int len,
+                                                 int type, int mode) {
+  uint64_t rdata = pmem_read(addr, len);
+#ifdef CONFIG_SHARE
+  ref_log_cpu("paddr read addr:" FMT_PADDR ", data: %016lx, len:%d, type:%d, mode:%d",
+      addr, rdata, len, type, mode);
+#endif // CONFIG_SHARE
+  return rdata;
+}
+
+word_t paddr_read_pmem_checked(paddr_t addr, int len, int type, int trap_type,
+                               int mode, vaddr_t vaddr) {
+  int cross_page_load = (mode & CROSS_PAGE_LD_FLAG) != 0;
+  mode &= ~CROSS_PAGE_LD_FLAG;
+
+  if (!paddr_read_check(addr, len, type, trap_type, mode, vaddr,
+                        cross_page_load)) {
+    return 0;
+  }
+
+  return paddr_read_pmem_after_check(addr, len, type, mode);
+}
+
+word_t paddr_read(paddr_t addr, int len, int type, int trap_type, int mode, vaddr_t vaddr) {
+  int cross_page_load = (mode & CROSS_PAGE_LD_FLAG) != 0;
+  mode &= ~CROSS_PAGE_LD_FLAG;
+
+  if (!paddr_read_check(addr, len, type, trap_type, mode, vaddr,
+                        cross_page_load)) {
     return 0;
   }
 
   if (likely(in_pmem(addr))) {
-    uint64_t rdata = pmem_read(addr, len);
-#ifdef CONFIG_SHARE
-    ref_log_cpu("paddr read addr:" FMT_PADDR ", data: %016lx, len:%d, type:%d, mode:%d",
-        addr, rdata, len, type, mode);
-#endif // CONFIG_SHARE
-    return rdata;
+    return paddr_read_pmem_after_check(addr, len, type, mode);
   }
   else {
     if (likely(is_in_mmio(addr))) {


### PR DESCRIPTION
Page-table walks repeatedly read PTEs through the generic `paddr_read()` path.

In shared REF mode, `pte_read()` has already rejected MMIO and non-PMEM PTE
addresses before entering the physical-memory layer. Calling the generic path
therefore repeats address-space routing for every PTE read.

Additionally, normal execution calls the forced page-fault helpers after every
successful translation, even when guided exception injection is inactive.

This PR introduces a checked PMEM-only physical read interface and uses it for
the common shared REF page-table walk path.

The new path skips redundant PMEM/MMIO classification while preserving:

- guided hardware-error injection;
- PBMT handling;
- PMP, PMA, and BMC permission checks;
- SparseMM and memory-analysis backend behavior;
- REF access logging;
- the original access-fault types.

Guided PTE accesses continue to use the generic `paddr_read()` path.

The translation path also returns early when guided page-fault injection is
inactive, avoiding calls to `force_raise_pf()` and `force_raise_gpf()` during
normal execution. Guided exception injection retains the existing behavior.