### PR TITLE
ci(riscv64): run nexus-am RVH bare-metal tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,12 @@ jobs:
         uses: actions/checkout@v7
         with:
           submodules: 'recursive'
+      - name: Checkout workload-builder
+        uses: actions/checkout@v7
+        with:
+          repository: OpenXiangShan/workload-builder
+          ref: f662b2382ccb18274769d49559926ad656a4d9b2
+          path: workload-builder
       - name: Restore cache
         uses: actions/cache@v6
         with:
@@ -125,6 +131,19 @@ jobs:
       - name: System - KVM
         run: |
           ./build/riscv64-nemu-interpreter -b ${CI_WORKLOADS}/linux/kvmtool/fw_payload.bin
+      - name: RVH bare-metal regression tests
+        run: |
+          git -C workload-builder submodule update --init nexus-am
+          AM_HOME=${GITHUB_WORKSPACE}/workload-builder/nexus-am \
+          PKG_DIR=${GITHUB_WORKSPACE}/rvh-workload \
+          CROSS_COMPILE=${CROSS_COMPILE} \
+            bash workload-builder/workloads/am/rvh-tests/build.sh
+          make clean-all
+          make riscv64-xs_bitmap_defconfig
+          make -j `nproc`
+          for test_bin in ${GITHUB_WORKSPACE}/rvh-workload/bin/*.bin; do
+            ./build/riscv64-nemu-interpreter -b "$test_bin"
+          done
       - name: test cpt taking and restoring using zstd format
         run: |
           make clean-all


### PR DESCRIPTION
## Summary

Run the RVH bare-metal regression tests in the existing XiangShan CI job using the packaged workloads from `workload-builder`.

## Dependency

This PR depends on the corresponding PRs in:

1. `nexus-am`, which provides the test source.
2. `workload-builder`, which builds and packages the tests.

This PR should not be merged until both dependency PRs are merged. Afterward, it will be updated to use the workload generated from their merged main-branch revisions.