### PR TITLE
fix(riscv64): preserve CLINT mtime writes

### DIFF
--- a/src/isa/riscv64/clint.c
+++ b/src/isa/riscv64/clint.c
@@ -49,7 +49,7 @@ static void clint_io_handler(uint32_t offset, int len, bool is_write) {
 #ifdef CONFIG_LIGHTQS_DEBUG
   printf("clint op write %d addr %x\n", is_write, offset);
 #endif // CONFIG_LIGHTQS_DEBUG
-  if (is_write && offset == CLINT_MTIME) {
+  if (is_write && offset == CLINT_MTIME * sizeof(clint_base[0])) {
     set_mtime(clint_base[CLINT_MTIME]);
   } else {
     update_riscv_timer();


### PR DESCRIPTION
Fix CLINT `mtime` MMIO write detection on RISC-V.