### PR TITLE
perf(simpoint): accelerate basic-block profiling

### DIFF
--- a/include/checkpoint/simpoint.h
+++ b/include/checkpoint/simpoint.h
@@ -41,6 +41,7 @@
 #ifndef __CPU_SIMPLE_PROBES_SIMPOINT_HH__
 #define __CPU_SIMPLE_PROBES_SIMPOINT_HH__
 
+#include <array>
 #include <unordered_map>
 #include <base/output.h>
 
@@ -93,6 +94,8 @@ class SimPoint
 
     void profile_with_abs_icount(Addr pc, bool is_control, bool is_last_uop, uint64_t abs_icount);
 
+    void profile_basic_block_with_abs_icount(Addr control_pc, Addr next_pc, uint64_t abs_icount);
+
   private:
     uint64_t lastICount{0};
     /** SimPoint profiling interval size in instructions */
@@ -116,8 +119,17 @@ class SimPoint
         uint64_t count;
     };
 
+    static constexpr size_t bbLookupCacheSize = 8192;
+
+    struct BBLookupCacheEntry
+    {
+        BasicBlockRange range;
+        BBInfo *info;
+    };
+
     /** Hash table containing all previously seen basic blocks */
     ::std::unordered_map<BasicBlockRange, BBInfo> bbMap;
+    ::std::array<BBLookupCacheEntry, bbLookupCacheSize> bbLookupCache{};
     /** Currently executing basic block */
     BasicBlockRange currentBBV;
     /** inst count in current basic block */

