### PR TITLE
fix(matrix): handle bf16 fp32 mmacc

### DIFF
--- a/src/engine/interpreter/fp.c
+++ b/src/engine/interpreter/fp.c
@@ -522,6 +522,18 @@ def_rtl(mfpcall, rtlreg_t *dest, const rtlreg_t *src1, const rtlreg_t *src2, uin
       case FPCALL_F16ToF64: *dest = my_f16_to_f64(rtlToF16(*src1)).v; break;
       default: panic("op = %d not supported", op);
     }
+  } else if (w == FPCALL_BF16) {
+    bfloat16_t fsrc1 = rtlToVBF16(*src1);
+    bfloat16_t fsrc2 = rtlToVBF16(*src2);
+    switch (op) {
+      /* Matrix registers hold raw BF16 lanes, unlike boxed scalar operands. */
+      case FPCALL_MADD:
+        *dest = f32_mulAdd(my_bf16_to_f32(fsrc1), my_bf16_to_f32(fsrc2),
+                           rtlToVF32(*dest)).v;
+        break;
+      default:
+        panic("op = %d not supported for BF16 matrix operands", op);
+    }
   } else if (w == FPCALL_W32 || w == FPCALL_W16_to_32) {
     float32_t fsrc1;
     float32_t fsrc2;

--- a/src/isa/riscv64/instr/ame/mcompute.h
+++ b/src/isa/riscv64/instr/ame/mcompute.h
@@ -117,6 +117,9 @@ def_EHelper(mmacc) {
 #endif
   } else /* comb == 1, float mma */ {
     word_t FPCALL_TYPE = FPCALL_W64;
+    bool bf16_bf16_to_fp32 = s1mcfg.type_code == MTYPECODE_BF16 &&
+                             s2mcfg.type_code == MTYPECODE_BF16 &&
+                             dmcfg.type_code == MTYPECODE_FP32;
     switch (s1size) {
       case 0:
         Loge("fp8 and lower precision's mma not supported"); longjmp_exception(EX_II);
@@ -144,6 +147,9 @@ def_EHelper(mmacc) {
         Loge("other fp type not supported"); longjmp_exception(EX_II);
         break;
     }
+    if (bf16_bf16_to_fp32) {
+      FPCALL_TYPE = FPCALL_BF16;
+    }
     for (uint64_t i = 0; i < tile_m; i++) {
       for (uint64_t j = 0; j < tile_n; j++) {
         for (uint64_t k = 0; k < tile_k; k++) {
@@ -151,7 +157,8 @@ def_EHelper(mmacc) {
           get_mreg(ts2, j, k, &tmp_reg[2], s2size, false);
 
           get_mreg(td, i, j, &tmp_reg[0], dsize, false);
-          rtl_hostcall(s, HOSTCALL_MFP, &tmp_reg[0], &tmp_reg[1], &tmp_reg[2], FPCALL_CMD(FPCALL_MADD, FPCALL_TYPE));
+          rtl_hostcall(s, HOSTCALL_MFP, &tmp_reg[0], &tmp_reg[1], &tmp_reg[2],
+                       FPCALL_CMD(FPCALL_MADD, FPCALL_TYPE));
           set_mreg(td, i, j, tmp_reg[0], dsize);
         }
       }


### PR DESCRIPTION
Fix BF16 x BF16 -> FP32 `mmacc` handling in the matrix reference model.

The MMACC path now dispatches this type combination to a raw BF16 conversion path, converts operands to FP32, and performs the fused FP32 accumulation.
