### PR TITLE
fix(riscv64): invalidate HostTLB entries for superpage fences

### DIFF
--- a/src/memory/host-tlb.c
+++ b/src/memory/host-tlb.c
@@ -48,15 +48,10 @@ static inline int hosttlb_idx(vaddr_t vaddr) {
 
 void hosttlb_flush(vaddr_t vaddr) {
   Logm("hosttlb_flush " FMT_WORD, vaddr);
-  if (vaddr == 0) {
-    memset(hosttlb, -1, sizeof(hosttlb));
-  } else {
-    vaddr_t gvpn = hosttlb_vpn(vaddr);
-    int idx = hosttlb_idx(vaddr);
-    if (hostrtlb[idx].gvpn == gvpn) hostrtlb[idx].gvpn = (sword_t)-1;
-    if (hostwtlb[idx].gvpn == gvpn) hostwtlb[idx].gvpn = (sword_t)-1;
-    if (hostxtlb[idx].gvpn == gvpn) hostxtlb[idx].gvpn = (sword_t)-1;
-  }
+  // HostTLB entries are keyed by 4 KiB VPNs but do not retain the page-table
+  // leaf size. An address-specific SFENCE.VMA must also invalidate sibling
+  // entries derived from a superpage translation, so flush conservatively.
+  memset(hosttlb, -1, sizeof(hosttlb));
 }
 
 void hosttlb_init() {


### PR DESCRIPTION
## Summary

Fix stale guest memory accesses after Linux reclaims THP-backed anonymous
memory with `MADV_DONTNEED` and issues an address-specific `SFENCE.VMA`.

## Root Cause

NEMU's HostTLB caches translations using 4 KiB guest virtual page numbers.
However, a single 2 MiB guest page-table leaf can populate multiple 4 KiB
HostTLB entries.

For an address-specific `SFENCE.VMA`, the old implementation invalidated only
the exact 4 KiB entry corresponding to `rs1`. Sibling entries derived from the
same superpage translation remained valid and continued to point to stale
memory.

This caused stale data to be observed after Linux discarded and replaced a
THP-backed mapping, eventually corrupting jemalloc or application state.

## Simple Example

Assume Linux maps a 2 MiB virtual region using one superpage PTE:

```text
VA 0x40000000 - 0x401fffff
        ↓ one 2 MiB page-table leaf
PA 0x80000000 - 0x801fffff
```

A 2 MiB page contains 512 4 KiB pages. Although the guest page table
contains only one superpage mapping, NEMU's HostTLB may cache the accessed
subpages separately:

```text
HostTLB[0]   : VA 0x40000000 → old PA
HostTLB[1]   : VA 0x40001000 → old PA
HostTLB[2]   : VA 0x40002000 → old PA
...
HostTLB[511] : VA 0x401ff000 → old PA
```

After the guest executes `MADV_DONTNEED`, Linux discards the old physical
pages, updates the page-table mapping, and executes an address-specific
`SFENCE.VMA`.

The old NEMU implementation invalidated only the HostTLB entry for the
specified 4 KiB address. For example:

```text
Invalidated: HostTLB[0]
Still valid: HostTLB[1] ... HostTLB[511]
```

The next access to `0x40000000` performed a fresh page-table walk and observed
the new zero-filled page, but an access to `0x40001000` still hit a stale
HostTLB entry and read the old physical page.

The fix conservatively invalidates all HostTLB entries:

```text
Invalidated: HostTLB[0] ... HostTLB[511]
```

Subsequent accesses must walk the updated page tables and therefore observe
the new mapping.