### PR TITLE
perf(riscv64): cache final RVH translations

### DIFF
--- a/include/cpu/cpu.h
+++ b/include/cpu/cpu.h
@@ -56,6 +56,10 @@ enum {
 };
 void set_sys_state_flag(int flag);
 void mmu_tlb_flush(vaddr_t vaddr);
+#ifdef CONFIG_RVH
+void mmu_tlb_flush_host(vaddr_t vaddr);
+void mmu_tlb_flush_guest(vaddr_t vaddr);
+#endif
 
 struct Decode;
 void save_globals(struct Decode *s);

--- a/include/isa.h
+++ b/include/isa.h
@@ -59,6 +59,12 @@ int isa_mmu_check(vaddr_t vaddr, int len, int type);
 vaddr_t get_effective_address(vaddr_t vaddr, int type);
 #endif
 paddr_t isa_mmu_translate(vaddr_t vaddr, int len, int type);
+#ifdef CONFIG_RVH
+void isa_mmu_tlb_flush(void);
+#else
+static inline void isa_mmu_tlb_flush(void) {
+}
+#endif
 bool isa_pmp_check_permission(paddr_t addr, int len, int type, int mode);
 bool isa_pma_check_permission(paddr_t addr, int len, int type);
 #ifdef CONFIG_RV_MBMC

--- a/src/cpu/cpu-exec.c
+++ b/src/cpu/cpu-exec.c
@@ -182,9 +182,24 @@ void set_sys_state_flag(int flag) { g_sys_state_flag |= flag; }
 
 void mmu_tlb_flush(vaddr_t vaddr) {
   hosttlb_flush(vaddr);
+  isa_mmu_tlb_flush();
   if (vaddr == 0)
     set_sys_state_flag(SYS_STATE_FLUSH_TCACHE);
 }
+
+#ifdef CONFIG_RVH
+void mmu_tlb_flush_host(vaddr_t vaddr) {
+  hosttlb_flush(vaddr);
+  if (vaddr == 0)
+    set_sys_state_flag(SYS_STATE_FLUSH_TCACHE);
+}
+
+void mmu_tlb_flush_guest(vaddr_t vaddr) {
+  isa_mmu_tlb_flush();
+  if (vaddr == 0)
+    set_sys_state_flag(SYS_STATE_FLUSH_TCACHE);
+}
+#endif
 
 jmp_buf context_stack[CONTEXT_STACK_SIZE] = {};
 int context_idx = -1;

--- a/src/cpu/difftest/ref.c
+++ b/src/cpu/difftest/ref.c
@@ -63,6 +63,7 @@ void nemu_sparse_mem_copy(paddr_t nemu_addr, void *dut_buf, size_t n, bool direc
           dut_buf, a, direction == DIFFTEST_TO_REF ? "DIFFTEST_TO_REF": "REF_TO_DIFFTEST");
   if (direction == DIFFTEST_TO_REF)sparse_mem_copy(a, dut_buf);
   else sparse_mem_copy(dut_buf, a);
