### PR TITLE
fix(riscv64): apply MPRV to effective addresses

### DIFF
--- a/src/isa/riscv64/system/mmu.c
+++ b/src/isa/riscv64/system/mmu.c
@@ -366,7 +366,9 @@ inline vaddr_t get_effective_address(vaddr_t vaddr, int type) {
   if (hld_st) {
     mode = hstatus->spvp;
     virt = true;
-  } else if (get_mprv() && mode != MODE_M ) {
+  } else if (get_mprv()) {
+    // MPRV makes data accesses use MPP; checking the current mode here would
+    // suppress precisely the M-mode accesses for which MPRV is intended.
     mode = mstatus->mpp;
     virt = mstatus->mpv;
   }


### PR DESCRIPTION
Use the privilege and virtualization mode selected by `mstatus.MPRV` when
calculating effective addresses for data accesses.

This fixes pointer masking for M-mode loads and stores performed with
`MPRV=1`.
