### PR TITLE
perf(rvv): specialize translated VL8 loads in REF

### DIFF
--- a/src/isa/riscv64/instr/rvv/vldst.h
+++ b/src/isa/riscv64/instr/rvv/vldst.h
@@ -97,6 +97,9 @@ def_EHelper(vsxe) {
 def_EHelper(vle_mmu) { //unit-strided
   predecode_vls(s);
   require_vector(true);
+#if defined(CONFIG_SHARE_REF) && !defined(CONFIG_MULTICORE_DIFF)
+  if (likely(vld_unit_mmu_translate_vl8_hot(s))) return;
+#endif
   vld(s, MODE_UNIT, MMU_TRANSLATE);
 }
 

--- a/src/isa/riscv64/instr/rvv/vldst_impl.c
+++ b/src/isa/riscv64/instr/rvv/vldst_impl.c
@@ -258,6 +258,67 @@ void set_vec_load_difftest_info(int fn, int len) {
 }
 #endif // CONFIG_MULTICORE_DIFF
 
+#if defined(CONFIG_SHARE_REF) && !defined(CONFIG_MULTICORE_DIFF)
+static inline rtlreg_t vld_translate_vl8_load(Decode *s, vaddr_t addr, int width, uint64_t idx) {
+  vstart->val = idx;
+#ifdef CONFIG_TDATA1_MCONTROL6
+  if (trigger_mcontrol6_active(cpu.TM)) {
+    trig_action_t action = check_triggers_mcontrol6(cpu.TM, TRIG_OP_LOAD, addr, TRIGGER_NO_VALUE);
+    trigger_handler(TRIG_TYPE_MCONTROL6, action, addr);
+  }
+#endif
+  isa_vec_misalign_data_addr_check(addr, width, MEM_TYPE_READ);
+  rtlreg_t value;
+  rtl_lm(s, &value, &addr, 0, width, MMU_TRANSLATE);
+  return value;
+}
+
+static inline void vld_translate_vl8_fill_tail(uint64_t vd, int first_full_reg) {
+  for (int reg = first_full_reg; reg < 8; reg++) {
+    memset(&cpu.vr[vd + reg], 0xff, sizeof(cpu.vr[vd + reg]));
+  }
+}
+
+bool vld_unit_mmu_translate_vl8_hot(Decode *s) {
+  bool vle8 = s->v_width == 1 && vtype->vsew == 0;
+  bool vle32 = s->v_width == 4 && vtype->vsew == 2;
+  if (!(vle8 || vle32) || s->v_nf != 0 || s->vm == 0 ||
+      vtype->vlmul != 3 || vl->val != 8 || vstart->val != 0) {
+    return false;
+  }
+
+  vload_check(MODE_UNIT, s);
+  if (check_vstart_ignore(s)) return true;
+
+  rtl_lr(s, &s->src1.val, s->src1.reg, 4);
+  vaddr_t base = s->src1.val;
+  uint64_t vd = id_dest->reg;
+
+  if (vle8) {
+    for (uint64_t idx = 0; idx < 8; idx++) {
+      cpu.vr[vd]._8[idx] = vld_translate_vl8_load(s, base + idx, 1, idx);
+    }
+    if (RVV_AGNOSTIC && vtype->vta) {
+      memset(&cpu.vr[vd]._8[8], 0xff, sizeof(cpu.vr[vd]._8) - 8);
+      vld_translate_vl8_fill_tail(vd, 1);
+    }
+  } else {
+    for (uint64_t idx = 0; idx < 8; idx++) {
+      cpu.vr[vd + idx / 4]._32[idx % 4] =
+          vld_translate_vl8_load(s, base + idx * 4, 4, idx);
+    }
+    if (RVV_AGNOSTIC && vtype->vta) {
+      vld_translate_vl8_fill_tail(vd, 2);
+    }
+  }
+
+  vstart->val = 0;
+  cpu.isVldst = false;
+  vp_set_dirty();
+  return true;
+}
+#endif
+
 void vld(Decode *s, int mode, int mmu_mode) {
   vload_check(mode, s);
   if (skip_empty_vldst(s)) return;

--- a/src/isa/riscv64/instr/rvv/vldst_impl.h
+++ b/src/isa/riscv64/instr/rvv/vldst_impl.h
@@ -39,6 +39,9 @@
 #define MODE_MASK    3
 
 // vector load
+#if defined(CONFIG_SHARE_REF) && !defined(CONFIG_MULTICORE_DIFF)
+bool vld_unit_mmu_translate_vl8_hot(Decode *s);
+#endif
 void vld(Decode *s, int mode, int mmu_mode);
 void vldx(Decode *s, int mmu_mode);
 void vlr(Decode *s, int mmu_mode);


### PR DESCRIPTION
Use a dedicated shared-REF path for common unmasked VL=8 LMUL=8 vle8.v and vle32.v loads while retaining per-element translation, trigger, misalignment, vstart, and restart behavior.