### PR TITLE
feat(difftest): sync AME mcfg state via regcpy

### DIFF
--- a/src/isa/riscv64/include/isa-def.h
+++ b/src/isa/riscv64/include/isa-def.h
@@ -148,6 +148,7 @@ typedef struct {
 #ifdef CONFIG_RV_AME
   uint64_t mcsr, mxrm, msat, mfflags, mfrm, msaten;
   uint64_t tlenb, trlenb, alenb, mtilem, mtilen, mtilek, msync;
+  mcfg_t mcfg[8];
 #endif // CONFIG_RV_AME
 
 #ifdef CONFIG_DIFFTEST_CHECK_SDTRIG
@@ -221,7 +222,6 @@ typedef struct {
     uint8_t  _8[ARENUM8];
   } macc[4][ROWNUM];
 
-  mcfg_t mcfg[8];
   uint64_t mtokr[MSYNC];
 #endif // CONFIG_RV_AME
 


### PR DESCRIPTION
Move the eight AME matrix configuration entries before difftest_state_end so regcpy transfers them with the existing AME CSR state instead of keeping them in the private matrix execution state.

mcfg will use the same comparison method as states such as scalar registers, vector registers, and CSR.