--- a/src/checkpoint/simpoint.cpp
+++ b/src/checkpoint/simpoint.cpp
@@ -78,6 +78,7 @@ SimPoint::~SimPoint() {
 void
 SimPoint::init() {
   if (profiling_state == SimpointProfiling) {
+    bbMap.reserve(bbLookupCacheSize);
     pathManager.setSimpointProfilingOutputDir();
     assert(checkpoint_interval);
     intervalSize = checkpoint_interval;
@@ -102,6 +103,14 @@ SimPoint::profile_with_abs_icount(Addr pc, bool is_control, bool is_last_uop, ui
 }
 
 void
+SimPoint::profile_basic_block_with_abs_icount(Addr control_pc, Addr next_pc, uint64_t abs_icount) {
+  unsigned exec_count = abs_icount - lastICount;
+  profile(control_pc, true, true, exec_count);
+  currentBBV.first = next_pc;
+  lastICount = abs_icount;
+}
+
+void
 SimPoint::profile(Addr pc, bool is_control, bool is_last_uop, unsigned instr_count) {
 
   if (!is_last_uop)
@@ -121,21 +130,26 @@ SimPoint::profile(Addr pc, bool is_control, bool is_last_uop, unsigned instr_cou
   if (is_control) {
     currentBBV.second = pc;
 
-    auto map_itr = bbMap.find(currentBBV);
-    Logsp("Finding BB 0x%lx -> 0x%lx", currentBBV.first, currentBBV.second);
-    if (map_itr == bbMap.end()) {
-      // If a new (previously unseen) basic block is found,
-      // add a new unique id, record num of insts and insert into bbMap.
-      BBInfo info;
-      info.id = bbMap.size() + 1;
-      info.insts = currentBBVInstCount;
-      info.count = currentBBVInstCount;
-      bbMap.insert(::std::make_pair(currentBBV, info));
+    const size_t cache_idx = std::hash<BasicBlockRange>()(currentBBV) &
+                             (bbLookupCacheSize - 1);
+    BBLookupCacheEntry &cache_entry = bbLookupCache[cache_idx];
+    BBInfo *info = cache_entry.info;
+    if (info != nullptr && cache_entry.range == currentBBV) {
+      info->count += currentBBVInstCount;
     } else {
-      // If basic block is seen before, just increment the count by the
-      // number of insts in basic block.
-      BBInfo &info = map_itr->second;
-      info.count += currentBBVInstCount;
+      auto map_itr = bbMap.find(currentBBV);
+      Logsp("Finding BB 0x%lx -> 0x%lx", currentBBV.first, currentBBV.second);
+      if (map_itr == bbMap.end()) {
+        BBInfo new_info;
+        new_info.id = bbMap.size() + 1;
+        new_info.insts = currentBBVInstCount;
+        new_info.count = currentBBVInstCount;
+        map_itr = bbMap.insert(::std::make_pair(currentBBV, new_info)).first;
+      } else {
+        map_itr->second.count += currentBBVInstCount;
+      }
+      cache_entry.range = currentBBV;
+      cache_entry.info = &map_itr->second;
     }
     currentBBVInstCount = 0;
 
@@ -189,6 +203,10 @@ void simpoint_init() {
 #ifndef CONFIG_SHARE
 void simpoint_profiling(uint64_t pc, bool is_control, uint64_t abs_instr_count) {
   simpoit_obj.profile_with_abs_icount(pc, is_control, true, abs_instr_count);
+}
+
+void simpoint_profiling_bb(uint64_t control_pc, uint64_t next_pc, uint64_t abs_instr_count) {
+  simpoit_obj.profile_basic_block_with_abs_icount(control_pc, next_pc, abs_instr_count);
 }
 #endif
 }

--- a/src/cpu/cpu-exec.c
+++ b/src/cpu/cpu-exec.c
@@ -323,27 +323,26 @@ uint64_t per_bb_profile(Decode *prev_s, Decode *s, bool control_taken) {
   // checkpoint_icount_base is set from nemu_trap.
   // Profiling and checkpointing use this as the starting point for instruction counting.
   uint64_t abs_inst_count = get_abs_instr_count() - checkpoint_icount_base;
+  bool workload_ready = workload_loaded || donot_skip_boot;
   // workload_loaded set from nemu_trap
   //
-  if (enable_semantic_point_cpt() && (workload_loaded || donot_skip_boot)) {
+  if (workload_ready && enable_semantic_point_cpt()) {
     semantic_point_profile(prev_s->pc, true, abs_inst_count);
     semantic_point_profile(s->pc, false, abs_inst_count);
   }
 
-  if (profiling_state == SimpointProfiling && (workload_loaded||donot_skip_boot)) {
-    simpoint_profiling(prev_s->pc, true, abs_inst_count);
-    simpoint_profiling(s->pc, false, abs_inst_count);
+  if (workload_ready && profiling_state == SimpointProfiling) {
+    simpoint_profiling_bb(prev_s->pc, s->pc, abs_inst_count);
+  }
+
+  if (!workload_ready || checkpoint_state == NoCheckpoint) {
+    return abs_inst_count;
   }
 
   //umod or not set force m mod
   extern bool able_to_take_cpt();
   bool able_to_take = able_to_take_cpt() || force_cpt_mmode;
   if (!able_to_take) {
-    return abs_inst_count;
-  }
-
-  //
-  if (!(workload_loaded||donot_skip_boot)) {
     return abs_inst_count;
   }
 

--- a/src/engine/interpreter/rtl-basic.h
+++ b/src/engine/interpreter/rtl-basic.h
@@ -227,6 +227,7 @@ static inline def_rtl(host_sm, void *addr, const rtlreg_t *src1, int len) {
 // control
 #ifndef CONFIG_SHARE
 extern void simpoint_profiling(uint64_t pc, bool is_control, uint64_t abs_instr_count);
+extern void simpoint_profiling_bb(uint64_t control_pc, uint64_t next_pc, uint64_t abs_instr_count);
 #endif // CONFIG_SHARE
 extern uint64_t get_abs_instr_count();
 


### PR DESCRIPTION
## Summary

Optimize the SimPoint basic-block profiling hot path.

- Add an 8192-entry direct-mapped cache for basic-block lookups while retaining the unordered map as the authoritative fallback.
- Merge the two PERF_OPT profiling calls at each basic-block boundary into one transition.
- Skip checkpoint eligibility checks when checkpointing is disabled or the workload is not ready.

Basic-block ID allocation and BBV accumulation semantics remain unchanged.

## Performance

On the fixed all-boot 100M-instruction SimPoint benchmark, median throughput improves from 93.103 MIPS to 118.172 MIPS (+26.93%), reducing host execution time by about 21.22%.

The previous unordered-map lookup hotspot, which accounted for 16.96% of cycles, falls below the 0.3% reporting threshold.

## Validation

- NEMU builds successfully.
- Five repeated 100M-instruction runs produce identical decompressed BBVs.
- Baseline and optimized 300M-instruction runs produce identical decompressed BBVs.
- Normal execution remains functional and reaches 132.681 MIPS.
- `git diff --check` passes.