+  if (direction == DIFFTEST_TO_REF) isa_mmu_tlb_flush();
 
   printf("[sp-mem] copy complete, eg data: ");
   for (int j = 0; j < 8; j++) {
@@ -74,7 +75,10 @@ void nemu_sparse_mem_copy(paddr_t nemu_addr, void *dut_buf, size_t n, bool direc
 
 void nemu_memcpy_helper(paddr_t nemu_addr, void *dut_buf, size_t n, bool direction, void* (*cpy_func)(void*, const void*, size_t)) {
   assert(guest_to_host(nemu_addr) != NULL);
-  if (direction == DIFFTEST_TO_REF) cpy_func(guest_to_host(nemu_addr), dut_buf, n);
+  if (direction == DIFFTEST_TO_REF) {
+    cpy_func(guest_to_host(nemu_addr), dut_buf, n);
+    isa_mmu_tlb_flush();
+  }
   else cpy_func(dut_buf, guest_to_host(nemu_addr), n);
 }
 
@@ -83,6 +87,7 @@ void difftest_get_backed_memory(void *backed_pmem, size_t n) {
   // set pmem to backed_pmem, then nothing
   assert(n == CONFIG_MSIZE);
   set_pmem(true, backed_pmem);
+  isa_mmu_tlb_flush();
 #endif
 }
 

--- a/src/isa/riscv64/system/mmu.c
+++ b/src/isa/riscv64/system/mmu.c
@@ -730,6 +730,107 @@ int get_hyperinst_mmu_state() {
 
 #endif
 
+#ifdef CONFIG_RVH
+// Cache the final VS-stage + G-stage translation instead of walking both page
+// tables on every guest access. MPRV accesses remain on the slow path;
+// hypervisor loads/stores use a distinct translation context.
+#define RVH_FINAL_TLB_SIZE 4096
+
+typedef struct {
+  vaddr_t vpn;
+  paddr_t ppn;
+  uint64_t generation;
+  uint8_t type;
+  uint8_t pbmt;
+} rvh_final_tlb_entry_t;
+
+static rvh_final_tlb_entry_t rvh_final_tlb[RVH_FINAL_TLB_SIZE];
+static uint64_t rvh_final_tlb_generation = 1;
+static uint64_t rvh_final_tlb_vsatp = UINT64_MAX;
+static uint64_t rvh_final_tlb_hgatp = UINT64_MAX;
+static uint16_t rvh_final_tlb_context = UINT16_MAX;
+
+void isa_mmu_tlb_flush(void) {
+  if (unlikely(++rvh_final_tlb_generation == 0)) {
+    memset(rvh_final_tlb, 0, sizeof(rvh_final_tlb));
+    rvh_final_tlb_generation = 1;
+  }
+}
+
+static inline bool rvh_final_tlb_cacheable(int type) {
+  return (cpu.v || hld_st) && !cpu.amo &&
+      (type == MEM_TYPE_IFETCH || !get_mprv());
+}
+
+static inline uint16_t rvh_final_tlb_current_context(void) {
+  return (uint16_t)(
+      (cpu.mode << 0) |
+      (mstatus->mxr << 2) |
+      (vsstatus->mxr << 3) |
+      (vsstatus->sum << 4) |
+      (menvcfg->pbmte << 5) |
+      (henvcfg->pbmte << 6) |
+      (menvcfg->adue << 7) |
+      (henvcfg->adue << 8) |
+      (hld_st << 9) |
+      (hlvx << 10) |
+      (hstatus->spvp << 11));
+}
+
+static inline void rvh_final_tlb_sync_context(void) {
+  uint16_t context = rvh_final_tlb_current_context();
+  uint64_t current_vsatp = (cpu.v || hld_st) ? vsatp->val : UINT64_MAX;
+  uint64_t current_hgatp = (cpu.v || hld_st) ? hgatp->val : UINT64_MAX;
+  if (unlikely(rvh_final_tlb_vsatp != current_vsatp ||
+      rvh_final_tlb_hgatp != current_hgatp ||
+      rvh_final_tlb_context != context)) {
+    isa_mmu_tlb_flush();
+    rvh_final_tlb_vsatp = current_vsatp;
+    rvh_final_tlb_hgatp = current_hgatp;
+    rvh_final_tlb_context = context;
+  }
+}
+
+static inline rvh_final_tlb_entry_t *rvh_final_tlb_entry(vaddr_t vaddr, int type) {
+  uint64_t vpn = vaddr >> PAGE_SHIFT;
+  uint64_t hash = vpn ^ (uint64_t)type;
+  return &rvh_final_tlb[hash & (RVH_FINAL_TLB_SIZE - 1)];
+}
+
+static inline bool rvh_final_tlb_lookup(vaddr_t vaddr, int len, int type, paddr_t *result) {
+  if (!rvh_final_tlb_cacheable(type) ||
+      unlikely((vaddr & PAGE_MASK) + (word_t)len > PAGE_SIZE)) {
+    return false;
+  }
+
+  rvh_final_tlb_sync_context();
+  rvh_final_tlb_entry_t *entry = rvh_final_tlb_entry(vaddr, type);
+  if (likely(entry->generation == rvh_final_tlb_generation &&
+      entry->vpn == (vaddr >> PAGE_SHIFT) &&
+      entry->type == type)) {
+    cpu.pbmt = entry->pbmt;
+    *result = entry->ppn;
+    return true;
+  }
+  return false;
+}
+
+static inline void rvh_final_tlb_insert(vaddr_t vaddr, int len, int type, paddr_t result) {
+  if (!rvh_final_tlb_cacheable(type) ||
+      unlikely((vaddr & PAGE_MASK) + (word_t)len > PAGE_SIZE) ||
+      unlikely((result & PAGE_MASK) != MEM_RET_OK)) {
+    return;
+  }
+
+  rvh_final_tlb_entry_t *entry = rvh_final_tlb_entry(vaddr, type);
+  entry->vpn = vaddr >> PAGE_SHIFT;
+  entry->ppn = result & ~PAGE_MASK;
+  entry->type = type;
+  entry->pbmt = cpu.pbmt;
+  entry->generation = rvh_final_tlb_generation;
+}
+#endif
+
 int get_data_mmu_state() {
   return (data_mmu_state == MMU_DIRECT ? MMU_DIRECT : MMU_TRANSLATE);
 }
@@ -915,7 +1016,15 @@ void isa_amo_misalign_data_addr_check(vaddr_t vaddr, int len, int type) {
 }
 
 paddr_t isa_mmu_translate(vaddr_t vaddr, int len, int type) {
-  paddr_t ptw_result = ptw(vaddr, type);
+  paddr_t ptw_result;
+#ifdef CONFIG_RVH
+  bool tlb_hit = rvh_final_tlb_lookup(vaddr, len, type, &ptw_result);
+  if (!tlb_hit) {
+    ptw_result = ptw(vaddr, type);
+  }
+#else
+  ptw_result = ptw(vaddr, type);
+#endif
 #ifdef FORCE_RAISE_PF
 #ifdef CONFIG_RVH
   if(ptw_result != MEM_RET_FAIL && (force_raise_pf(vaddr, type) != MEM_RET_OK || force_raise_gpf(vaddr, type) != MEM_RET_OK))
@@ -925,6 +1034,11 @@ paddr_t isa_mmu_translate(vaddr_t vaddr, int len, int type) {
     return MEM_RET_FAIL;
 #endif // CONFIG_RVH
 #endif // FORCE_RAISE_PF
+#ifdef CONFIG_RVH
+  if (!tlb_hit) {
+    rvh_final_tlb_insert(vaddr, len, type, ptw_result);
+  }
+#endif
   return ptw_result;
 }
 

--- a/src/isa/riscv64/system/priv.c
+++ b/src/isa/riscv64/system/priv.c
@@ -3810,7 +3810,16 @@ void riscv64_priv_sfence_vma(vaddr_t vaddr, word_t asid) {
   if ((cpu.mode == MODE_S && mstatus->tvm == 1) || cpu.mode == MODE_U)
     longjmp_exception(EX_II);
 #endif // CONFIG_RVH
+#ifdef CONFIG_RVH
+  // SFENCE.VMA orders only the currently active first-stage translation.
+  if (cpu.v) {
+    mmu_tlb_flush_guest(vaddr);
+  } else {
+    mmu_tlb_flush_host(vaddr);
+  }
+#else
   mmu_tlb_flush(vaddr);
+#endif
 }
 
 #ifdef CONFIG_RVH
@@ -3821,7 +3830,7 @@ void riscv64_priv_sfence_vma(vaddr_t vaddr, word_t asid) {
 void riscv64_priv_hfence_vvma(vaddr_t vaddr, word_t asid) {
   if(cpu.v) longjmp_exception(EX_VI);
   if(!cpu.v && cpu.mode == MODE_U) longjmp_exception(EX_II);
-  mmu_tlb_flush(vaddr);
+  mmu_tlb_flush_guest(vaddr);
 }
 
 /// @brief Do RISC-V 64 privileged instruction: hfence.gvma
@@ -3831,7 +3840,7 @@ void riscv64_priv_hfence_vvma(vaddr_t vaddr, word_t asid) {
 void riscv64_priv_hfence_gvma(vaddr_t vaddr, word_t vmid) {
   if(cpu.v) longjmp_exception(EX_VI);
   if(!cpu.v && (cpu.mode == MODE_U || (cpu.mode == MODE_S && mstatus->tvm))) longjmp_exception(EX_II);
-  mmu_tlb_flush(vaddr);
+  mmu_tlb_flush_guest(vaddr);
 }
 #endif // CONFIG_RVH
 


### PR DESCRIPTION
Add a 4096-entry cache for final RVH two-stage translations, caching the final PPN and PBMT results from VS-stage and G-stage translation.

Track translation context and use generation-based invalidation. Separate host and guest invalidation for SFENCE/HFENCE, and invalidate cached translations when DiffTest updates guest memory.

Validated with H-extension tests, Linux with a KVM guest, REF shared-object execution, AM cputest, and non-RVH builds.