### PR TITLE
fix(build): override empty CC/CXX value

### DIFF
--- a/scripts/build.mk
+++ b/scripts/build.mk
@@ -16,8 +16,12 @@ XINC_DIR = $(INC_DIR) $(WORK_DIR)/resource
 OBJ_DIR  = $(BUILD_DIR)/obj-$(NAME)$(SO)
 BINARY   = $(BUILD_DIR)/$(NAME)$(SO)
 
-CC ?= gcc
-CXX ?= g++
+ifeq ($(strip $(CC)),)
+CC := gcc
+endif
+ifeq ($(strip $(CXX)),)
+CXX := g++
+endif
 
 ifdef PGO_PROF
 PGO_FLAGS = -fprofile-generate -fprofile-dir=$(NEMU_HOME)/profile


### PR DESCRIPTION
In top-level Makefile, these values are set to CONFIG_CC/CXX:
https://github.com/OpenXiangShan/NEMU/blob/4e701e62410ea5459d6df89f6ca19d2fd3bd5d81/Makefile#L90-L91

When .config does not exist yet, `CONFIG_*` is undefined, so we got `CC = ` (empty value).

And, in the shared `scripts/build.mk`, `CC ?= gcc` take effects only if `CC` is undefined.

Normally this is fine as top-level `CC = ` is not passed to recursive `$(MAKE) -C tools/kconfig` calls, but if we have `CC` in the enviroment variables, it will be cleared and passed in.

To reproduce:
```bash
$ git clone https://github.com/OpenXiangShan/NEMU # get a newly cloned NEMU repo without .config file
$ export CC=gcc
$ make xxx_defconfig # or even `make menuconfig` will also fail
```
In such case, `make` tries to build `kconfig` first, and fails due to the empty `CC` value, gives the following error (`$(CC) -MMD ...` becomes `-MMD ...` and make takes the prefix `-` as "ignore error" flag, so it runs `MMD ...`):
```
+ CC confdata.c
make[1]: MMD: No such file or directory
// or if ccache is enabled:
ccache: error: Could not find compiler "-MMD" in PATH
```

This PR fixes that by explicitly detecting an empty CC/CXX and falling back to default gcc/g++.

