### PR TITLE
perf(ame): add auto-vectorized floating-point MMACC paths

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -182,11 +182,12 @@ config CC_ASAN
 
 config AME_MMACC_VECTORIZE
   depends on RV_AME && !SHARE
-  bool "Enable AME integer MMACC optimization"
+  bool "Enable AME MMACC optimization"
   default n
   help
-    Enable an optimized execution path for supported AME integer MMACC
-    operations. Unsupported combinations use the scalar implementation.
+    Enable optimized execution paths for supported AME integer and
+    floating-point MMACC operations. Unsupported combinations use the scalar
+    implementation.
 
 config AME_MLDST_VECTORIZE
   depends on RV_AME && !SHARE

--- a/src/isa/riscv64/instr/ame/mcompute.h
+++ b/src/isa/riscv64/instr/ame/mcompute.h
@@ -66,21 +66,15 @@ def_EHelper(mmacc) {
   if (!tilem_valid || !tilen_valid || !tilek_valid) {
     longjmp_exception(EX_II);
   }
-  // Check combination of ms1/ms2 and md type
-  int8_t comb = check_comb(s1mcfg, s2mcfg, dmcfg);
-  if (comb == -1) {
-    // Invalid type combination
+  mmacc_type_t mmacc_type = get_mmacc_type(s1mcfg, s2mcfg, dmcfg);
+  if (mmacc_type == MMACC_TYPE_INVALID) {
     longjmp_exception(EX_II);
   }
-#if defined(CONFIG_DIFFTEST_AMU_CTRL) || defined(CONFIG_SHARE_CTRL) || defined(PRINT_AMUCTRLIO)
-  uint8_t m_s_sz = s1size;
-  uint8_t m_d_sz = dsize;
-#endif
   bool s1_signed = is_signed_int_mtype(s1mcfg.type_code);
   bool s2_signed = is_signed_int_mtype(s2mcfg.type_code);
 #ifndef CONFIG_SHARE_REF
   // When NEMU is not used as a reference model, execute MMA here directly.
-  if (comb == 0) /* int mma */ {
+  if (mmacc_type == MMACC_TYPE_INTEGER) {
 #ifdef CONFIG_AME_MMACC_VECTORIZE
     bool auto_vectorized = try_auto_vectorized_int8_mmacc(
       td, ts1, ts2, tile_m, tile_n, tile_k,
@@ -115,40 +109,35 @@ def_EHelper(mmacc) {
 #ifdef CONFIG_AME_MMACC_VECTORIZE
     }
 #endif
-  } else /* comb == 1, float mma */ {
-    word_t FPCALL_TYPE = FPCALL_W64;
-    bool bf16_bf16_to_fp32 = s1mcfg.type_code == MTYPECODE_BF16 &&
-                             s2mcfg.type_code == MTYPECODE_BF16 &&
-                             dmcfg.type_code == MTYPECODE_FP32;
-    switch (s1size) {
-      case 0:
-        Loge("fp8 and lower precision's mma not supported"); longjmp_exception(EX_II);
+  } else /* MMACC_TYPE_FLOAT */ {
+    float_mmacc_type_t float_mmacc_type = get_float_mmacc_type(
+      dmcfg.type_code, s1mcfg.type_code, s2mcfg.type_code
+    );
+#ifdef CONFIG_AME_MMACC_VECTORIZE
+    bool auto_vectorized = try_auto_vectorized_float_mmacc(
+      td, ts1, ts2, tile_m, tile_n, tile_k,
+      float_mmacc_type, mfrm->val
+    );
+    if (!auto_vectorized) {
+#endif
+    word_t FPCALL_TYPE;
+    switch (float_mmacc_type) {
+      case FLOAT_MMACC_FP16_FP16_FP16:
+        FPCALL_TYPE = FPCALL_W16;
         break;
-      case 1:
-        switch (dsize) {
-          case 1:
-            FPCALL_TYPE = FPCALL_W16;
-            break;
-          case 2:
-            FPCALL_TYPE = FPCALL_W16_to_32;
-            break;
-          default:
-            Loge("type not supported"); longjmp_exception(EX_II);
-            break;
-        }
+      case FLOAT_MMACC_FP16_FP16_FP32:
+        FPCALL_TYPE = FPCALL_W16_to_32;
         break;
-      case 2:
+      case FLOAT_MMACC_BF16_BF16_FP32:
+        FPCALL_TYPE = FPCALL_BF16;
+        break;
+      case FLOAT_MMACC_FP32_FP32_FP32:
         FPCALL_TYPE = FPCALL_W32;
         break;
-      case 3:
-        FPCALL_TYPE = FPCALL_W64;
-        break;
+      case FLOAT_MMACC_UNSUPPORTED:
       default:
-        Loge("other fp type not supported"); longjmp_exception(EX_II);
-        break;
-    }
-    if (bf16_bf16_to_fp32) {
-      FPCALL_TYPE = FPCALL_BF16;
+        Loge("floating-point mma type not supported");
+        longjmp_exception(EX_II);
     }
     for (uint64_t i = 0; i < tile_m; i++) {
       for (uint64_t j = 0; j < tile_n; j++) {
@@ -163,24 +152,36 @@ def_EHelper(mmacc) {
         }
       }
     }
+#ifdef CONFIG_AME_MMACC_VECTORIZE
+    }
+#endif
   }
 #endif // CONFIG_SHARE_REF
+#if defined(CONFIG_DIFFTEST_AMU_CTRL) || defined(CONFIG_SHARE_CTRL) || defined(PRINT_AMUCTRLIO)
+  uint8_t m_s_sz = s1size;
+  uint8_t m_d_sz = dsize;
+  bool is_float_mmacc = mmacc_type == MMACC_TYPE_FLOAT;
+#endif
 #ifdef CONFIG_DIFFTEST_AMU_CTRL
-  amu_ctrl_queue_mma_emplace(td, mxrm->val, msaten->val, comb, ts1, ts2,
-                      mtilem->val, mtilen->val, mtilek->val,
-                      (s1_signed << 2) | m_s_sz, (s2_signed << 2) | m_s_sz, m_d_sz);
+  amu_ctrl_queue_mma_emplace(
+    td, mxrm->val, msaten->val, is_float_mmacc, ts1, ts2,
+    mtilem->val, mtilen->val, mtilek->val,
+    (s1_signed << 2) | m_s_sz, (s2_signed << 2) | m_s_sz, m_d_sz
+  );
 #endif // CONFIG_DIFFTEST_AMU_CTRL
 #ifdef CONFIG_SHARE_CTRL
-  cutest_mma_emplace(td, msaten->val, comb, ts1, ts2,
-              mtilem->val, mtilen->val, mtilek->val,
-              4 | m_s_sz, 4 | m_s_sz, m_d_sz);
+  cutest_mma_emplace(
+    td, msaten->val, is_float_mmacc, ts1, ts2,
+    mtilem->val, mtilen->val, mtilek->val,
+    4 | m_s_sz, 4 | m_s_sz, m_d_sz
+  );
 #endif // CONFIG_SHARE_CTRL
 #ifdef PRINT_AMUCTRLIO
   fprintf(stderr,
     "[AmuCtrlIO] op=0 \n"
     "            md=%ld, sat=%ld, isfp=%d, ms1=%ld, ms2=%ld\n"
     "            mtilem=%ld, mtilen=%ld, mtilek=%ld, types1=%#x, types2=%#x, typed=%#x\n",
-    td, msaten->val, comb, ts1, ts2,
+    td, msaten->val, is_float_mmacc, ts1, ts2,
     mtilem->val, mtilen->val, mtilek->val, 4 | m_s_sz, 4 | m_s_sz, m_d_sz);
 #endif // PRINT_AMUCTRLIO
 }

--- a/src/isa/riscv64/instr/ame/mcompute_impl.c
+++ b/src/isa/riscv64/instr/ame/mcompute_impl.c
@@ -20,6 +20,9 @@
 
 #include "mcompute_impl.h"
 #include <cpu/cpu.h>
+#include <fenv.h>
+#include <float.h>
+#include <rtl/fp.h>
 #include "mcommon.h"
 
 void require_matrix() {
@@ -49,27 +52,23 @@ uint8_t get_pack(mcfg_t cfg) {
   }
 }
 
-// Return 0 for int mma, 1 for float mma, -1 for invalid combination.
-int8_t check_comb(mcfg_t s1cfg, mcfg_t s2cfg, mcfg_t dcfg) {
+mmacc_type_t get_mmacc_type(mcfg_t s1cfg, mcfg_t s2cfg, mcfg_t dcfg) {
   uint32_t s1_mask = 1u << s1cfg.type_code;
   uint32_t s2_mask = 1u << s2cfg.type_code;
   uint32_t d_mask = 1u << dcfg.type_code;
   const uint32_t int_mask = (1u << MTYPECODE_INT4) | (1u << MTYPECODE_UINT4) |
                             (1u << MTYPECODE_INT8) | (1u << MTYPECODE_UINT8) |
                             (1u << MTYPECODE_INT32);
-  const uint32_t fp_mask = (1u << MTYPECODE_NVFP4) | (1u << MTYPECODE_MXFP4) |
-                           (1u << MTYPECODE_FP8E5M2) | (1u << MTYPECODE_FP8E4M3) |
-                           (1u << MTYPECODE_FP16) | (1u << MTYPECODE_BF16) |
-                           (1u << MTYPECODE_TF32) | (1u << MTYPECODE_FP32) |
-                           (1u << MTYPECODE_FP2PACK4) | (1u << MTYPECODE_FP2PACK5);
 
   if ((s1_mask & int_mask) && (s2_mask & int_mask) && (d_mask & int_mask)) {
-    return 0;
+    return MMACC_TYPE_INTEGER;
+  } else if (get_float_mmacc_type(
+        dcfg.type_code, s1cfg.type_code, s2cfg.type_code
+      ) != FLOAT_MMACC_UNSUPPORTED) {
+    return MMACC_TYPE_FLOAT;
+  } else {
+    return MMACC_TYPE_INVALID;
   }
-  if ((s1_mask & fp_mask) && (s2_mask & fp_mask) && (d_mask & fp_mask)) {
-    return 1;
-  }
-  return -1;
 }
 
 bool is_signed_int_mtype(uint64_t type_code) {
@@ -85,17 +84,75 @@ bool is_signed_int_mtype(uint64_t type_code) {
   }
 }
 
+float_mmacc_type_t get_float_mmacc_type(
+  uint64_t d_type, uint64_t s1_type, uint64_t s2_type
+) {
+  if (d_type == MTYPECODE_FP16 &&
+      s1_type == MTYPECODE_FP16 && s2_type == MTYPECODE_FP16) {
+    return FLOAT_MMACC_FP16_FP16_FP16;
+  } else if (d_type == MTYPECODE_FP32 &&
+      s1_type == MTYPECODE_FP16 && s2_type == MTYPECODE_FP16) {
+    return FLOAT_MMACC_FP16_FP16_FP32;
+  } else if (d_type == MTYPECODE_FP32 &&
+      s1_type == MTYPECODE_BF16 && s2_type == MTYPECODE_BF16) {
+    return FLOAT_MMACC_BF16_BF16_FP32;
+  } else if (d_type == MTYPECODE_FP32 &&
+      s1_type == MTYPECODE_FP32 && s2_type == MTYPECODE_FP32) {
+    return FLOAT_MMACC_FP32_FP32_FP32;
+  } else {
+    return FLOAT_MMACC_UNSUPPORTED;
+  }
+}
+
 #ifdef CONFIG_AME_MMACC_VECTORIZE
+
+#define MACC_REG_BASE 4
+
+// IEEE-754 field widths and positions, from least significant bit upward.
+#define FP_SIGN_BITS 1
+
+#define FP16_FRACTION_BITS 10
+#define FP16_EXPONENT_BITS 5
+
+#define BF16_FRACTION_BITS 7
+#define BF16_EXPONENT_BITS 8
+
+#define FP32_FRACTION_BITS 23
+#define FP32_EXPONENT_BITS 8
+
+#define EXPONENT_SHIFT(format) format##_FRACTION_BITS
+#define SIGN_SHIFT(format) \
+  (EXPONENT_SHIFT(format) + format##_EXPONENT_BITS)
+
+#define FP_LOW_BITS_MASK(bits) \
+  ((UINT32_C(1) << (bits)) - UINT32_C(1))
+#define FP_FIELD_MASK(bits, shift) \
+  (FP_LOW_BITS_MASK(bits) << (shift))
+
+#define FRACTION_MASK(format) FP_LOW_BITS_MASK(format##_FRACTION_BITS)
+#define EXPONENT_MASK(format) \
+  FP_FIELD_MASK(format##_EXPONENT_BITS, EXPONENT_SHIFT(format))
+#define SIGN_MASK(format) FP_FIELD_MASK(FP_SIGN_BITS, SIGN_SHIFT(format))
+#define ABS_MASK(format) FP_LOW_BITS_MASK(SIGN_SHIFT(format))
+#define FP_ABS_BITS(format, bits) ((bits) & ABS_MASK(format))
+#define FP_IS_FINITE(format, bits) \
+  ((((bits) >> EXPONENT_SHIFT(format)) & \
+    FP_LOW_BITS_MASK(format##_EXPONENT_BITS)) != \
+   FP_LOW_BITS_MASK(format##_EXPONENT_BITS))
+
+static inline int macc_reg_index(int reg) {
+  return reg - MACC_REG_BASE;
+}
 
 #define def_auto_vectorized_int8_mmacc(name, lhs_type, rhs_type) \
 static void name( \
-  int td, int ts1, int ts2, \
+  int acc_idx, int ts1, int ts2, \
   uint64_t tile_m, uint64_t tile_n, uint64_t tile_k \
 ) { \
   for (uint64_t i = 0; i < tile_m; i++) { \
     const lhs_type *restrict lhs_row = \
       (const lhs_type *)cpu.mtr[ts1][i]._8; \
-    uint32_t *restrict dest_row = cpu.macc[td - 4][i]._32; \
+    uint32_t *restrict dest_row = cpu.macc[acc_idx][i]._32; \
     for (uint64_t j = 0; j < tile_n; j++) { \
       const rhs_type *restrict rhs_row = \
         (const rhs_type *)cpu.mtr[ts2][j]._8; \
@@ -112,6 +169,307 @@ def_auto_vectorized_int8_mmacc(mmacc_i8_i8, int8_t, int8_t)
 def_auto_vectorized_int8_mmacc(mmacc_i8_u8, int8_t, uint8_t)
 def_auto_vectorized_int8_mmacc(mmacc_u8_i8, uint8_t, int8_t)
 def_auto_vectorized_int8_mmacc(mmacc_u8_u8, uint8_t, uint8_t)
+
+#ifndef CONFIG_FPU_NONE
+
+static bool map_fma_rounding_mode_to_host(
+  uint64_t rounding_mode, int *host_rounding_mode
+) {
+  switch (rounding_mode) {
+    case FPCALL_RM_RNE:
+      *host_rounding_mode = FE_TONEAREST;
+      return true;
+    case FPCALL_RM_RTZ:
+      *host_rounding_mode = FE_TOWARDZERO;
+      return true;
+    case FPCALL_RM_RDN:
+      *host_rounding_mode = FE_DOWNWARD;
+      return true;
+    case FPCALL_RM_RUP:
+      *host_rounding_mode = FE_UPWARD;
+      return true;
+    default:
+      return false;
+  }
+}
+
+static bool host_fma_env_begin(
+  fenv_t *saved_env, int host_rounding_mode
+) {
+  if (feholdexcept(saved_env) != 0) {
+    return false;
+  }
+  if (fesetround(host_rounding_mode) != 0) {
+    fesetenv(saved_env);
+    return false;
+  }
+  return true;
+}
+
+static void host_fma_env_end(const fenv_t *saved_env) {
+  fesetenv(saved_env);
+}
+
+static inline float fp32_from_bits(uint32_t bits) {
+  float value;
+  __builtin_memcpy(&value, &bits, sizeof(value));
+  return value;
+}
+
+static inline uint32_t fp32_to_bits(float value) {
+  uint32_t bits;
+  __builtin_memcpy(&bits, &value, sizeof(bits));
+  return bits;
+}
+
+static inline float bf16_to_fp32(uint16_t value) {
+  return fp32_from_bits((uint32_t)value <<
+                        (SIGN_SHIFT(FP32) - SIGN_SHIFT(BF16)));
+}
+
+static inline float fp16_to_fp32(uint16_t value) {
+  uint32_t sign = ((uint32_t)value & SIGN_MASK(FP16)) <<
+                  (SIGN_SHIFT(FP32) - SIGN_SHIFT(FP16));
+  uint32_t exponent = ((uint32_t)value & EXPONENT_MASK(FP16)) >>
+                      EXPONENT_SHIFT(FP16);
+  uint32_t fraction = (uint32_t)value & FRACTION_MASK(FP16);
+  uint32_t bits;
+
+  if (exponent == 0) {
+    if (fraction == 0) {
+      bits = sign;
+    } else {
+      uint32_t shift = (uint32_t)__builtin_clz(fraction) - 21;
+      bits = sign | ((UINT32_C(113) - shift) << EXPONENT_SHIFT(FP32)) |
+             (((fraction << shift) & FRACTION_MASK(FP16)) <<
+              (FP32_FRACTION_BITS - FP16_FRACTION_BITS));
+    }
+  } else if (exponent == (EXPONENT_MASK(FP16) >> EXPONENT_SHIFT(FP16))) {
+    bits = sign | EXPONENT_MASK(FP32) |
+           (fraction << (FP32_FRACTION_BITS - FP16_FRACTION_BITS));
+  } else {
+    bits = sign | ((exponent + UINT32_C(112)) << EXPONENT_SHIFT(FP32)) |
+           (fraction << (FP32_FRACTION_BITS - FP16_FRACTION_BITS));
+  }
+  return fp32_from_bits(bits);
+}
+
+static inline uint16_t fp16_from_fp32(float value) {
+  _Float16 result = (_Float16)value;
+  uint16_t bits;
+  __builtin_memcpy(&bits, &result, sizeof(bits));
+  return bits;
+}
+
+static bool mmacc_fp16_fp16_fp16(
+  int acc_idx, int ts1, int ts2,
+  uint64_t tile_m, uint64_t tile_n, uint64_t tile_k,
+  int host_rounding_mode
+) {
+  float rhs_by_k[TRENUM16][ROWNUM];
+
+  for (uint64_t i = 0; i < tile_m; i++) {
+    const uint16_t *lhs_row = cpu.mtr[ts1][i]._16;
+    for (uint64_t k = 0; k < tile_k; k++) {
+      if (unlikely(!FP_IS_FINITE(FP16, lhs_row[k]))) {
+        return false;
+      }
+    }
+  }
+  for (uint64_t k = 0; k < tile_k; k++) {
+    for (uint64_t j = 0; j < tile_n; j++) {
+      uint16_t bits = cpu.mtr[ts2][j]._16[k];
+      if (unlikely(!FP_IS_FINITE(FP16, bits))) {
+        return false;
+      }
+      rhs_by_k[k][j] = fp16_to_fp32(bits);
+    }
+  }
+  for (uint64_t i = 0; i < tile_m; i++) {
+    const uint16_t *dest_row = cpu.macc[acc_idx][i]._16;
+    for (uint64_t j = 0; j < tile_n; j++) {
+      if (unlikely(!FP_IS_FINITE(FP16, dest_row[j]))) {
+        return false;
+      }
+    }
+  }
+
+  fenv_t saved_env;
+  if (!host_fma_env_begin(&saved_env, host_rounding_mode)) {
+    return false;
+  }
+  for (uint64_t i = 0; i < tile_m; i++) {
+    const uint16_t *restrict lhs_row = cpu.mtr[ts1][i]._16;
+    uint16_t *restrict dest_row = cpu.macc[acc_idx][i]._16;
+    float acc_values[ROWNUM];
+    for (uint64_t j = 0; j < tile_n; j++) {
+      acc_values[j] = fp16_to_fp32(dest_row[j]);
+    }
+    for (uint64_t k = 0; k < tile_k; k++) {
+      const float lhs = fp16_to_fp32(lhs_row[k]);
+      const float *restrict rhs_row = rhs_by_k[k];
+#pragma GCC ivdep
+      for (uint64_t j = 0; j < tile_n; j++) {
+        acc_values[j] = __builtin_fmaf(lhs, rhs_row[j], acc_values[j]);
+      }
+    }
+    // AME leaves intermediate accumulation precision open. Keep the dot
+    // product in FP32 and round once when storing the FP16 accumulator.
+    for (uint64_t j = 0; j < tile_n; j++) {
+      dest_row[j] = fp16_from_fp32(acc_values[j]);
+    }
+  }
+  host_fma_env_end(&saved_env);
+  return true;
+}
+
+#define def_auto_vectorized_float16_mmacc( \
+  name, to_fp32, format \
+) \
+static bool name( \
+  int acc_idx, int ts1, int ts2, \
+  uint64_t tile_m, uint64_t tile_n, uint64_t tile_k, \
+  int host_rounding_mode \
+) { \
+  /* Transpose B so the vectorized j loop preserves k accumulation order. */ \
+  float rhs_by_k[TRENUM16][ROWNUM]; \
+  long double lhs_abs_max = 0.0; \
+  long double rhs_abs_max = 0.0; \
+  long double dest_abs_max = 0.0; \
+  for (uint64_t i = 0; i < tile_m; i++) { \
+    const uint16_t *lhs_row = cpu.mtr[ts1][i]._16; \
+    for (uint64_t k = 0; k < tile_k; k++) { \
+      uint16_t lhs_bits = lhs_row[k]; \
+      if (unlikely(!FP_IS_FINITE(format, lhs_bits))) { \
+        return false; \
+      } \
+      float abs_value = to_fp32(FP_ABS_BITS(format, lhs_bits)); \
+      if (abs_value > lhs_abs_max) { \
+        lhs_abs_max = abs_value; \
+      } \
+    } \
+  } \
+  for (uint64_t k = 0; k < tile_k; k++) { \
+    for (uint64_t j = 0; j < tile_n; j++) { \
+      uint16_t value = cpu.mtr[ts2][j]._16[k]; \
+      if (unlikely(!FP_IS_FINITE(format, value))) { \
+        return false; \
+      } \
+      rhs_by_k[k][j] = to_fp32(value); \
+      float abs_value = to_fp32(FP_ABS_BITS(format, value)); \
+      if (abs_value > rhs_abs_max) { \
+        rhs_abs_max = abs_value; \
+      } \
+    } \
+  } \
+  for (uint64_t i = 0; i < tile_m; i++) { \
+    const uint32_t *dest_row = cpu.macc[acc_idx][i]._32; \
+    for (uint64_t j = 0; j < tile_n; j++) { \
+      uint32_t dest_bits = dest_row[j]; \
+      if (unlikely(!FP_IS_FINITE(FP32, dest_bits))) { \
+        return false; \
+      } \
+      float abs_value = fp32_from_bits(FP_ABS_BITS(FP32, dest_bits)); \
+      if (abs_value > dest_abs_max) { \
+        dest_abs_max = abs_value; \
+      } \
+    } \
+  } \
+  /* Keep exceptional operands and possible overflow on the SoftFloat path. */ \
+  long double result_abs_bound = dest_abs_max + \
+    (long double)tile_k * lhs_abs_max * rhs_abs_max; \
+  if (unlikely(result_abs_bound > FLT_MAX)) { \
+    return false; \
+  } \
+  fenv_t saved_env; \
+  if (!host_fma_env_begin(&saved_env, host_rounding_mode)) { \
+    return false; \
+  } \
+  for (uint64_t i = 0; i < tile_m; i++) { \
+    const uint16_t *restrict lhs_row = cpu.mtr[ts1][i]._16; \
+    uint32_t *restrict dest_row = cpu.macc[acc_idx][i]._32; \
+    for (uint64_t k = 0; k < tile_k; k++) { \
+      const float lhs = to_fp32(lhs_row[k]); \
+      const float *restrict rhs_row = rhs_by_k[k]; \
+      _Pragma("GCC ivdep") \
+      for (uint64_t j = 0; j < tile_n; j++) { \
+        float dest = fp32_from_bits(dest_row[j]); \
+        dest_row[j] = fp32_to_bits(__builtin_fmaf(lhs, rhs_row[j], dest)); \
+      } \
+    } \
+  } \
+  host_fma_env_end(&saved_env); \
+  return true; \
+}
+
+def_auto_vectorized_float16_mmacc(
+  mmacc_fp16_fp16_fp32, fp16_to_fp32, FP16)
+def_auto_vectorized_float16_mmacc(
+  mmacc_bf16_bf16_fp32, bf16_to_fp32, BF16)
+
+#undef def_auto_vectorized_float16_mmacc
+
+static bool mmacc_fp32_fp32_fp32(
+  int acc_idx, int ts1, int ts2,
+  uint64_t tile_m, uint64_t tile_n, uint64_t tile_k,
+  int host_rounding_mode
+) {
+  float rhs_by_k[TRENUM32][ROWNUM];
+
+  for (uint64_t i = 0; i < tile_m; i++) {
+    const uint32_t *lhs_row = cpu.mtr[ts1][i]._32;
+    for (uint64_t k = 0; k < tile_k; k++) {
+      if (unlikely(!FP_IS_FINITE(FP32, lhs_row[k]))) {
+        return false;
+      }
+    }
+  }
+  for (uint64_t k = 0; k < tile_k; k++) {
+    for (uint64_t j = 0; j < tile_n; j++) {
+      uint32_t bits = cpu.mtr[ts2][j]._32[k];
+      if (unlikely(!FP_IS_FINITE(FP32, bits))) {
+        return false;
+      }
+      rhs_by_k[k][j] = fp32_from_bits(bits);
+    }
+  }
+  for (uint64_t i = 0; i < tile_m; i++) {
+    const uint32_t *dest_row = cpu.macc[acc_idx][i]._32;
+    for (uint64_t j = 0; j < tile_n; j++) {
+      if (unlikely(!FP_IS_FINITE(FP32, dest_row[j]))) {
+        return false;
+      }
+    }
+  }
+
+  fenv_t saved_env;
+  if (!host_fma_env_begin(&saved_env, host_rounding_mode)) {
+    return false;
+  }
+  for (uint64_t i = 0; i < tile_m; i++) {
+    const uint32_t *restrict lhs_row = cpu.mtr[ts1][i]._32;
+    uint32_t *restrict dest_row = cpu.macc[acc_idx][i]._32;
+    float dest_values[ROWNUM];
+    for (uint64_t j = 0; j < tile_n; j++) {
+      dest_values[j] = fp32_from_bits(dest_row[j]);
+    }
+    for (uint64_t k = 0; k < tile_k; k++) {
+      const float lhs = fp32_from_bits(lhs_row[k]);
+      const float *restrict rhs_row = rhs_by_k[k];
+#pragma GCC ivdep
+      for (uint64_t j = 0; j < tile_n; j++) {
+        dest_values[j] = __builtin_fmaf(lhs, rhs_row[j], dest_values[j]);
+      }
+    }
+    for (uint64_t j = 0; j < tile_n; j++) {
+      dest_row[j] = fp32_to_bits(dest_values[j]);
+    }
+  }
+  host_fma_env_end(&saved_env);
+  return true;
+}
+
+#endif // CONFIG_FPU_NONE
 
 bool try_auto_vectorized_int8_mmacc(
   int td, int ts1, int ts2,
@@ -131,18 +489,52 @@ bool try_auto_vectorized_int8_mmacc(
     return false;
   }
 
+  int acc_idx = macc_reg_index(td);
   if (s1_type == MTYPECODE_INT8) {
     if (s2_type == MTYPECODE_INT8) {
-      mmacc_i8_i8(td, ts1, ts2, tile_m, tile_n, tile_k);
+      mmacc_i8_i8(acc_idx, ts1, ts2, tile_m, tile_n, tile_k);
     } else {
-      mmacc_i8_u8(td, ts1, ts2, tile_m, tile_n, tile_k);
+      mmacc_i8_u8(acc_idx, ts1, ts2, tile_m, tile_n, tile_k);
     }
   } else if (s2_type == MTYPECODE_INT8) {
-    mmacc_u8_i8(td, ts1, ts2, tile_m, tile_n, tile_k);
+    mmacc_u8_i8(acc_idx, ts1, ts2, tile_m, tile_n, tile_k);
   } else {
-    mmacc_u8_u8(td, ts1, ts2, tile_m, tile_n, tile_k);
+    mmacc_u8_u8(acc_idx, ts1, ts2, tile_m, tile_n, tile_k);
   }
   return true;
+}
+
+bool try_auto_vectorized_float_mmacc(
+  int td, int ts1, int ts2,
+  uint64_t tile_m, uint64_t tile_n, uint64_t tile_k,
+  float_mmacc_type_t float_mmacc_type,
+  uint64_t rounding_mode
+) {
+#ifndef CONFIG_FPU_NONE
+  int host_rounding_mode;
+  if (!map_fma_rounding_mode_to_host(rounding_mode, &host_rounding_mode)) {
+    return false;
+  }
+  int acc_idx = macc_reg_index(td);
+  switch (float_mmacc_type) {
+    case FLOAT_MMACC_FP16_FP16_FP16:
+      return mmacc_fp16_fp16_fp16(
+        acc_idx, ts1, ts2, tile_m, tile_n, tile_k, host_rounding_mode);
+    case FLOAT_MMACC_FP16_FP16_FP32:
+      return mmacc_fp16_fp16_fp32(
+        acc_idx, ts1, ts2, tile_m, tile_n, tile_k, host_rounding_mode);
+    case FLOAT_MMACC_BF16_BF16_FP32:
+      return mmacc_bf16_bf16_fp32(
+        acc_idx, ts1, ts2, tile_m, tile_n, tile_k, host_rounding_mode);
+    case FLOAT_MMACC_FP32_FP32_FP32:
+      return mmacc_fp32_fp32_fp32(
+        acc_idx, ts1, ts2, tile_m, tile_n, tile_k, host_rounding_mode);
+    case FLOAT_MMACC_UNSUPPORTED:
+    default:
+      return false;
+  }
+#endif
+  return false;
 }
 
 #endif // CONFIG_AME_MMACC_VECTORIZE

--- a/src/isa/riscv64/instr/ame/mcompute_impl.c
+++ b/src/isa/riscv64/instr/ame/mcompute_impl.c
@@ -120,6 +120,13 @@ float_mmacc_type_t get_float_mmacc_type(
 #define FP32_FRACTION_BITS 23
 #define FP32_EXPONENT_BITS 8
 
+#if defined(__FLT16_MANT_DIG__) && defined(__FLT16_MAX_EXP__) && \
+    __FLT16_MANT_DIG__ == 11 && __FLT16_MAX_EXP__ == 16
+#define HOST_HAS_IEEE_FLOAT16 1
+#else
+#define HOST_HAS_IEEE_FLOAT16 0
+#endif
+
 #define EXPONENT_SHIFT(format) format##_FRACTION_BITS
 #define SIGN_SHIFT(format) \
   (EXPONENT_SHIFT(format) + format##_EXPONENT_BITS)
@@ -254,6 +261,8 @@ static inline float fp16_to_fp32(uint16_t value) {
   return fp32_from_bits(bits);
 }
 
+#if HOST_HAS_IEEE_FLOAT16
+
 static inline uint16_t fp16_from_fp32(float value) {
   _Float16 result = (_Float16)value;
   uint16_t bits;
@@ -322,6 +331,8 @@ static bool mmacc_fp16_fp16_fp16(
   host_fma_env_end(&saved_env);
   return true;
 }
+
+#endif
 
 #define def_auto_vectorized_float16_mmacc( \
   name, to_fp32, format \
@@ -518,8 +529,12 @@ bool try_auto_vectorized_float_mmacc(
   int acc_idx = macc_reg_index(td);
   switch (float_mmacc_type) {
     case FLOAT_MMACC_FP16_FP16_FP16:
+#if HOST_HAS_IEEE_FLOAT16
       return mmacc_fp16_fp16_fp16(
         acc_idx, ts1, ts2, tile_m, tile_n, tile_k, host_rounding_mode);
+#else
+      return false;
+#endif
     case FLOAT_MMACC_FP16_FP16_FP32:
       return mmacc_fp16_fp16_fp32(
         acc_idx, ts1, ts2, tile_m, tile_n, tile_k, host_rounding_mode);

--- a/src/isa/riscv64/instr/ame/mcompute_impl.h
+++ b/src/isa/riscv64/instr/ame/mcompute_impl.h
@@ -26,8 +26,27 @@
 
 void require_matrix();
 uint8_t get_pack(mcfg_t cfg);
-int8_t check_comb(mcfg_t s1cfg, mcfg_t s2cfg, mcfg_t dcfg);
 bool is_signed_int_mtype(uint64_t type_code);
+
+typedef enum {
+  MMACC_TYPE_INVALID,
+  MMACC_TYPE_INTEGER,
+  MMACC_TYPE_FLOAT,
+} mmacc_type_t;
+
+typedef enum {
+  FLOAT_MMACC_UNSUPPORTED,
+  FLOAT_MMACC_FP16_FP16_FP16,
+  FLOAT_MMACC_FP16_FP16_FP32,
+  FLOAT_MMACC_BF16_BF16_FP32,
+  FLOAT_MMACC_FP32_FP32_FP32,
+} float_mmacc_type_t;
+
+mmacc_type_t get_mmacc_type(mcfg_t s1cfg, mcfg_t s2cfg, mcfg_t dcfg);
+
+float_mmacc_type_t get_float_mmacc_type(
+  uint64_t d_type, uint64_t s1_type, uint64_t s2_type
+);
 
 #ifdef CONFIG_AME_MMACC_VECTORIZE
 bool try_auto_vectorized_int8_mmacc(
@@ -35,6 +54,13 @@ bool try_auto_vectorized_int8_mmacc(
   uint64_t tile_m, uint64_t tile_n, uint64_t tile_k,
   uint64_t d_type, uint64_t s1_type, uint64_t s2_type,
   bool saturation
+);
+
+bool try_auto_vectorized_float_mmacc(
+  int td, int ts1, int ts2,
+  uint64_t tile_m, uint64_t tile_n, uint64_t tile_k,
+  float_mmacc_type_t float_mmacc_type,
+  uint64_t rounding_mode
 );
 #endif
 


### PR DESCRIPTION
## Summary

Extend NEMU's AME MMACC optimization support from integer operations to
auto-vectorized floating-point matrix multiply-accumulate operations.

The existing scalar and SoftFloat fallback paths are preserved for unsupported
data-type combinations or cases where the vectorized path cannot be used.

## Implementation Details

- Extend `CONFIG_AME_MMACC_VECTORIZE` to cover both integer and floating-point MMACC operations.
- Replace the previous combination-checking logic with explicit MMACC type classification and dispatch.
- Add auto-vectorized fast paths for:
  - FP16 × FP16 → FP16
  - FP16 × FP16 → FP32
  - BF16 × BF16 → FP32
  - FP32 × FP32 → FP32
- Add host FMA rounding-mode support for:
  - RNE
  - RTZ
  - RDN
  - RUP
- Save and restore the host floating-point environment around vectorized floating-point MMACC execution.
- Use FP32 accumulation for the FP16 × FP16 → FP16 fast path and perform the final conversion to FP16 after completing the `k` dimension.
- Add shared format metadata and bit-level conversion helpers for FP16, BF16, and FP32.
- Replace accumulator register offset magic numbers with named constants and helper functions.
- Keep the original scalar FPCALL path available as a fallback.

## Performance

The new fast paths were evaluated on an AMD Ryzen 9 7950X3D using identical AME workloads and the same guest instruction counts. Each configuration was run three times, with the median host time spent used for comparison.

The following table shows speedup relative to the scalar slow path:

| Data type | AVX-512 | AVX2 | SSE |
| ------ | ------ | ------ | ------ |
| FP16 × FP16 -> FP16 | 181.71× | 135.89× | 5.50× |
| FP16 × FP16 -> FP32 | 71.63× | 66.67× | 7.96× |
| BF16 × BF16 -> FP32 | 68.82× | 60.47× | 6.42× |
| FP32 × FP32 -> FP32 | 285.52× | 239.77× | 7.31× |

AVX-512 was the fastest configuration for all tested workloads. The SSE results also show that the main benefit comes from replacing the per-element scalar/SoftFloat execution with batched host-side computation, rather than from AVX-512 width alone.

For FP16/BF16 to FP32 workloads, the relative AVX-512 advantage over AVX2 is smaller because format conversion, finite-value checks, input preparation, bounds checks, and accumulator accesses contribute a significant portion of the total execution time.

Since matrix operations are only a portion of AI workloads, such significant performance improvements are not achieved under common workloads. The actual improvement depends on the proportion of matrix operations.

## Semantics and Fallback Behavior

The vectorized implementation is used only for supported floating-point combinations and compatible execution conditions. Unsupported combinations, invalid fast-path conditions, and configurations without the required host instruction-set support continue to use the existing scalar or SoftFloat implementation.

