### PR TITLE
fix(riscv64): reset hypervisor access state

### DIFF
--- a/src/cpu/cpu-exec.c
+++ b/src/cpu/cpu-exec.c
@@ -855,6 +855,15 @@ void cpu_exec(uint64_t n) {
       cpu.pbmt = 0;
       cpu.isVldst = false;
       cpu.isVecUnitStore = false;
+#ifdef CONFIG_RVH
+      // HLV/HLVX/HSV set these transient translation controls around the
+      // memory operation. A fault leaves through longjmp, bypassing the
+      // normal helper epilogue, so clear them before executing the handler.
+      extern bool hld_st;
+      extern bool hlvx;
+      hld_st = false;
+      hlvx = false;
+#endif
 
       // No need to settle instruction counting here, as it is done in longjmp handler.
       // It's necessary to flush tcache for exception: addr space may conflict in different priv/mmu mode.

--- a/src/isa/riscv64/system/priv.c
+++ b/src/isa/riscv64/system/priv.c
@@ -3858,12 +3858,6 @@ void isa_hostcall(uint32_t id, rtlreg_t *dest, const rtlreg_t *src1,
 }
 
 #ifdef CONFIG_RVH
-int rvh_hlvx_check(struct Decode *s, int type){
-  extern bool hlvx;
-  hlvx = (s->isa.instr.i.opcode6_2 == 0x1c && s->isa.instr.i.funct3 == 0x4
-                  && (s->isa.instr.i.simm11_0 == 0x643 || s->isa.instr.i.simm11_0 == 0x683));
-  return hlvx;
-}
 extern bool hld_st;
 int riscv64_priv_hload(Decode *s, rtlreg_t *dest, const rtlreg_t * addr, int len, bool is_signed, bool is_hlvx) {
   if (cpu.v) {
@@ -3873,7 +3867,9 @@ int riscv64_priv_hload(Decode *s, rtlreg_t *dest, const rtlreg_t * addr, int len
     longjmp_exception(EX_II);
   }
 
+  extern bool hlvx;
   hld_st = true;
+  hlvx = is_hlvx;
   int mmu_mode = get_hyperinst_mmu_state();
 #ifdef CONFIG_TDATA1_MCONTROL6
   trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_LOAD, *addr, TRIGGER_NO_VALUE);
@@ -3887,6 +3883,7 @@ int riscv64_priv_hload(Decode *s, rtlreg_t *dest, const rtlreg_t * addr, int len
     IFDEF(CONFIG_RT_CHECK, assert(len == 1 || len == 2 || len == 4));
   }
   hld_st = false;
+  hlvx = false;
   return 0;
 }
 
@@ -3898,7 +3895,9 @@ int riscv64_priv_hstore(Decode *s, rtlreg_t *src, const rtlreg_t * addr, int len
     longjmp_exception(EX_II);
   }
 
+  extern bool hlvx;
   hld_st = true;
+  hlvx = false;
   int mmu_mode = get_hyperinst_mmu_state();
 #ifdef CONFIG_TDATA1_MCONTROL6
   trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_STORE, *addr, *src);
@@ -3907,6 +3906,7 @@ int riscv64_priv_hstore(Decode *s, rtlreg_t *src, const rtlreg_t * addr, int len
   rtl_sm(s, src, addr, 0, len, mmu_mode);
   IFDEF(CONFIG_RT_CHECK, assert(len == 1 || len == 2 || len == 4 || len == 8));
   hld_st = false;
+  hlvx = false;
   return 0;
 }
 #endif

--- a/src/memory/vaddr.c
+++ b/src/memory/vaddr.c
@@ -221,15 +221,6 @@ static void vaddr_mmu_write_matrix(struct Decode *s, vaddr_t base, vaddr_t strid
 
 static inline word_t vaddr_read_internal(void *s, vaddr_t addr, int len, int type, int mmu_mode) {
 
-#ifdef CONFIG_RVH
-  // check whether here is a hlvx instruction
-  // when inst fetch or vaddr_read_safe (for examine memory), s is NULL
-  if (s != NULL) {
-    extern int rvh_hlvx_check(struct Decode *s, int type);
-    rvh_hlvx_check((Decode*)s, type);
-  }
-#endif
-
   addr = get_effective_address(addr, type);
 
   bool is_cross_page = false;
@@ -270,10 +261,6 @@ static inline void vaddr_read_matrix_internal(struct Decode *s, vaddr_t base, va
     paddr_read_matrix(base, stride, row, column, msew, transpose,
                              cpu.mode, base, m_name, mreg_id);
   } else {
-#ifdef CONFIG_RVH
-    extern int rvh_hlvx_check(struct Decode *s, int type);
-    rvh_hlvx_check((Decode*)s, MEM_TYPE_MATRIX_READ);
-#endif
     MUXDEF(ENABLE_HOSTTLB, hosttlb_read_matrix, vaddr_mmu_read_matrix) (s, base, stride,
       row, column, msew, transpose, m_name, mreg_id);
   }


### PR DESCRIPTION
Set HLV/HLVX/HSV translation state explicitly instead of decoding the instruction again in the memory subsystem.

Clear the transient state after both normal execution and exception exits, preventing it from affecting later memory accesses.