### PR TITLE
fix(difftest): flush tcache after injected interrupts

### DIFF
--- a/src/isa/riscv64/difftest/ref.c
+++ b/src/isa/riscv64/difftest/ref.c
@@ -333,6 +333,7 @@ void isa_difftest_raise_intr(word_t NO) {
   IFDEF(CONFIG_TDATA1_ITRIGGER, trig_action_t itrigger_action = check_triggers_itrigger(cpu.TM, NO));
 
   cpu.pc = raise_intr(NO, cpu.pc);
+  set_sys_state_flag(SYS_STATE_FLUSH_TCACHE);
 
   IFDEF(CONFIG_TDATA1_ITRIGGER, trigger_handler(TRIG_TYPE_ITRIG, itrigger_action, 0));
 


### PR DESCRIPTION
## Summary

- request a translation-cache flush after interrupts injected through the
  DiffTest API
- make the next reference-model step decode the handler after privilege/MMU
  state changes

## Background

The normal `cpu_exec()` interrupt path flushes the tcache immediately after
`raise_intr()`. The DiffTest API calls `raise_intr()` directly and bypasses
that path, so it can reuse a basic block cached under the previous privilege
or MMU state.

## Test

- `NEMU_HOME=$PWD make riscv64-xs-ref_defconfig`
- `NEMU_HOME=$PWD make -j$(nproc)`
- the same fix on `v2-fpgadiff` ran an FPGA DiffTest GCC workload for
  4,178 seconds without mismatch before manual stop
