### PR TITLE
fix(riscv64): initialize mstatus FS to Off

### DIFF
--- a/src/isa/riscv64/init.c
+++ b/src/isa/riscv64/init.c
@@ -68,7 +68,7 @@ void init_isa() {
   // For RV64 systems, if U-mode is not supported, then UXL is hardwired to zero.
   mstatus->val = 0xaUL << 32;
   // initialize the value fs and vs to 0
-  mstatus->fs = 1;
+  mstatus->fs = 0;
   mstatus->vs = 0;
   // initialize the value ms to 0
   mstatus->ms = 0;


### PR DESCRIPTION
## Motivation

When running SPEC CPU2017 with difftest, NEMU initializes
`mstatus.FS` to `Initial`, while the DUT starts with it set to `Off`.
The inconsistent initial states cause an `mstatus` mismatch before
software enables the floating-point context.