### PR TITLE
fix(build): remove redundant -c from preprocessing

### DIFF
--- a/scripts/build.mk
+++ b/scripts/build.mk
@@ -60,7 +60,7 @@ $(OBJ_DIR)/%.o: %.c
 	@echo + CC $<
 	@mkdir -p $(dir $@)
 	@$(CC) $(CFLAGS) $(SO_CFLAGS) -c -o $@ $<
-	@$(CC) $(CFLAGS) -E $(SO_CFLAGS) -c -o $@.c $<
+	@$(CC) $(CFLAGS) -E $(SO_CFLAGS) -o $@.c $<
 	$(call call_fixdep, $(@:.o=.d), $@)
 
 $(OBJ_DIR)/%.opp: %.cpp


### PR DESCRIPTION
When building NEMU with Clang 21.1.8 and `-Werror`, the preprocessing command fails with:

```text
error: argument unused during compilation: '-c' [-Werror,-Wunused-command-line-argument]
```

The command uses both -E and -c. Since -E stops after preprocessing, -c is redundant and Clang reports it as unused.
Remove -c from the preprocessing command while retaining it in the object compilation command.