### PR TITLE
fix(wfi): wake on mtopi/stopi/vstopi pending under AIA (#1056)

### DIFF
--- a/src/isa/riscv64/system/priv.c
+++ b/src/isa/riscv64/system/priv.c
@@ -3766,10 +3766,24 @@ void riscv64_priv_wfi() {
 #ifdef CONFIG_HAS_CLINT
   void update_riscv_timer();
   update_riscv_timer();
+  // Spec: WFI must resume when an interrupt is pending at any privilege
+  // level (mtopi/stopi/vstopi != 0), independent of mie/mip enables.
+  // isa_query_intr() means "deliverable now" and misses AIA hvictl.VTI
+  // paths that set vstopi without touching mip (#1056).
+#ifdef CONFIG_RV_IMSIC
+  update_mtopi();
+  update_stopi();
+  update_vstopi();
+  if (mtopi->val == 0 && stopi->val == 0 && vstopi->val == 0) {
+    void timer_wait_for_interrupt();
+    timer_wait_for_interrupt();
+  }
+#else
   if (isa_query_intr() == INTR_EMPTY) {
     void timer_wait_for_interrupt();
     timer_wait_for_interrupt();
   }
+#endif // CONFIG_RV_IMSIC
 #endif // CONFIG_HAS_CLINT
 
 set_sys_state_flag(SYS_STATE_UPDATE);


### PR DESCRIPTION
## Summary
- Under `CONFIG_RV_IMSIC`, decide WFI timer wait by whether `mtopi`/`stopi`/`vstopi` are all zero, matching the pending-at-any-level wake condition.
- Do not reuse `isa_query_intr()` for WFI: it means "deliverable now" and misses AIA paths such as `hvictl.VTI` that set `vstopi` without `mip`.
- Keep the previous `isa_query_intr() == INTR_EMPTY` check when IMSIC is disabled.

Fixes #1056

## Test plan
- [x] Local smoke (`CONFIG_RV_IMSIC` + `CLINT_LOCAL_TIMER_INTERRUPT`): set `hvictl.VTI` so `vstopi != 0`; WFI must not advance mtime by `WFI_TIMEOUT` (before: sleeps; after: wakes).
- [x] Same config with no topi pending: WFI still waits (mtime jumps).
- [ ] Reviewer: rebuild with AIA/IMSIC defconfig used by XS ref if needed.