### PR TITLE
fix(cpu-exec): preserve current PC across tcache flush

### DIFF
--- a/src/cpu/cpu-exec.c
+++ b/src/cpu/cpu-exec.c
@@ -278,9 +278,11 @@ static bool manual_cpt_quit = false;
   do {                                                                         \
     if (g_sys_state_flag) {                                                    \
       if (g_sys_state_flag & SYS_STATE_FLUSH_TCACHE) {                         \
+        Decode *executed_s = s; /* save the executed instruction */            \
         /* Settle instruction counting for the unended bb. */                  \
         IFDEF(CONFIG_INSTR_CNT_BY_BB, n_remain -= s->idx_in_bb);               \
         s = tcache_handle_flush(s->snpc);                                      \
+        save_globals(executed_s);                                              \
       } else {                                                                 \
         /* BB has not end, but BATCH is about to end. */                       \
         /* Record unsettled instruction number for feature flush. */           \
@@ -294,6 +296,7 @@ static bool manual_cpt_quit = false;
 
 #define rtl_priv_jr(s, target)                                                 \
   do {                                                                         \
+    Decode *executed_s = s;                                                    \
     /* Settle instruction counting for the last bb. */                         \
     IFDEF(CONFIG_INSTR_CNT_BY_BB, n_remain -= s->idx_in_bb);                   \
     is_ctrl = true;                                                            \
@@ -301,6 +304,7 @@ static bool manual_cpt_quit = false;
     if (g_sys_state_flag) {                                                    \
       if (g_sys_state_flag & SYS_STATE_FLUSH_TCACHE) {                         \
         s = tcache_handle_flush(s->pc);                                        \
+        save_globals(executed_s);                                              \
       }                                                                        \
       g_sys_state_flag = 0;                                                    \
     }                                                                          \


### PR DESCRIPTION
Under `CONFIG_PERF_OPT`, `prev_s` records the instruction currently being executed. However, `rtl_priv_next()` calls `tcache_handle_flush()` before jumping to `end_of_loop`.

The tcache flush path calls `save_globals(ex.tnext)`, which updates `prev_s` to the next instruction too early. As a result, the trace incorrectly reports the next instruction as the previous instruction.

For example, executing the instruction at `0x800002c4` produced:
```
  [execute] prev pc = 0x800002bc, pc = 0x800002c0
  [execute] end_of_loop: prev pc = 0x800002c4, pc = 0x800002c4
```
The end_of_loop message should report:
```
  [execute] end_of_loop: prev pc = 0x800002c0, pc = 0x800002c4
```