### PR TITLE
fix(mmio): raise access-fault for misaligned MMIO accesses

### DIFF
--- a/src/memory/paddr.c
+++ b/src/memory/paddr.c
@@ -230,12 +230,13 @@ static inline void hardware_error_check(vaddr_t vaddr) {
 }
 #endif
 
-// MMIO access currently does not support hardware misalignment.
+// MMIO is non-idempotent: misaligned access must raise access-fault (not
+// address-misaligned), so software will not emulate it with smaller accesses.
 void isa_mmio_misalign_data_addr_check(paddr_t paddr, vaddr_t vaddr, int len, int type, int is_cross_page) {
   if (unlikely((paddr & (len - 1)) != 0) || is_cross_page) {
     Logm("addr misaligned happened: paddr:" FMT_PADDR " vaddr:" FMT_WORD " len:%d type:%d pc:%lx", paddr, vaddr, len, type, cpu.pc);
     if (ISDEF(CONFIG_MMIO_AC_SOFT)) {
-      int ex = cpu.amo || type == MEM_TYPE_WRITE ? EX_SAM : EX_LAM;
+      int ex = cpu.amo || type == MEM_TYPE_WRITE ? EX_SAF : EX_LAF;
       cpu.trapInfo.tval = vaddr;
       longjmp_exception(ex);
     }


### PR DESCRIPTION
## Summary

- Raise `EX_LAF` / `EX_SAF` (instead of `EX_LAM` / `EX_SAM`) for misaligned MMIO accesses in `isa_mmio_misalign_data_addr_check`.
- Non-idempotent regions should not use address-misaligned traps, so software will not emulate them with multiple smaller MMIO accesses (Privileged Spec §3.6.1).
- Aligns NEMU with XiangShan behavior from OpenXiangShan/XiangShan#5700.

Fixes #990

## Test

- [x] Bare-metal smoke against CLINT (`0x38000001`): misaligned `lw`/`sw`
  - before: `mcause` = LAM (4) → BAD TRAP (`a0=4`)
  - after: `mcause` = LAF (5) then SAF (7) → GOOD TRAP (`a0=0`)
- [x] Only MMIO soft-check path changed; general/`AC_SOFT` and NC paths untouched